### PR TITLE
More styling changes

### DIFF
--- a/export/index.html
+++ b/export/index.html
@@ -407,10 +407,10 @@
         const style = {
           border: "none",
           color: "#555b64",
-          fontWeight: "400",
           fontSize: ".875rem",
           lineHeight: "1.25rem",
-          fontFamily: "\"iA Writer Mono\", SFMono-Regular, Menlo, Consolas, monospace",
+          overflowWrap: "break-word",
+          textAlign: "left",
         };
 
         // Create a new div with the key material and append the new div to the body


### PR DESCRIPTION
Remove unnecessary font weight attribute, align text to left instead of center, and wrap around text (this breaks the private key text onto multiple lines as needed, thus preventing scrolling)