### PR TITLE
kustomize: add resource request for memory

### DIFF
--- a/kustomize/resources.yaml
+++ b/kustomize/resources.yaml
@@ -24,6 +24,9 @@ spec:
             httpGet:
               path: /health
               port: auth
+          resource:
+            requests:
+              memory: 5Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
This pod doesn't need much, in production it only uses:
```
NAME                      CPU(cores)   MEMORY(bytes)
frames-55b57894cd-nksbh   0m           3Mi
```