### PR TITLE
utf8-encode the exported private key

### DIFF
--- a/export/index.html
+++ b/export/index.html
@@ -272,8 +272,8 @@
        * @param {Uint8Array} privateKeyBytes
        */
       const parseKey = privateKeyBytes => {
-        const privateKeyHexString = uint8arrayToHexString(privateKeyBytes);
-        return "0x" + privateKeyHexString;
+        const decoder = new TextDecoder("utf-8");
+        return decoder.decode(privateKeyBytes);
       }
 
       /**

--- a/export/index.html
+++ b/export/index.html
@@ -268,7 +268,7 @@
       }
 
       /**
-       * Returns a hex-encoded raw private key from private key bytes.
+       * Returns a hex-encoded or base58-encoded private key from private key bytes.
        * @param {Uint8Array} privateKeyBytes
        */
       const parseKey = privateKeyBytes => {

--- a/export/index.test.js
+++ b/export/index.test.js
@@ -84,10 +84,20 @@ describe("TKHQ", () => {
     expect(key.key_ops).toContain("deriveBits");
   })
 
-  it("parses private key correctly", async () => {
-    const keyHex = "0x13eff5b3f9c63eab5d53cff5149f01606b69325496e0e98b53afa938d890cd2e";
-    const parsedKey = TKHQ.parseKey(TKHQ.uint8arrayFromHexString(keyHex.slice(2)));
+  it("parses hex-encoded private key correctly", async () => {
+    const keyHex = "13eff5b3f9c63eab5d53cff5149f01606b69325496e0e98b53afa938d890cd2e";
+    const encoder = new TextEncoder("utf-8");
+    const encodedKey = encoder.encode(keyHex);
+    const parsedKey = TKHQ.parseKey(encodedKey);
     expect(parsedKey).toEqual(keyHex);
+  })
+
+  it("parses base58-encoded private key correctly", async () => {
+    const keybase58 = "5HueCGU8rMjxExZhSwp1xXQPBDsMaZwk74rZkDfDXvDVpi7L6vBZp2uhZLyStgM9xXdwvCLSrqQfJCVDqWsRU8T7";
+    const encoder = new TextEncoder("utf-8");
+    const encodedKey = encoder.encode(keybase58);
+    const parsedKey = TKHQ.parseKey(encodedKey);
+    expect(parsedKey).toEqual(keybase58);
   })
 
   it("parses wallet with only mnemonic correctly", async () => {

--- a/import/index.html
+++ b/import/index.html
@@ -12,7 +12,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     body {
-    #wallet-mnemonic-plaintext {
+    #plaintext {
       width: 300px;
       font-size: .875rem;
       line-height: 1.25rem;
@@ -35,7 +35,7 @@
 
 <body>
   <form>
-    <textarea name="wallet-mnemonic-plaintext" id="wallet-mnemonic-plaintext"></textarea>
+    <textarea name="plaintext" id="plaintext"></textarea>
   </form>
 
   <!--
@@ -154,9 +154,17 @@
             TKHQ.sendMessageUp("ERROR", e.toString());
           }
         }
+        // TODO: deprecate EXTRACT_WALLET_ENCRYPTED_BUNDLE in favor of EXTRACT_ENCRYPTED_BUNDLE
         if (event.data && event.data["type"] == "EXTRACT_WALLET_ENCRYPTED_BUNDLE") {
           try {
-            await onExtractWalletEncryptedBundle()
+            await onExtractEncryptedBundle()
+          } catch (e) {
+            TKHQ.sendMessageUp("ERROR", e.toString());
+          }
+        }
+        if (event.data && event.data["type"] == "EXTRACT_ENCRYPTED_BUNDLE") {
+          try {
+            await onExtractEncryptedBundle()
           } catch (e) {
             TKHQ.sendMessageUp("ERROR", e.toString());
           }
@@ -194,23 +202,24 @@
     }
 
     /**
-     * Function triggered when EXTRACT_WALLET_ENCRYPTED_BUNDLE event is received.
+     * Function triggered when EXTRACT_ENCRYPTED_BUNDLE (and previously EXTRACT_WALLET_ENCRYPTED_BUNDLE)
+     * event is received.
      * Prerequisite: This function uses the target public key in local storage that is imported
      * from the INJECT_IMPORT_BUNDLE event.
      * Uses the target public key in local storage to encrypt the text entered in the
-     * `wallet-mnemonic-plaintext` textarea element. Upon successful encryption, sends
+     * `plaintext` textarea element. Upon successful encryption, sends
      * an `encrypted_bundle` containing the ciphertext and encapped public key.
      * Example bundle: {"encappedPublic":"0497f33f3306f67f4402d4824e15b63b04786b6558d417aac2fef69051e46fa7bfbe776b142e4ded4f02097617a7588e93c53b71f900a4a8831a31be6f95e5f60f","ciphertext":"c17c3085505f3c094f0fa61791395b83ab1d8c90bdf9f12a64fc6e2e9cba266beb528f65c88bd933e36e6203752a9b63e6a92290a0ab6bf0ed591cf7bfa08006001e2cc63870165dc99ec61554ffdc14dea7d567e62cceed29314ae6c71a013843f5c06146dee5bf9c1d"}
      */
-    const onExtractWalletEncryptedBundle = async () => {
+    const onExtractEncryptedBundle = async () => {
       // Get target embedded key from previous step (onInjectImportBundle)
       const targetPublicKeyJwk = TKHQ.getTargetEmbeddedKey();
       if (targetPublicKeyJwk == null) {
         throw new Error("no target key found");
       }
 
-      // Get plaintext wallet seedphrase
-      const plaintext = document.getElementById("wallet-mnemonic-plaintext").value;
+      // Get plaintext wallet seedphrase or private key
+      const plaintext = document.getElementById("plaintext").value;
       const plaintextBuf = new TextEncoder().encode(plaintext);
 
       // Encrypt the bundle using the enclave target public key

--- a/import/standalone.html
+++ b/import/standalone.html
@@ -74,7 +74,7 @@
   <br>
   <form>
     <label>Encrypted Bundle</label>
-    <input type="text" name="wallet-mnemonic-plaintext" id="wallet-mnemonic-plaintext"/>
+    <input type="text" name="plaintext" id="plaintext"/>
     <button id="encrypt-wallet-bundle">Encrypt Bundle</button>
   </form>
   <br>
@@ -214,10 +214,19 @@
             TKHQ.sendMessageUp("ERROR", e.toString());
           }
         }
+        // TODO: deprecate EXTRACT_WALLET_ENCRYPTED_BUNDLE in favor of EXTRACT_ENCRYPTED_BUNDLE
         if (event.data && event.data["type"] == "EXTRACT_WALLET_ENCRYPTED_BUNDLE") {
           TKHQ.logMessage(`⬇️ Received message ${event.data["type"]}: ${event.data["value"]}`);
           try {
-            await onExtractWalletEncryptedBundle(event.data["value"])
+            await onExtractEncryptedBundle(event.data["value"])
+          } catch (e) {
+            TKHQ.sendMessageUp("ERROR", e.toString());
+          }
+        }
+        if (event.data && event.data["type"] == "EXTRACT_ENCRYPTED_BUNDLE") {
+          TKHQ.logMessage(`⬇️ Received message ${event.data["type"]}: ${event.data["value"]}`);
+          try {
+            await onExtractEncryptedBundle(event.data["value"])
           } catch (e) {
             TKHQ.sendMessageUp("ERROR", e.toString());
           }
@@ -240,7 +249,7 @@
         e.preventDefault();
         window.postMessage({
           "type": "EXTRACT_WALLET_ENCRYPTED_BUNDLE",
-          "value": document.getElementById("wallet-mnemonic-plaintext").value,
+          "value": document.getElementById("plaintext").value,
         })
       }, false);
     }, false);
@@ -279,11 +288,11 @@
      * Prerequisite: This function uses the target public key in local storage that is imported
      * from the INJECT_IMPORT_BUNDLE event.
      * Uses the target public key in local storage to encrypt the text entered in the
-     * `wallet-mnemonic-plaintext` textarea element. Upon successful encryption, sends
+     * `plaintext` textarea element. Upon successful encryption, sends
      * an `encrypted_bundle` containing the ciphertext and encapped public key.
      * Example bundle: {"encappedPublic":"0497f33f3306f67f4402d4824e15b63b04786b6558d417aac2fef69051e46fa7bfbe776b142e4ded4f02097617a7588e93c53b71f900a4a8831a31be6f95e5f60f","ciphertext":"c17c3085505f3c094f0fa61791395b83ab1d8c90bdf9f12a64fc6e2e9cba266beb528f65c88bd933e36e6203752a9b63e6a92290a0ab6bf0ed591cf7bfa08006001e2cc63870165dc99ec61554ffdc14dea7d567e62cceed29314ae6c71a013843f5c06146dee5bf9c1d"}
      */
-    const onExtractWalletEncryptedBundle = async bundle => {
+    const onExtractEncryptedBundle = async bundle => {
       // Get target embedded key from previous step (onInjectImportBundle)
       const targetPublicKeyJwk = TKHQ.getTargetEmbeddedKey();
       if (targetPublicKeyJwk == null) {


### PR DESCRIPTION
Cannot be released until v2024.3.13 release.

Exported and imported private keys will be utf-8 encoded on the clients (iframes like import.turnkey.com and export.turnkey.com as well as the Turnkey CLI) and will only be base58 or hex-encoded in the Turnkey signer enclave.