### PR TITLE
Sha512 ESM

### DIFF
--- a/export/index.html
+++ b/export/index.html
@@ -96,9 +96,6 @@
       <option value="HEXADECIMAL">Hexadecimal (Default)</option>
       <option value="SOLANA">Solana</option>
     </select>
-    <br>
-    <label>Public Key (Optional)</label>
-    <input type="text" name="key-export-public-key" id="key-export-public-key"/>
   </form>
   <br>
   <h2>Inject Wallet Export Bundle</h2>
@@ -468,9 +465,9 @@
       // We do not want to arbitrarily receive messages from all origins.
       window.addEventListener("message", async function(event) {
         if (event.data && event.data["type"] == "INJECT_KEY_EXPORT_BUNDLE") {
-          TKHQ.logMessage(`⬇️ Received message ${event.data["type"]}: ${event.data["value"]}, ${event.data["keyFormat"]}, ${event.data["publicKey"]}`);
+          TKHQ.logMessage(`⬇️ Received message ${event.data["type"]}: ${event.data["value"]}, ${event.data["keyFormat"]}`);
           try {
-            await onInjectKeyBundle(event.data["value"], event.data["keyFormat"], event.data["publicKey"])
+            await onInjectKeyBundle(event.data["value"], event.data["keyFormat"])
           } catch (e) {
             TKHQ.sendMessageUp("ERROR", e.toString());
           }
@@ -504,7 +501,6 @@
           "type": "INJECT_KEY_EXPORT_BUNDLE",
           "value": document.getElementById("key-export-bundle").value,
           "keyFormat": document.getElementById("key-export-format").value,
-          "publicKey": document.getElementById("key-export-public-key").value,
         })
       }, false);
       document.getElementById("inject-wallet").addEventListener("click", async e => {

--- a/export/index.html
+++ b/export/index.html
@@ -452,6 +452,9 @@
     // TODO: this should be bundled at build time or replaced with code written by Turnkey entirely.
     import * as hpke from "https://esm.sh/@hpke/core";
     import * as ed from "https://esm.sh/@noble/ed25519";
+    import { sha512 } from 'https://esm.sh/@noble/hashes/sha512';
+
+    ed.etc.sha512Sync = (...m) => sha512(ed.etc.concatBytes(...m));
 
     document.addEventListener("DOMContentLoaded", async () => {
       await TKHQ.initEmbeddedKey();
@@ -568,10 +571,6 @@
         });
     }
 
-    const getEd25519PublicKey = async (privateKeyHex) => {
-      return await ed.getPublicKey(privateKeyHex);
-    };
-
     /**
      * Function triggered when INJECT_KEY_EXPORT_BUNDLE event is received.
      * @param {string} bundle
@@ -581,13 +580,14 @@
         const keyBytes = await decryptBundle(bundle);
 
         // Parse the decrypted key bytes
+        var key;
         const privateKeyBytes = new Uint8Array(keyBytes);
         if (keyFormat === "SOLANA") {
           const privateKeyHex = TKHQ.uint8arrayToHexString(privateKeyBytes.subarray(0,32));
-          const publicKeyBytes = getEd25519PublicKey(privateKeyHex);
-          const key = await TKHQ.encodeKey(privateKeyBytes, keyFormat, publicKeyBytes);
+          const publicKeyBytes = ed.getPublicKey(privateKeyHex);
+          key = await TKHQ.encodeKey(privateKeyBytes, keyFormat, publicKeyBytes);
         } else {
-          const key = await TKHQ.encodeKey(privateKeyBytes, keyFormat);
+          key = await TKHQ.encodeKey(privateKeyBytes, keyFormat);
         }
 
         // Display only the key


### PR DESCRIPTION
Need to import `sha512` for `ed.getPublicKey` and use sync instead of async method to get public key. Do not pass `publicKey` param to `onInjectKeyBundle` and remove the public key HTML elements used for testing.