### PR TITLE
Harden `uint8arrayFromHexString`

### DIFF
--- a/auth/index.html
+++ b/auth/index.html
@@ -213,7 +213,8 @@
        * @returns {Uint8Array}
        */
       var uint8arrayFromHexString = function(hexString) {
-        if (!hexString || hexString.length % 2 != 0 || !/^[0-9A-Fa-f]+$/.test(hexString)) {
+        var hexRegex = /^[0-9A-Fa-f]+$/;
+        if (!hexString || hexString.length % 2 != 0 || !hexRegex.test(hexString)) {
           throw new Error('cannot create uint8array from invalid hex string: "' + hexString + '"');
         }
         return new Uint8Array(hexString.match(/../g).map(h=>parseInt(h,16)));

--- a/auth/index.html
+++ b/auth/index.html
@@ -213,6 +213,9 @@
        * @returns {Uint8Array}
        */
       var uint8arrayFromHexString = function(hexString) {
+        if (!hexString || hexString.length % 2 != 0 || !/^[0-9A-Fa-f]+$/.test(hexString)) {
+          throw new Error('cannot create uint8array from invalid hex string: "' + hexString + '"');
+        }
         return new Uint8Array(hexString.match(/../g).map(h=>parseInt(h,16)));
       }
 

--- a/auth/index.test.js
+++ b/auth/index.test.js
@@ -161,6 +161,23 @@ describe("TKHQ", () => {
   
   it("contains uint8arrayFromHexString", () => {
     expect(TKHQ.uint8arrayFromHexString("627566666572").toString()).toEqual("98,117,102,102,101,114");
+    
+    // Error case: bad value
+    expect(() => {
+      TKHQ.uint8arrayFromHexString({});
+    }).toThrow('cannot create uint8array from invalid hex string: "[object Object]"');
+    // Error case: empty string
+    expect(() => {
+      TKHQ.uint8arrayFromHexString("");
+    }).toThrow('cannot create uint8array from invalid hex string: ""');
+    // Error case: odd number of characters
+    expect(() => {
+      TKHQ.uint8arrayFromHexString("123");
+    }).toThrow('cannot create uint8array from invalid hex string: "123"');
+    // Error case: bad characters outside of hex range
+    expect(() => {
+      TKHQ.uint8arrayFromHexString("oops");
+    }).toThrow('cannot create uint8array from invalid hex string: "oops"');
   })
 
   it("contains bigIntToHex", () => {

--- a/export/index.html
+++ b/export/index.html
@@ -201,8 +201,12 @@
        * @param {string} hexString
        * @returns {Uint8Array}
        */
-       const uint8arrayFromHexString = hexString => 
-        new Uint8Array(hexString.match(/../g).map(h=>parseInt(h,16)));
+       const uint8arrayFromHexString = function(hexString) {
+        if (!hexString || hexString.length % 2 != 0 || !/^[0-9A-Fa-f]+$/.test(hexString)) {
+          throw new Error('cannot create uint8array from invalid hex string: "' + hexString + '"');
+        }
+        return new Uint8Array(hexString.match(/../g).map(h=>parseInt(h,16)));
+      }
 
       /**
         * Takes a Uint8Array and returns a hex string

--- a/export/index.html
+++ b/export/index.html
@@ -202,7 +202,8 @@
        * @returns {Uint8Array}
        */
        const uint8arrayFromHexString = function(hexString) {
-        if (!hexString || hexString.length % 2 != 0 || !/^[0-9A-Fa-f]+$/.test(hexString)) {
+        var hexRegex = /^[0-9A-Fa-f]+$/;
+        if (!hexString || hexString.length % 2 != 0 || !hexRegex.test(hexString)) {
           throw new Error('cannot create uint8array from invalid hex string: "' + hexString + '"');
         }
         return new Uint8Array(hexString.match(/../g).map(h=>parseInt(h,16)));

--- a/export/index.test.js
+++ b/export/index.test.js
@@ -125,6 +125,23 @@ describe("TKHQ", () => {
   
   it("contains uint8arrayFromHexString", () => {
     expect(TKHQ.uint8arrayFromHexString("627566666572").toString()).toEqual("98,117,102,102,101,114");
+    
+    // Error case: bad value
+    expect(() => {
+      TKHQ.uint8arrayFromHexString({});
+    }).toThrow('cannot create uint8array from invalid hex string: "[object Object]"');
+    // Error case: empty string
+    expect(() => {
+      TKHQ.uint8arrayFromHexString("");
+    }).toThrow('cannot create uint8array from invalid hex string: ""');
+    // Error case: odd number of characters
+    expect(() => {
+      TKHQ.uint8arrayFromHexString("123");
+    }).toThrow('cannot create uint8array from invalid hex string: "123"');
+    // Error case: bad characters outside of hex range
+    expect(() => {
+      TKHQ.uint8arrayFromHexString("oops");
+    }).toThrow('cannot create uint8array from invalid hex string: "oops"');
   })
 
   it("logs messages and sends messages up", async () => {


### PR DESCRIPTION
Pretty straightforward: this change adds some validation to the argument passed to `uint8arrayFromHexString` and errors explicitly if it's bad (not a string, or an empty string, or a non-hex string)