### PR TITLE
add optional target length

### DIFF
--- a/auth/index.html
+++ b/auth/index.html
@@ -503,7 +503,7 @@
       /**
        * Converts a `BigInt` into a base64url encoded string
        * @param {BigInt} num
-       * @param {number} length: optional expected length of the resulting buffer
+       * @param {number} length: optional number of bytes contained in the resulting string
        * @return {string}
        */
       var bigIntToBase64Url = function(num, length) {

--- a/auth/index.html
+++ b/auth/index.html
@@ -208,16 +208,23 @@
       };
 
       /**
-       * Takes a hex string (e.g. "e4567ab") and returns an array buffer (Uint8Array)
+       * Takes a hex string (e.g. "e4567abc") and returns an array buffer (Uint8Array)
        * @param {string} hexString
+       * @param {number} length: optional expected length of the resulting buffer
        * @returns {Uint8Array}
        */
-      var uint8arrayFromHexString = function(hexString) {
+      var uint8arrayFromHexString = function(hexString, length) {
         var hexRegex = /^[0-9A-Fa-f]+$/;
         if (!hexString || hexString.length % 2 != 0 || !hexRegex.test(hexString)) {
           throw new Error('cannot create uint8array from invalid hex string: "' + hexString + '"');
         }
-        return new Uint8Array(hexString.match(/../g).map(h=>parseInt(h,16)));
+        var buffer = new Uint8Array(hexString.match(/../g).map((h) => parseInt(h, 16)));
+        if (!length) {
+            return buffer;
+        }
+        var paddedBuffer = new Uint8Array(length);
+        paddedBuffer.set(buffer, length - buffer.length);
+        return paddedBuffer;
       }
 
       /**
@@ -479,9 +486,9 @@
           {
             kty: "EC",
             crv: "P-256",
-            d: bigIntToBase64Url(privateKey),
-            x: bigIntToBase64Url(publicKeyPoint.x.num),
-            y: bigIntToBase64Url(publicKeyPoint.y.num),
+            d: bigIntToBase64Url(privateKey, 32),
+            x: bigIntToBase64Url(publicKeyPoint.x.num, 32),
+            y: bigIntToBase64Url(publicKeyPoint.y.num, 32),
             ext: true,
           },
           {
@@ -496,21 +503,22 @@
       /**
        * Converts a `BigInt` into a base64url encoded string
        * @param {BigInt} num
+       * @param {number} length: optional expected length of the resulting buffer
        * @return {string}
        */
-      var bigIntToBase64Url = function(num) {
+      var bigIntToBase64Url = function(num, length) {
           var hexString = num.toString(16);
           // Add an extra 0 to the start of the string to get a valid hex string (even length)
           // (e.g. 0x0123 instead of 0x123)
           var hexString = hexString.padStart(Math.ceil(hexString.length/2)*2, 0)
-          var buffer = uint8arrayFromHexString(hexString);
+          var buffer = uint8arrayFromHexString(hexString, length);
           return base64urlEncode(buffer)
       }
 
       /**
        * Converts a `BigInt` into a hex encoded string
        * @param {BigInt} num
-       * @param {number} length expected length of the resulting hex string
+       * @param {number} length: expected length of the resulting hex string
        * @return {string}
        */
        var bigIntToHex = function(num, length) {

--- a/auth/index.test.js
+++ b/auth/index.test.js
@@ -178,6 +178,10 @@ describe("TKHQ", () => {
     expect(() => {
       TKHQ.uint8arrayFromHexString("oops");
     }).toThrow('cannot create uint8array from invalid hex string: "oops"');
+    // Happy path: if length parameter is included, pad the resulting buffer
+    expect(TKHQ.uint8arrayFromHexString("01", 2).toString()).toEqual("0,1");
+    // Happy path: if length parameter is omitted, do not pad the resulting buffer
+    expect(TKHQ.uint8arrayFromHexString("01").toString()).toEqual("1");
   })
 
   it("contains bigIntToHex", () => {

--- a/auth/index.test.js
+++ b/auth/index.test.js
@@ -95,16 +95,16 @@ describe("TKHQ", () => {
 
   it("compresses raw P-256 public keys", async () => {
     let compressed02 = TKHQ.compressRawPublicKey(TKHQ.uint8arrayFromHexString("04c6de3e1d08270d39076651a2b14fd38031dae89892dc124d2f9557816e7e5da4f510c344715f84cf0ba0cc71bd04136c0fb2633a3f459e68ffb8620be16900f0"));
-    expect(compressed02).toEqual(TKHQ.uint8arrayFromHexString("02c6de3e1d08270d39076651a2b14fd38031dae89892dc124d2f9557816e7e5da4", "hex"));
+    expect(compressed02).toEqual(TKHQ.uint8arrayFromHexString("02c6de3e1d08270d39076651a2b14fd38031dae89892dc124d2f9557816e7e5da4"));
     let compressed03 = TKHQ.compressRawPublicKey(TKHQ.uint8arrayFromHexString("04be3c8147b75405c94e24280a1759374688bf689549cc1c0afd8e8af20621d734dab002b3cced5db9d9cd343b7d2197c757f42dea13f6689b3553ab1c667a8c67"));
-    expect(compressed03).toEqual(TKHQ.uint8arrayFromHexString("03be3c8147b75405c94e24280a1759374688bf689549cc1c0afd8e8af20621d734", "hex"));
+    expect(compressed03).toEqual(TKHQ.uint8arrayFromHexString("03be3c8147b75405c94e24280a1759374688bf689549cc1c0afd8e8af20621d734"));
   })
 
   it("uncompresses raw P-256 public keys", async () => {
     let uncompressedFrom02 = TKHQ.uncompressRawPublicKey(TKHQ.uint8arrayFromHexString("02c6de3e1d08270d39076651a2b14fd38031dae89892dc124d2f9557816e7e5da4"));
-    expect(uncompressedFrom02).toEqual(TKHQ.uint8arrayFromHexString("04c6de3e1d08270d39076651a2b14fd38031dae89892dc124d2f9557816e7e5da4f510c344715f84cf0ba0cc71bd04136c0fb2633a3f459e68ffb8620be16900f0", "hex"));
+    expect(uncompressedFrom02).toEqual(TKHQ.uint8arrayFromHexString("04c6de3e1d08270d39076651a2b14fd38031dae89892dc124d2f9557816e7e5da4f510c344715f84cf0ba0cc71bd04136c0fb2633a3f459e68ffb8620be16900f0"));
     let uncompressedFrom03 = TKHQ.uncompressRawPublicKey(TKHQ.uint8arrayFromHexString("03be3c8147b75405c94e24280a1759374688bf689549cc1c0afd8e8af20621d734"));
-    expect(uncompressedFrom03).toEqual(TKHQ.uint8arrayFromHexString("04be3c8147b75405c94e24280a1759374688bf689549cc1c0afd8e8af20621d734dab002b3cced5db9d9cd343b7d2197c757f42dea13f6689b3553ab1c667a8c67", "hex"));
+    expect(uncompressedFrom03).toEqual(TKHQ.uint8arrayFromHexString("04be3c8147b75405c94e24280a1759374688bf689549cc1c0afd8e8af20621d734dab002b3cced5db9d9cd343b7d2197c757f42dea13f6689b3553ab1c667a8c67"));
   })
 
   it("contains p256JWKPrivateToPublic", async () => {


### PR DESCRIPTION
Some randomly generated credentials would not be large enough to fully occupy the expected length of 32 bytes. This is specifically to address an issue where a JWT token would have `d, x, or y` values that are too short. 

Here's a sample error message: 
```
The JWK's "x" member defines an octet string of length 31 bytes but should be 32
```

Sample webcrypto tests can be found here: https://chromium.googlesource.com/chromium/src/+/master/components/test/data/webcrypto/bad_ec_keys.json

Tested locally by: creating a credential that results in a buffer of length 31 for any of the `d, x, or y` components of the JWT, ensuring that the buffer is padded, and that ultimately the credential can be injected + used to stamp a payload.

https://github.com/user-attachments/assets/0f44f7da-3468-4ac5-b483-62ea356d2573


