### PR TITLE
tweak verify params

### DIFF
--- a/auth/index.html
+++ b/auth/index.html
@@ -509,13 +509,13 @@
         };
 
         /**
-         * Function to send a message. 
-         * 
+         * Function to send a message.
+         *
          * If this page is embedded as an iframe we'll send a postMessage
          * in one of two ways depending on the version of @turnkey/iframe-stamper:
-         *   1. newer versions (>=v2.1.0) pass a MessageChannel MessagePort from the parent frame for postMessages. 
+         *   1. newer versions (>=v2.1.0) pass a MessageChannel MessagePort from the parent frame for postMessages.
          *   2. older versions (<v2.1.0) still use the contentWindow so we will postMessage to the window.parent for backwards compatibility.
-         * 
+         *
          * Otherwise we'll display it in the DOM.
          * @param type message type. Can be "PUBLIC_KEY_CREATED", "BUNDLE_INJECTED" or "STAMP"
          * @param value message value
@@ -525,7 +525,7 @@
             parentFrameMessageChannelPort.postMessage({
               type: type,
               value: value,
-            })
+            });
           } else if (window.parent !== window) {
             window.parent.postMessage(
               {
@@ -1037,7 +1037,7 @@
        * Instead of receiving events from the parent page, forms trigger them.
        * This is useful for debugging as well.
        */
-      var addDOMEventListeners = function () {   
+      var addDOMEventListeners = function () {
         document.getElementById("inject").addEventListener(
           "click",
           async function (e) {
@@ -1068,12 +1068,12 @@
           },
           false
         );
-      }
+      };
 
       /**
        * Message Event Handlers to process messages from the parent frame
        */
-      var messageEventListener = async function(event) {
+      var messageEventListener = async function (event) {
         if (
           event.data &&
           (event.data["type"] == "INJECT_CREDENTIAL_BUNDLE" ||
@@ -1106,7 +1106,7 @@
             TKHQ.sendMessageUp("ERROR", e.toString());
           }
         }
-      }
+      };
 
       /**
        * Initialize the embedded key and set up the DOM and message event listeners
@@ -1119,12 +1119,11 @@
           var targetPubBuf = await TKHQ.p256JWKPrivateToPublic(embeddedKeyJwk);
           var targetPubHex = TKHQ.uint8arrayToHexString(targetPubBuf);
           document.getElementById("embedded-key").value = targetPubHex;
-          
-          window.addEventListener(
-            "message",
-            messageEventListener,
-            { capture: false, signal: messageListenerController.signal }
-          );
+
+          window.addEventListener("message", messageEventListener, {
+            capture: false,
+            signal: messageListenerController.signal,
+          });
 
           addDOMEventListeners();
 
@@ -1133,34 +1132,44 @@
         false
       );
 
-      window.addEventListener("message", async function (event) {
-        /** 
-         * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
-         * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
-         * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
-         * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
-        */
-        if (event.data && event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" && event.ports?.[0]) {
-          // remove the message event listener that was added in the DOMContentLoaded event
-          messageListenerController.abort();
+      window.addEventListener(
+        "message",
+        async function (event) {
+          /**
+           * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
+           * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
+           * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
+           * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
+           */
+          if (
+            event.data &&
+            event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
+            event.ports?.[0]
+          ) {
+            // remove the message event listener that was added in the DOMContentLoaded event
+            messageListenerController.abort();
 
-          iframeMessagePort = event.ports[0];
-          iframeMessagePort.onmessage = messageEventListener
+            iframeMessagePort = event.ports[0];
+            iframeMessagePort.onmessage = messageEventListener;
 
-          TKHQ.setParentFrameMessageChannelPort(iframeMessagePort);
+            TKHQ.setParentFrameMessageChannelPort(iframeMessagePort);
 
-          await TKHQ.initEmbeddedKey();
-          var embeddedKeyJwk = await TKHQ.getEmbeddedKey();
-          var targetPubBuf = await TKHQ.p256JWKPrivateToPublic(embeddedKeyJwk);
-          var targetPubHex = TKHQ.uint8arrayToHexString(targetPubBuf);
-          document.getElementById("embedded-key").value = targetPubHex;
+            await TKHQ.initEmbeddedKey();
+            var embeddedKeyJwk = await TKHQ.getEmbeddedKey();
+            var targetPubBuf = await TKHQ.p256JWKPrivateToPublic(
+              embeddedKeyJwk
+            );
+            var targetPubHex = TKHQ.uint8arrayToHexString(targetPubBuf);
+            document.getElementById("embedded-key").value = targetPubHex;
 
-          TKHQ.sendMessageUp("PUBLIC_KEY_READY", targetPubHex);
-          
-          // remove the listener for TURNKEY_INIT_MESSAGE_CHANNEL after it's been processed
-          turnkeyInitController.abort()
-        }
-      }, { signal: turnkeyInitController.signal });
+            TKHQ.sendMessageUp("PUBLIC_KEY_READY", targetPubHex);
+
+            // remove the listener for TURNKEY_INIT_MESSAGE_CHANNEL after it's been processed
+            turnkeyInitController.abort();
+          }
+        },
+        { signal: turnkeyInitController.signal }
+      );
 
       /**
        * Function triggered when INJECT_CREDENTIAL_BUNDLE event is received.

--- a/export/index.template.html
+++ b/export/index.template.html
@@ -245,7 +245,7 @@
 
         function setParentFrameMessageChannelPort(port) {
           parentFrameMessageChannelPort = port;
-        };
+        }
 
         /**
          * Resets the current embedded private key JWK.
@@ -478,7 +478,7 @@
           const publicSignatureBuf = fromDerSignature(publicSignature);
           const signedDataBuf = uint8arrayFromHexString(signedData);
           return await crypto.subtle.verify(
-            { name: "ECDSA", namedCurve: "P-256", hash: { name: "SHA-256" } },
+            { name: "ECDSA", hash: "SHA-256" },
             quorumKey,
             publicSignatureBuf,
             signedDataBuf
@@ -486,13 +486,13 @@
         }
 
         /**
-         * Function to send a message. 
-         * 
+         * Function to send a message.
+         *
          * If this page is embedded as an iframe we'll send a postMessage
          * in one of two ways depending on the version of @turnkey/iframe-stamper:
-         *   1. newer versions (>=v2.1.0) pass a MessageChannel MessagePort from the parent frame for postMessages. 
+         *   1. newer versions (>=v2.1.0) pass a MessageChannel MessagePort from the parent frame for postMessages.
          *   2. older versions (<v2.1.0) still use the contentWindow so we will postMessage to the window.parent for backwards compatibility.
-         * 
+         *
          * Otherwise we'll display it in the DOM.
          * @param type message type. Can be "PUBLIC_KEY_CREATED" or "BUNDLE_INJECTED"
          * @param value message value
@@ -502,7 +502,7 @@
             parentFrameMessageChannelPort.postMessage({
               type: type,
               value: value,
-            })
+            });
           } else if (window.parent !== window) {
             window.parent.postMessage(
               {
@@ -862,7 +862,7 @@
        * Instead of receiving events from the parent page, forms trigger them.
        * This is useful for debugging as well.
        */
-      var addDOMEventListeners = function () {   
+      var addDOMEventListeners = function () {
         document.getElementById("inject-key").addEventListener(
           "click",
           async (e) => {
@@ -884,9 +884,8 @@
             window.postMessage({
               type: "INJECT_WALLET_EXPORT_BUNDLE",
               value: document.getElementById("wallet-export-bundle").value,
-              organizationId: document.getElementById(
-                "wallet-organization-id"
-              ).value,
+              organizationId: document.getElementById("wallet-organization-id")
+                .value,
             });
           },
           false
@@ -899,16 +898,13 @@
           },
           false
         );
-      }
+      };
 
       /**
        * Message Event Handlers to process messages from the parent frame
        */
-       var messageEventListener = async function(event) {
-        if (
-          event.data &&
-          event.data["type"] == "INJECT_KEY_EXPORT_BUNDLE"
-        ) {
+      var messageEventListener = async function (event) {
+        if (event.data && event.data["type"] == "INJECT_KEY_EXPORT_BUNDLE") {
           TKHQ.logMessage(
             `⬇️ Received message ${event.data["type"]}: ${event.data["value"]}, ${event.data["keyFormat"]}, ${event.data["organizationId"]}`
           );
@@ -922,10 +918,7 @@
             TKHQ.sendMessageUp("ERROR", e.toString());
           }
         }
-        if (
-          event.data &&
-          event.data["type"] == "INJECT_WALLET_EXPORT_BUNDLE"
-        ) {
+        if (event.data && event.data["type"] == "INJECT_WALLET_EXPORT_BUNDLE") {
           TKHQ.logMessage(
             `⬇️ Received message ${event.data["type"]}: ${event.data["value"]}, ${event.data["organizationId"]}`
           );
@@ -953,7 +946,7 @@
             TKHQ.sendMessageUp("ERROR", e.toString());
           }
         }
-      }
+      };
 
       /**
        * Initialize the embedded key and set up the DOM and message event listeners
@@ -990,18 +983,22 @@
       );
 
       window.addEventListener("message", async function (event) {
-        /** 
+        /**
          * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
          * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
          * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
          * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
-        */
-        if (event.data && event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" && event.ports?.[0]) {
+         */
+        if (
+          event.data &&
+          event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
+          event.ports?.[0]
+        ) {
           // remove the message event listener that was added in the DOMContentLoaded event
           messageListenerController.abort();
 
           iframeMessagePort = event.ports[0];
-          iframeMessagePort.onmessage = messageEventListener
+          iframeMessagePort.onmessage = messageEventListener;
 
           TKHQ.setParentFrameMessageChannelPort(iframeMessagePort);
 

--- a/export/index.template.html
+++ b/export/index.template.html
@@ -962,11 +962,10 @@
           const targetPubHex = TKHQ.uint8arrayToHexString(targetPubBuf);
           document.getElementById("embedded-key").value = targetPubHex;
 
-          window.addEventListener(
-            "message",
-            messageEventListener,
-            { capture: false, signal: messageListenerController.signal }
-          );
+          window.addEventListener("message", messageEventListener, {
+            capture: false,
+            signal: messageListenerController.signal,
+          });
 
           addDOMEventListeners();
 
@@ -982,38 +981,44 @@
         false
       );
 
-      window.addEventListener("message", async function (event) {
-        /**
-         * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
-         * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
-         * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
-         * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
-         */
-        if (
-          event.data &&
-          event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
-          event.ports?.[0]
-        ) {
-          // remove the message event listener that was added in the DOMContentLoaded event
-          messageListenerController.abort();
+      window.addEventListener(
+        "message",
+        async function (event) {
+          /**
+           * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
+           * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
+           * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
+           * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
+           */
+          if (
+            event.data &&
+            event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
+            event.ports?.[0]
+          ) {
+            // remove the message event listener that was added in the DOMContentLoaded event
+            messageListenerController.abort();
 
-          iframeMessagePort = event.ports[0];
-          iframeMessagePort.onmessage = messageEventListener;
+            iframeMessagePort = event.ports[0];
+            iframeMessagePort.onmessage = messageEventListener;
 
-          TKHQ.setParentFrameMessageChannelPort(iframeMessagePort);
+            TKHQ.setParentFrameMessageChannelPort(iframeMessagePort);
 
-          await TKHQ.initEmbeddedKey();
-          var embeddedKeyJwk = await TKHQ.getEmbeddedKey();
-          var targetPubBuf = await TKHQ.p256JWKPrivateToPublic(embeddedKeyJwk);
-          var targetPubHex = TKHQ.uint8arrayToHexString(targetPubBuf);
-          document.getElementById("embedded-key").value = targetPubHex;
+            await TKHQ.initEmbeddedKey();
+            var embeddedKeyJwk = await TKHQ.getEmbeddedKey();
+            var targetPubBuf = await TKHQ.p256JWKPrivateToPublic(
+              embeddedKeyJwk
+            );
+            var targetPubHex = TKHQ.uint8arrayToHexString(targetPubBuf);
+            document.getElementById("embedded-key").value = targetPubHex;
 
-          TKHQ.sendMessageUp("PUBLIC_KEY_READY", targetPubHex);
+            TKHQ.sendMessageUp("PUBLIC_KEY_READY", targetPubHex);
 
-          // remove the listener for TURNKEY_INIT_MESSAGE_CHANNEL after it's been processed
-          turnkeyInitController.abort();
-        }
-      }, { signal: turnkeyInitController.signal });
+            // remove the listener for TURNKEY_INIT_MESSAGE_CHANNEL after it's been processed
+            turnkeyInitController.abort();
+          }
+        },
+        { signal: turnkeyInitController.signal }
+      );
 
       /**
        * Hide every HTML element in <body> except any <script> elements.

--- a/import/index.template.html
+++ b/import/index.template.html
@@ -245,7 +245,7 @@
 
         function setParentFrameMessageChannelPort(port) {
           parentFrameMessageChannelPort = port;
-        };
+        }
 
         /**
          * Function to normalize padding of byte array with 0's to a target length
@@ -384,7 +384,7 @@
           const publicSignatureBuf = fromDerSignature(publicSignature);
           const signedDataBuf = uint8arrayFromHexString(signedData);
           return await crypto.subtle.verify(
-            { name: "ECDSA", namedCurve: "P-256", hash: { name: "SHA-256" } },
+            { name: "ECDSA", hash: "SHA-256" },
             quorumKey,
             publicSignatureBuf,
             signedDataBuf
@@ -494,13 +494,13 @@
         }
 
         /**
-         * Function to send a message. 
-         * 
+         * Function to send a message.
+         *
          * If this page is embedded as an iframe we'll send a postMessage
          * in one of two ways depending on the version of @turnkey/iframe-stamper:
-         *   1. newer versions (>=v2.1.0) pass a MessageChannel MessagePort from the parent frame for postMessages. 
+         *   1. newer versions (>=v2.1.0) pass a MessageChannel MessagePort from the parent frame for postMessages.
          *   2. older versions (<v2.1.0) still use the contentWindow so we will postMessage to the window.parent for backwards compatibility.
-         * 
+         *
          * Otherwise we'll display it in the DOM.
          * @param type message type. Can be "PUBLIC_KEY_CREATED" or "BUNDLE_INJECTED"
          * @param value message value
@@ -510,7 +510,7 @@
             parentFrameMessageChannelPort.postMessage({
               type: type,
               value: value,
-            })
+            });
           } else if (window.parent !== window) {
             window.parent.postMessage(
               {
@@ -559,7 +559,7 @@
       /**
        * Message Event Handlers to process messages from the parent frame
        */
-      var messageEventListener = async function(event) {
+      var messageEventListener = async function (event) {
         if (event.data && event.data["type"] == "INJECT_IMPORT_BUNDLE") {
           try {
             await onInjectImportBundle(
@@ -598,7 +598,7 @@
             TKHQ.sendMessageUp("ERROR", e.toString());
           }
         }
-      }
+      };
 
       /**
        * Broadcast that the frame is ready and set up the message event listeners
@@ -630,18 +630,22 @@
       );
 
       window.addEventListener("message", async function (event) {
-        /** 
+        /**
          * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
          * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
          * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
          * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
-        */
-        if (event.data && event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" && event.ports?.[0]) {
+         */
+        if (
+          event.data &&
+          event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
+          event.ports?.[0]
+        ) {
           // remove the message event listener that was added in the DOMContentLoaded event
           messageListenerController.abort();
 
           iframeMessagePort = event.ports[0];
-          iframeMessagePort.onmessage = messageEventListener
+          iframeMessagePort.onmessage = messageEventListener;
 
           TKHQ.setParentFrameMessageChannelPort(iframeMessagePort);
 

--- a/import/index.template.html
+++ b/import/index.template.html
@@ -606,11 +606,10 @@
       document.addEventListener(
         "DOMContentLoaded",
         async function () {
-          window.addEventListener(
-            "message",
-            messageEventListener,
-            { capture: false, signal: messageListenerController.signal }
-          );
+          window.addEventListener("message", messageEventListener, {
+            capture: false,
+            signal: messageListenerController.signal,
+          });
 
           if (!messageListenerController.signal.aborted) {
             // If styles are saved in local storage, sanitize and apply them.
@@ -629,37 +628,41 @@
         false
       );
 
-      window.addEventListener("message", async function (event) {
-        /**
-         * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
-         * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
-         * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
-         * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
-         */
-        if (
-          event.data &&
-          event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
-          event.ports?.[0]
-        ) {
-          // remove the message event listener that was added in the DOMContentLoaded event
-          messageListenerController.abort();
+      window.addEventListener(
+        "message",
+        async function (event) {
+          /**
+           * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
+           * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
+           * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
+           * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
+           */
+          if (
+            event.data &&
+            event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
+            event.ports?.[0]
+          ) {
+            // remove the message event listener that was added in the DOMContentLoaded event
+            messageListenerController.abort();
 
-          iframeMessagePort = event.ports[0];
-          iframeMessagePort.onmessage = messageEventListener;
+            iframeMessagePort = event.ports[0];
+            iframeMessagePort.onmessage = messageEventListener;
 
-          TKHQ.setParentFrameMessageChannelPort(iframeMessagePort);
+            TKHQ.setParentFrameMessageChannelPort(iframeMessagePort);
 
-          // This is a workaround for how @turnkey/iframe-stamper is initialized. Currently,
-          // init() waits for a public key to be initialized that can be used to send to the server
-          // which will encrypt messages to this public key.
-          // In the case of import, this public key is not used because the client encrypts messages
-          // to the server's public key.
-          TKHQ.sendMessageUp("PUBLIC_KEY_READY", "")
+            // This is a workaround for how @turnkey/iframe-stamper is initialized. Currently,
+            // init() waits for a public key to be initialized that can be used to send to the server
+            // which will encrypt messages to this public key.
+            // In the case of import, this public key is not used because the client encrypts messages
+            // to the server's public key.
+            TKHQ.sendMessageUp("PUBLIC_KEY_READY", "");
 
-          // remove the listener for TURNKEY_INIT_MESSAGE_CHANNEL after it's been processed
-          turnkeyInitController.abort();
-        }
-      }, { signal: turnkeyInitController.signal });
+            // remove the listener for TURNKEY_INIT_MESSAGE_CHANNEL after it's been processed
+            turnkeyInitController.abort();
+          }
+        },
+        { signal: turnkeyInitController.signal }
+      );
 
       /**
        * Function triggered when INJECT_IMPORT_BUNDLE event is received.

--- a/import/standalone.template.html
+++ b/import/standalone.template.html
@@ -437,7 +437,7 @@
           const publicSignatureBuf = fromDerSignature(publicSignature);
           const signedDataBuf = uint8arrayFromHexString(signedData);
           return await crypto.subtle.verify(
-            { name: "ECDSA", namedCurve: "P-256", hash: { name: "SHA-256" } },
+            { name: "ECDSA", hash: "SHA-256" },
             quorumKey,
             publicSignatureBuf,
             signedDataBuf


### PR DESCRIPTION
Tweak `crypto.subtle.verify` params per https://developer.mozilla.org/en-US/docs/Web/API/EcdsaParams

`namedCurve` parameter simply wasn't being used.

- ✅ tested locally
- tested by putting this in editor to verify types
- `type AlgorithmIdentifier = Algorithm | string;` https://github.com/microsoft/TypeScript/blob/700ee076e515db2ef49d8cf7e4dc4bf70679575c/src/lib/dom.generated.d.ts#L28707