### PR TITLE
add request id to iframe requests

### DIFF
--- a/auth/index.html
+++ b/auth/index.html
@@ -519,13 +519,21 @@
          * Otherwise we'll display it in the DOM.
          * @param type message type. Can be "PUBLIC_KEY_CREATED", "BUNDLE_INJECTED" or "STAMP"
          * @param value message value
+         * @param requestId serves as an idempotency key to match incoming requests. Backwards compatible: if not provided, it isn't passed in.
          */
-        var sendMessageUp = function (type, value) {
+        var sendMessageUp = function (type, value, requestId) {
+          const message = {
+            type: type,
+            value: value,
+          };
+
+          // Only include requestId if it was provided
+          if (requestId) {
+            message.requestId = requestId;
+          }
+
           if (parentFrameMessageChannelPort) {
-            parentFrameMessageChannelPort.postMessage({
-              type: type,
-              value: value,
-            });
+            parentFrameMessageChannelPort.postMessage(message);
           } else if (window.parent !== window) {
             window.parent.postMessage(
               {
@@ -1038,6 +1046,7 @@
        * This is useful for debugging as well.
        */
       var addDOMEventListeners = function () {
+      var addDOMEventListeners = function () {
         document.getElementById("inject").addEventListener(
           "click",
           async function (e) {
@@ -1069,10 +1078,12 @@
           false
         );
       };
+      };
 
       /**
        * Message Event Handlers to process messages from the parent frame
        */
+      var messageEventListener = async function (event) {
       var messageEventListener = async function (event) {
         if (
           event.data &&
@@ -1083,9 +1094,9 @@
             `⬇️ Received message ${event.data["type"]}: ${event.data["value"]}`
           );
           try {
-            await onInjectBundle(event.data["value"]);
+            await onInjectBundle(event.data["value"], event.data["requestId"]);
           } catch (e) {
-            TKHQ.sendMessageUp("ERROR", e.toString());
+            TKHQ.sendMessageUp("ERROR", e.toString(), event.data["requestId"]);
           }
         }
         if (event.data && event.data["type"] == "STAMP_REQUEST") {
@@ -1093,11 +1104,12 @@
             `⬇️ Received message ${event.data["type"]}: ${event.data["value"]}`
           );
           try {
-            await onStampRequest(event.data["value"]);
+            await onStampRequest(event.data["value"], event.data["requestId"]);
           } catch (e) {
-            TKHQ.sendMessageUp("ERROR", e.toString());
+            TKHQ.sendMessageUp("ERROR", e.toString(), event.data["requestId"]);
           }
         }
+        // This is localized just to the button on the actual page
         if (event.data && event.data["type"] == "RESET_EMBEDDED_KEY") {
           TKHQ.logMessage(`⬇️ Received message ${event.data["type"]}`);
           try {
@@ -1106,6 +1118,7 @@
             TKHQ.sendMessageUp("ERROR", e.toString());
           }
         }
+      };
       };
 
       /**
@@ -1132,25 +1145,23 @@
         false
       );
 
-      window.addEventListener(
-        "message",
-        async function (event) {
-          /**
-           * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
-           * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
-           * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
-           * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
-           */
-          if (
-            event.data &&
-            event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
-            event.ports?.[0]
-          ) {
-            // remove the message event listener that was added in the DOMContentLoaded event
-            messageListenerController.abort();
+      window.addEventListener("message", async function (event) {
+        /**
+         * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
+         * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
+         * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
+         * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
+         */
+        if (
+          event.data &&
+          event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
+          event.ports?.[0]
+        ) {
+          // remove the message event listener that was added in the DOMContentLoaded event
+          messageListenerController.abort();
 
-            iframeMessagePort = event.ports[0];
-            iframeMessagePort.onmessage = messageEventListener;
+          iframeMessagePort = event.ports[0];
+          iframeMessagePort.onmessage = messageEventListener;
 
             TKHQ.setParentFrameMessageChannelPort(iframeMessagePort);
 
@@ -1176,8 +1187,9 @@
        * The `bundle` param is the concatenation of a public key and an encrypted payload, and then base64 encoded
        * Example: A6ZPGAlxBRZhjKWky4RpXnHVceGzJjTuBrzKvMGnIgZ3r6JD4D1iiSg_m-y_u0BgJKI397Xjn0wgu17w9wuRooEp-F38m4ql57FgQ7sX9nQA
        * @param {string} bundle
+       * @param {string} requestId
        */
-      var onInjectBundle = async function (bundle) {
+      var onInjectBundle = async function (bundle, requestId) {
         if (
           // Non-alphanumerical characters in base64url: - and _. These aren't in base58.
           bundle.indexOf("-") === -1 &&
@@ -1226,13 +1238,15 @@
         });
 
         CREDENTIAL_BYTES = new Uint8Array(credentialBytes);
-        TKHQ.sendMessageUp("BUNDLE_INJECTED", true);
+        TKHQ.sendMessageUp("BUNDLE_INJECTED", true, requestId);
       };
+
       /**
        * Function triggered when STAMP_REQUEST event is received.
-       * @param {string} payload to sign
+       * @param {string} payload: payload to sign
+       * @param {string} requestId: idempotency key
        */
-      var onStampRequest = async function (payload) {
+      var onStampRequest = async function (payload, requestId) {
         if (CREDENTIAL_BYTES === null) {
           throw new Error(
             "cannot sign payload without credential. Credential bytes are null"
@@ -1271,7 +1285,7 @@
         var stampHeaderValue = TKHQ.stringToBase64urlString(
           JSON.stringify(stamp)
         );
-        TKHQ.sendMessageUp("STAMP", stampHeaderValue);
+        TKHQ.sendMessageUp("STAMP", stampHeaderValue, requestId);
       };
 
       /**

--- a/auth/index.html
+++ b/auth/index.html
@@ -1046,7 +1046,6 @@
        * This is useful for debugging as well.
        */
       var addDOMEventListeners = function () {
-      var addDOMEventListeners = function () {
         document.getElementById("inject").addEventListener(
           "click",
           async function (e) {
@@ -1078,12 +1077,10 @@
           false
         );
       };
-      };
 
       /**
        * Message Event Handlers to process messages from the parent frame
        */
-      var messageEventListener = async function (event) {
       var messageEventListener = async function (event) {
         if (
           event.data &&
@@ -1119,7 +1116,6 @@
           }
         }
       };
-      };
 
       /**
        * Initialize the embedded key and set up the DOM and message event listeners
@@ -1145,23 +1141,25 @@
         false
       );
 
-      window.addEventListener("message", async function (event) {
-        /**
-         * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
-         * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
-         * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
-         * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
-         */
-        if (
-          event.data &&
-          event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
-          event.ports?.[0]
-        ) {
-          // remove the message event listener that was added in the DOMContentLoaded event
-          messageListenerController.abort();
+      window.addEventListener(
+        "message",
+        async function (event) {
+          /**
+           * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
+           * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
+           * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
+           * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
+           */
+          if (
+            event.data &&
+            event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
+            event.ports?.[0]
+          ) {
+            // remove the message event listener that was added in the DOMContentLoaded event
+            messageListenerController.abort();
 
-          iframeMessagePort = event.ports[0];
-          iframeMessagePort.onmessage = messageEventListener;
+            iframeMessagePort = event.ports[0];
+            iframeMessagePort.onmessage = messageEventListener;
 
             TKHQ.setParentFrameMessageChannelPort(iframeMessagePort);
 

--- a/export/index.template.html
+++ b/export/index.template.html
@@ -496,13 +496,21 @@
          * Otherwise we'll display it in the DOM.
          * @param type message type. Can be "PUBLIC_KEY_CREATED" or "BUNDLE_INJECTED"
          * @param value message value
+         * @param requestId serves as an idempotency key to match incoming requests. Backwards compatible: if not provided, it isn't passed in.
          */
-        function sendMessageUp(type, value) {
+        function sendMessageUp(type, value, requestId) {
+          const message = {
+            type: type,
+            value: value,
+          };
+
+          // Only include requestId if it was provided
+          if (requestId) {
+            message.requestId = requestId;
+          }
+
           if (parentFrameMessageChannelPort) {
-            parentFrameMessageChannelPort.postMessage({
-              type: type,
-              value: value,
-            });
+            parentFrameMessageChannelPort.postMessage(message);
           } else if (window.parent !== window) {
             window.parent.postMessage(
               {
@@ -912,10 +920,11 @@
             await onInjectKeyBundle(
               event.data["value"],
               event.data["keyFormat"],
-              event.data["organizationId"]
+              event.data["organizationId"],
+              event.data["requestId"]
             );
           } catch (e) {
-            TKHQ.sendMessageUp("ERROR", e.toString());
+            TKHQ.sendMessageUp("ERROR", e.toString(),  event.data["requestId"]);
           }
         }
         if (event.data && event.data["type"] == "INJECT_WALLET_EXPORT_BUNDLE") {
@@ -925,23 +934,25 @@
           try {
             await onInjectWalletBundle(
               event.data["value"],
-              event.data["organizationId"]
+              event.data["organizationId"],
+              event.data["requestId"]
             );
           } catch (e) {
-            TKHQ.sendMessageUp("ERROR", e.toString());
-          }
-        }
-        if (event.data && event.data["type"] == "RESET_EMBEDDED_KEY") {
-          TKHQ.logMessage(`⬇️ Received message ${event.data["type"]}`);
-          try {
-            TKHQ.onResetEmbeddedKey();
-          } catch (e) {
-            TKHQ.sendMessageUp("ERROR", e.toString());
+            TKHQ.sendMessageUp("ERROR", e.toString(), event.data["requestId"]);
           }
         }
         if (event.data && event.data["type"] == "APPLY_SETTINGS") {
           try {
-            await onApplySettings(event.data["value"]);
+            await onApplySettings(event.data["value"], event.data["requestId"]);
+          } catch (e) {
+            TKHQ.sendMessageUp("ERROR", e.toString(), event.data["requestId"]);
+          }
+        }
+        // This is localized just to the button on the actual page
+        if (event.data && event.data["type"] == "RESET_EMBEDDED_KEY") {
+          TKHQ.logMessage(`⬇️ Received message ${event.data["type"]}`);
+          try {
+            TKHQ.onResetEmbeddedKey();
           } catch (e) {
             TKHQ.sendMessageUp("ERROR", e.toString());
           }
@@ -981,25 +992,23 @@
         false
       );
 
-      window.addEventListener(
-        "message",
-        async function (event) {
-          /**
-           * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
-           * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
-           * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
-           * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
-           */
-          if (
-            event.data &&
-            event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
-            event.ports?.[0]
-          ) {
-            // remove the message event listener that was added in the DOMContentLoaded event
-            messageListenerController.abort();
+      window.addEventListener("message", async function (event) {
+        /**
+         * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
+         * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
+         * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
+         * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
+         */
+        if (
+          event.data &&
+          event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
+          event.ports?.[0]
+        ) {
+          // remove the message event listener that was added in the DOMContentLoaded event
+          messageListenerController.abort();
 
-            iframeMessagePort = event.ports[0];
-            iframeMessagePort.onmessage = messageEventListener;
+          iframeMessagePort = event.ports[0];
+          iframeMessagePort.onmessage = messageEventListener;
 
             TKHQ.setParentFrameMessageChannelPort(iframeMessagePort);
 
@@ -1143,8 +1152,9 @@
        * @param {string} bundle
        * @param {string} keyFormat
        * @param {string} organizationId
+       * @param {string} requestId
        */
-      async function onInjectKeyBundle(bundle, keyFormat, organizationId) {
+      async function onInjectKeyBundle(bundle, keyFormat, organizationId, requestId) {
         // Decrypt the export bundle
         const keyBytes = await decryptBundle(bundle, organizationId);
 
@@ -1172,15 +1182,16 @@
         displayKey(key);
 
         // Send up BUNDLE_INJECTED message
-        TKHQ.sendMessageUp("BUNDLE_INJECTED", true);
+        TKHQ.sendMessageUp("BUNDLE_INJECTED", true, requestId);
       }
 
       /**
        * Function triggered when INJECT_WALLET_EXPORT_BUNDLE event is received.
        * @param {string} bundle
        * @param {string} organizationId
+       * @param {string} requestId
        */
-      async function onInjectWalletBundle(bundle, organizationId) {
+      async function onInjectWalletBundle(bundle, organizationId, requestId) {
         // Decrypt the export bundle
         const walletBytes = await decryptBundle(bundle, organizationId);
 
@@ -1194,7 +1205,7 @@
         displayKey(wallet.mnemonic);
 
         // Send up BUNDLE_INJECTED message
-        TKHQ.sendMessageUp("BUNDLE_INJECTED", true);
+        TKHQ.sendMessageUp("BUNDLE_INJECTED", true, requestId);
       }
 
       /**
@@ -1202,8 +1213,10 @@
        * For now, the only settings that can be applied are for "styles".
        * Persist them in local storage so they can be applied on every
        * page load.
+       * @param {string} settings: JSON-stringified settings
+       * @param {string} requestId
        */
-      async function onApplySettings(settings) {
+      async function onApplySettings(settings, requestId) {
         // Apply settings
         const validSettings = TKHQ.applySettings(settings);
 
@@ -1211,7 +1224,7 @@
         TKHQ.setSettings(validSettings);
 
         // Send up SETTINGS_APPLIED message
-        TKHQ.sendMessageUp("SETTINGS_APPLIED", true);
+        TKHQ.sendMessageUp("SETTINGS_APPLIED", true, requestId);
       }
 
       /**

--- a/export/index.template.html
+++ b/export/index.template.html
@@ -924,7 +924,7 @@
               event.data["requestId"]
             );
           } catch (e) {
-            TKHQ.sendMessageUp("ERROR", e.toString(),  event.data["requestId"]);
+            TKHQ.sendMessageUp("ERROR", e.toString(), event.data["requestId"]);
           }
         }
         if (event.data && event.data["type"] == "INJECT_WALLET_EXPORT_BUNDLE") {
@@ -992,23 +992,25 @@
         false
       );
 
-      window.addEventListener("message", async function (event) {
-        /**
-         * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
-         * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
-         * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
-         * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
-         */
-        if (
-          event.data &&
-          event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
-          event.ports?.[0]
-        ) {
-          // remove the message event listener that was added in the DOMContentLoaded event
-          messageListenerController.abort();
+      window.addEventListener(
+        "message",
+        async function (event) {
+          /**
+           * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
+           * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
+           * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
+           * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
+           */
+          if (
+            event.data &&
+            event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
+            event.ports?.[0]
+          ) {
+            // remove the message event listener that was added in the DOMContentLoaded event
+            messageListenerController.abort();
 
-          iframeMessagePort = event.ports[0];
-          iframeMessagePort.onmessage = messageEventListener;
+            iframeMessagePort = event.ports[0];
+            iframeMessagePort.onmessage = messageEventListener;
 
             TKHQ.setParentFrameMessageChannelPort(iframeMessagePort);
 
@@ -1154,7 +1156,12 @@
        * @param {string} organizationId
        * @param {string} requestId
        */
-      async function onInjectKeyBundle(bundle, keyFormat, organizationId, requestId) {
+      async function onInjectKeyBundle(
+        bundle,
+        keyFormat,
+        organizationId,
+        requestId
+      ) {
         // Decrypt the export bundle
         const keyBytes = await decryptBundle(bundle, organizationId);
 

--- a/import/index.template.html
+++ b/import/index.template.html
@@ -640,23 +640,25 @@
         false
       );
 
-      window.addEventListener("message", async function (event) {
-        /**
-         * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
-         * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
-         * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
-         * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
-         */
-        if (
-          event.data &&
-          event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
-          event.ports?.[0]
-        ) {
-          // remove the message event listener that was added in the DOMContentLoaded event
-          messageListenerController.abort();
+      window.addEventListener(
+        "message",
+        async function (event) {
+          /**
+           * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
+           * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
+           * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
+           * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
+           */
+          if (
+            event.data &&
+            event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
+            event.ports?.[0]
+          ) {
+            // remove the message event listener that was added in the DOMContentLoaded event
+            messageListenerController.abort();
 
-          iframeMessagePort = event.ports[0];
-          iframeMessagePort.onmessage = messageEventListener;
+            iframeMessagePort = event.ports[0];
+            iframeMessagePort.onmessage = messageEventListener;
 
             TKHQ.setParentFrameMessageChannelPort(iframeMessagePort);
 
@@ -684,7 +686,12 @@
        * @param {string} userId
        * @param {string} requestId
        */
-      async function onInjectImportBundle(bundle, organizationId, userId, requestId) {
+      async function onInjectImportBundle(
+        bundle,
+        organizationId,
+        userId,
+        requestId
+      ) {
         let targetPublicBuf;
         let verified;
 
@@ -805,7 +812,11 @@
         TKHQ.resetTargetEmbeddedKey();
 
         // Send up ENCRYPTED_BUNDLE_EXTRACTED message
-        TKHQ.sendMessageUp("ENCRYPTED_BUNDLE_EXTRACTED", encryptedBundle, requestId);
+        TKHQ.sendMessageUp(
+          "ENCRYPTED_BUNDLE_EXTRACTED",
+          encryptedBundle,
+          requestId
+        );
       }
 
       /**
@@ -843,7 +854,11 @@
         TKHQ.resetTargetEmbeddedKey();
 
         // Send up ENCRYPTED_BUNDLE_EXTRACTED message
-        TKHQ.sendMessageUp("ENCRYPTED_BUNDLE_EXTRACTED", encryptedBundle, requestId);
+        TKHQ.sendMessageUp(
+          "ENCRYPTED_BUNDLE_EXTRACTED",
+          encryptedBundle,
+          requestId
+        );
       }
 
       /**

--- a/import/index.template.html
+++ b/import/index.template.html
@@ -504,13 +504,21 @@
          * Otherwise we'll display it in the DOM.
          * @param type message type. Can be "PUBLIC_KEY_CREATED" or "BUNDLE_INJECTED"
          * @param value message value
+         * @param requestId serves as an idempotency key to match incoming requests. Backwards compatible: if not provided, it isn't passed in.
          */
-        function sendMessageUp(type, value) {
+        function sendMessageUp(type, value, requestId) {
+          const message = {
+            type: type,
+            value: value,
+          };
+
+          // Only include requestId if it was provided
+          if (requestId) {
+            message.requestId = requestId;
+          }
+
           if (parentFrameMessageChannelPort) {
-            parentFrameMessageChannelPort.postMessage({
-              type: type,
-              value: value,
-            });
+            parentFrameMessageChannelPort.postMessage(message);
           } else if (window.parent !== window) {
             window.parent.postMessage(
               {
@@ -565,10 +573,11 @@
             await onInjectImportBundle(
               event.data["value"],
               event.data["organizationId"],
-              event.data["userId"]
+              event.data["userId"],
+              event.data["requestId"]
             );
           } catch (e) {
-            TKHQ.sendMessageUp("ERROR", e.toString());
+            TKHQ.sendMessageUp("ERROR", e.toString(), event.data["requestId"]);
           }
         }
         if (
@@ -576,9 +585,9 @@
           event.data["type"] == "EXTRACT_WALLET_ENCRYPTED_BUNDLE"
         ) {
           try {
-            await onExtractWalletEncryptedBundle();
+            await onExtractWalletEncryptedBundle(event.data["requestId"]);
           } catch (e) {
-            TKHQ.sendMessageUp("ERROR", e.toString());
+            TKHQ.sendMessageUp("ERROR", e.toString(), event.data["requestId"]);
           }
         }
         if (
@@ -586,16 +595,19 @@
           event.data["type"] == "EXTRACT_KEY_ENCRYPTED_BUNDLE"
         ) {
           try {
-            await onExtractKeyEncryptedBundle(event.data["keyFormat"]);
+            await onExtractKeyEncryptedBundle(
+              event.data["keyFormat"],
+              event.data["requestId"]
+            );
           } catch (e) {
-            TKHQ.sendMessageUp("ERROR", e.toString());
+            TKHQ.sendMessageUp("ERROR", e.toString(), event.data["requestId"]);
           }
         }
         if (event.data && event.data["type"] == "APPLY_SETTINGS") {
           try {
-            await onApplySettings(event.data["value"]);
+            await onApplySettings(event.data["value"], event.data["requestId"]);
           } catch (e) {
-            TKHQ.sendMessageUp("ERROR", e.toString());
+            TKHQ.sendMessageUp("ERROR", e.toString(), event.data["requestId"]);
           }
         }
       };
@@ -628,25 +640,23 @@
         false
       );
 
-      window.addEventListener(
-        "message",
-        async function (event) {
-          /**
-           * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
-           * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
-           * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
-           * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
-           */
-          if (
-            event.data &&
-            event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
-            event.ports?.[0]
-          ) {
-            // remove the message event listener that was added in the DOMContentLoaded event
-            messageListenerController.abort();
+      window.addEventListener("message", async function (event) {
+        /**
+         * @turnkey/iframe-stamper >= v2.1.0 is using a MessageChannel to communicate with the parent frame.
+         * The parent frame sends a TURNKEY_INIT_MESSAGE_CHANNEL event with the MessagePort.
+         * If we receive this event, we want to remove the message event listener that was added in the DOMContentLoaded event to avoid processing messages twice.
+         * We persist the MessagePort so we can use it to communicate with the parent window in subsequent calls to TKHQ.sendMessageUp
+         */
+        if (
+          event.data &&
+          event.data["type"] == "TURNKEY_INIT_MESSAGE_CHANNEL" &&
+          event.ports?.[0]
+        ) {
+          // remove the message event listener that was added in the DOMContentLoaded event
+          messageListenerController.abort();
 
-            iframeMessagePort = event.ports[0];
-            iframeMessagePort.onmessage = messageEventListener;
+          iframeMessagePort = event.ports[0];
+          iframeMessagePort.onmessage = messageEventListener;
 
             TKHQ.setParentFrameMessageChannelPort(iframeMessagePort);
 
@@ -672,8 +682,9 @@
        * Example bundle: {"targetPublic":"0491ccb68758b822a6549257f87769eeed37c6cb68a6c6255c5f238e2b6e6e61838c8ac857f2e305970a6435715f84e5a2e4b02a4d1e5289ba7ec7910e47d2d50f","targetPublicSignature":"3045022100cefc333c330c9fa300d1aa10a439a76539b4d6967301638ab9edc9fd9468bfdb0220339bba7e2b00b45d52e941d068ecd3bfd16fd1926da69dd7769893268990d62f","enclaveQuorumPublic":"04cf288fe433cc4e1aa0ce1632feac4ea26bf2f5a09dcfe5a42c398e06898710330f0572882f4dbdf0f5304b8fc8703acd69adca9a4bbf7f5d00d20a5e364b2569"}
        * @param {string} organizationId
        * @param {string} userId
+       * @param {string} requestId
        */
-      async function onInjectImportBundle(bundle, organizationId, userId) {
+      async function onInjectImportBundle(bundle, organizationId, userId, requestId) {
         let targetPublicBuf;
         let verified;
 
@@ -757,7 +768,7 @@
         TKHQ.setTargetEmbeddedKey(targetPublicKeyJwk);
 
         // Send up BUNDLE_INJECTED message
-        TKHQ.sendMessageUp("BUNDLE_INJECTED", true);
+        TKHQ.sendMessageUp("BUNDLE_INJECTED", true, requestId);
       }
 
       /**
@@ -768,8 +779,9 @@
        * `plaintext` textarea element. Upon successful encryption, sends
        * an `encrypted_bundle` containing the ciphertext and encapped public key.
        * Example bundle: {"encappedPublic":"0497f33f3306f67f4402d4824e15b63b04786b6558d417aac2fef69051e46fa7bfbe776b142e4ded4f02097617a7588e93c53b71f900a4a8831a31be6f95e5f60f","ciphertext":"c17c3085505f3c094f0fa61791395b83ab1d8c90bdf9f12a64fc6e2e9cba266beb528f65c88bd933e36e6203752a9b63e6a92290a0ab6bf0ed591cf7bfa08006001e2cc63870165dc99ec61554ffdc14dea7d567e62cceed29314ae6c71a013843f5c06146dee5bf9c1d"}
+       * @param {string} requestId
        */
-      async function onExtractWalletEncryptedBundle() {
+      async function onExtractWalletEncryptedBundle(requestId) {
         // Get target embedded key from previous step (onInjectImportBundle)
         const targetPublicKeyJwk = TKHQ.getTargetEmbeddedKey();
         if (targetPublicKeyJwk == null) {
@@ -793,7 +805,7 @@
         TKHQ.resetTargetEmbeddedKey();
 
         // Send up ENCRYPTED_BUNDLE_EXTRACTED message
-        TKHQ.sendMessageUp("ENCRYPTED_BUNDLE_EXTRACTED", encryptedBundle);
+        TKHQ.sendMessageUp("ENCRYPTED_BUNDLE_EXTRACTED", encryptedBundle, requestId);
       }
 
       /**
@@ -804,8 +816,10 @@
        * `plaintext` textarea element. Upon successful encryption, sends
        * an `encrypted_bundle` containing the ciphertext and encapped public key.
        * Example bundle: {"encappedPublic":"0497f33f3306f67f4402d4824e15b63b04786b6558d417aac2fef69051e46fa7bfbe776b142e4ded4f02097617a7588e93c53b71f900a4a8831a31be6f95e5f60f","ciphertext":"c17c3085505f3c094f0fa61791395b83ab1d8c90bdf9f12a64fc6e2e9cba266beb528f65c88bd933e36e6203752a9b63e6a92290a0ab6bf0ed591cf7bfa08006001e2cc63870165dc99ec61554ffdc14dea7d567e62cceed29314ae6c71a013843f5c06146dee5bf9c1d"}
+       * @param {string} keyFormat
+       * @param {string} requestId
        */
-      async function onExtractKeyEncryptedBundle(keyFormat) {
+      async function onExtractKeyEncryptedBundle(keyFormat, requestId) {
         // Get target embedded key from previous step (onInjectImportBundle)
         const targetPublicKeyJwk = TKHQ.getTargetEmbeddedKey();
         if (targetPublicKeyJwk == null) {
@@ -829,7 +843,7 @@
         TKHQ.resetTargetEmbeddedKey();
 
         // Send up ENCRYPTED_BUNDLE_EXTRACTED message
-        TKHQ.sendMessageUp("ENCRYPTED_BUNDLE_EXTRACTED", encryptedBundle);
+        TKHQ.sendMessageUp("ENCRYPTED_BUNDLE_EXTRACTED", encryptedBundle, requestId);
       }
 
       /**
@@ -837,6 +851,8 @@
        * For now, the only settings that can be applied are for "styles".
        * Persist them in local storage so they can be applied on every
        * page load.
+       * @param {string} settings: JSON-stringified settings
+       * @param {string} requestId
        */
       async function onApplySettings(settings) {
         // Apply settings
@@ -846,7 +862,7 @@
         TKHQ.setSettings(validSettings);
 
         // Send up SETTINGS_APPLIED message
-        TKHQ.sendMessageUp("SETTINGS_APPLIED", true);
+        TKHQ.sendMessageUp("SETTINGS_APPLIED", true, requestId);
       }
 
       async function HpkeEncrypt({ plaintextBuf, receiverPubJwk }) {

--- a/import/index.template.html
+++ b/import/index.template.html
@@ -869,7 +869,7 @@
        * @param {string} settings: JSON-stringified settings
        * @param {string} requestId
        */
-      async function onApplySettings(settings) {
+      async function onApplySettings(settings, requestId) {
         // Apply settings
         const validSettings = TKHQ.applySettings(settings);
 


### PR DESCRIPTION
$title

SDK counterpart: https://github.com/tkhq/sdk/pull/467

This mainly serves the case where there are concurrent, or serial, requests. Request IDs are used to disambiguate between multiple requests.