### PR TITLE
remove unused codepaths for bundle versions

### DIFF
--- a/export/index.template.html
+++ b/export/index.template.html
@@ -1067,34 +1067,6 @@
         // Parse the import bundle
         const bundleObj = JSON.parse(bundle);
         switch (bundleObj.version) {
-          case undefined:
-            // Validate fields exist
-            if (!bundleObj.encappedPublic) {
-              throw new Error('missing "encappedPublic" in bundle');
-            }
-
-            if (!bundleObj.encappedPublicSignature) {
-              throw new Error('missing "encappedPublicSignature" in bundle');
-            }
-
-            // Verify enclave signature
-            if (!TKHQ.verifyEnclaveSignature) {
-              throw new Error("method not loaded");
-            }
-            verified = await TKHQ.verifyEnclaveSignature(
-              bundleObj.enclaveQuorumPublic,
-              bundleObj.encappedPublicSignature,
-              bundleObj.encappedPublic
-            );
-            if (!verified) {
-              throw new Error(`failed to verify enclave signature: ${bundle}`);
-            }
-
-            encappedKeyBuf = TKHQ.uint8arrayFromHexString(
-              bundleObj.encappedPublic
-            );
-            ciphertextBuf = TKHQ.uint8arrayFromHexString(bundleObj.ciphertext);
-            break;
           case "v1.0.0":
             // Validate fields exist
             if (!bundleObj.data) {

--- a/import/index.template.html
+++ b/import/index.template.html
@@ -681,31 +681,6 @@
         const bundleObj = JSON.parse(bundle);
 
         switch (bundleObj.version) {
-          case undefined:
-            // Validate fields exist
-            if (!bundleObj.targetPublic) {
-              throw new Error('missing "targetPublic" in bundle');
-            }
-
-            if (!bundleObj.targetPublicSignature) {
-              throw new Error('missing "targetPublicSignature" in bundle');
-            }
-
-            // Verify enclave signature
-            verified = await TKHQ.verifyEnclaveSignature(
-              bundleObj.enclaveQuorumPublic,
-              bundleObj.targetPublicSignature,
-              bundleObj.targetPublic
-            );
-            if (!verified) {
-              throw new Error("failed to verify enclave signature");
-            }
-
-            // Load target public key generated from enclave and set in local storage
-            targetPublicBuf = TKHQ.uint8arrayFromHexString(
-              bundleObj.targetPublic
-            );
-            break;
           case "v1.0.0":
             // Validate fields exist
             if (!bundleObj.data) {

--- a/import/standalone.template.html
+++ b/import/standalone.template.html
@@ -620,31 +620,6 @@
         const bundleObj = JSON.parse(bundle);
 
         switch (bundleObj.version) {
-          case undefined:
-            // Validate fields exist
-            if (!bundleObj.targetPublic) {
-              throw new Error('missing "targetPublic" in bundle');
-            }
-
-            if (!bundleObj.targetPublicSignature) {
-              throw new Error('missing "targetPublicSignature" in bundle');
-            }
-
-            // Verify enclave signature
-            verified = await TKHQ.verifyEnclaveSignature(
-              bundleObj.enclaveQuorumPublic,
-              bundleObj.targetPublicSignature,
-              bundleObj.targetPublic
-            );
-            if (!verified) {
-              throw new Error("failed to verify enclave signature");
-            }
-
-            // Load target public key generated from enclave and set in local storage
-            targetPublicBuf = TKHQ.uint8arrayFromHexString(
-              bundleObj.targetPublic
-            );
-            break;
           case "v1.0.0":
             // Validate fields exist
             if (!bundleObj.data) {


### PR DESCRIPTION
$title

For TOB. Note that Turnkey-produced bundles are now all versioned; therefore, the `undefined` codepath is extremely unlikely to be used.