### PR TITLE
feat: add grafana faro instrumentation

### DIFF
--- a/auth/grafana-faro-web-sdk.js
+++ b/auth/grafana-faro-web-sdk.js
@@ -1,0 +1,5329 @@
+// vendored @grafana/faro-web-sdk v1.18.1 https://unpkg.com/@grafana/faro-web-sdk@1.18.1/dist/bundle/faro-web-sdk.iife.js
+
+var GrafanaFaroWebSdk = (function (e) {
+  "use strict";
+  function t(e, t) {
+    return typeof e === t;
+  }
+  function n(e, t) {
+    return Object.prototype.toString.call(e) === `[object ${t}]`;
+  }
+  function i(e, t) {
+    try {
+      return e instanceof t;
+    } catch (e) {
+      return !1;
+    }
+  }
+  const r = (e) => t(e, "null"),
+    o = (e) => t(e, "string"),
+    s = (e) => (t(e, "number") && !isNaN(e)) || t(e, "bigint"),
+    a = (e) => t(e, "boolean"),
+    u = (e) => !r(e) && t(e, "object"),
+    c = (e) => t(e, "function"),
+    l = (e) => n(e, "Array"),
+    d = (e) => !u(e) && !c(e),
+    f = "undefined" != typeof Event,
+    p = (e) => f && i(e, Event),
+    g = "undefined" != typeof Error,
+    m = (e) => g && i(e, Error),
+    v = (e) => n(e, "ErrorEvent"),
+    h = (e) => n(e, "DOMError"),
+    b = (e) => n(e, "DOMException"),
+    w = "undefined" != typeof Element,
+    y = "undefined" != typeof Map;
+  function S(e) {
+    return (
+      null == e ||
+      (l(e) || o(e) ? 0 === e.length : !!u(e) && 0 === Object.keys(e).length)
+    );
+  }
+  function T(e, n) {
+    if (e === n) return !0;
+    if (t(e, "number") && isNaN(e)) return t(n, "number") && isNaN(n);
+    const i = l(e),
+      r = l(n);
+    if (i !== r) return !1;
+    if (i && r) {
+      const t = e.length;
+      if (t !== n.length) return !1;
+      for (let i = t; 0 != i--; ) if (!T(e[i], n[i])) return !1;
+      return !0;
+    }
+    const o = u(e),
+      s = u(n);
+    if (o !== s) return !1;
+    if (e && n && o && s) {
+      const t = Object.keys(e),
+        i = Object.keys(n);
+      if (t.length !== i.length) return !1;
+      for (let e of t) if (!i.includes(e)) return !1;
+      for (let i of t) if (!T(e[i], n[i])) return !1;
+      return !0;
+    }
+    return !1;
+  }
+  function E() {
+    return Date.now();
+  }
+  function I() {
+    return new Date().toISOString();
+  }
+  function k(e) {
+    return new Date(e).toISOString();
+  }
+  var O;
+  (e.LogLevel = void 0),
+    ((O = e.LogLevel || (e.LogLevel = {})).TRACE = "trace"),
+    (O.DEBUG = "debug"),
+    (O.INFO = "info"),
+    (O.LOG = "log"),
+    (O.WARN = "warn"),
+    (O.ERROR = "error");
+  const x = e.LogLevel.LOG,
+    L = [
+      e.LogLevel.TRACE,
+      e.LogLevel.DEBUG,
+      e.LogLevel.INFO,
+      e.LogLevel.LOG,
+      e.LogLevel.WARN,
+      e.LogLevel.ERROR,
+    ];
+  function C() {}
+  function A(e) {
+    const { size: t, concurrency: n } = e,
+      i = [];
+    let r = 0;
+    const o = () => {
+      if (r < n && i.length) {
+        const { producer: e, resolve: t, reject: n } = i.shift();
+        r++,
+          e().then(
+            (e) => {
+              r--, o(), t(e);
+            },
+            (e) => {
+              r--, o(), n(e);
+            }
+          );
+      }
+    };
+    return {
+      add: (e) => {
+        if (i.length + r >= t) throw new Error("Task buffer full");
+        return new Promise((t, n) => {
+          i.push({ producer: e, resolve: t, reject: n }), o();
+        });
+      },
+    };
+  }
+  const P = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ0123456789";
+  function M(e = 10) {
+    return Array.from(Array(e))
+      .map(() => P[Math.floor(Math.random() * P.length)])
+      .join("");
+  }
+  const j =
+    "undefined" != typeof globalThis
+      ? globalThis
+      : "undefined" != typeof global
+      ? global
+      : "undefined" != typeof self
+      ? self
+      : void 0;
+  function N(e = {}) {
+    return JSON.stringify(
+      null != e ? e : {},
+      (function () {
+        const e = new WeakSet();
+        return function (t, n) {
+          if (u(n) && null !== n) {
+            if (e.has(n)) return null;
+            e.add(n);
+          }
+          return n;
+        };
+      })()
+    );
+  }
+  function _(e = {}) {
+    const t = {};
+    for (const [n, i] of Object.entries(e))
+      t[n] = u(i) && null !== i ? N(i) : String(i);
+    return t;
+  }
+  class D {
+    constructor() {
+      this.subscribers = [];
+    }
+    subscribe(e) {
+      return (
+        this.subscribers.push(e), { unsubscribe: () => this.unsubscribe(e) }
+      );
+    }
+    unsubscribe(e) {
+      this.subscribers = this.subscribers.filter((t) => t !== e);
+    }
+    notify(e) {
+      this.subscribers.forEach((t) => t(e));
+    }
+    first() {
+      const e = new D(),
+        t = (t) => {
+          e.notify(t), n.unsubscribe();
+        },
+        n = this.subscribe(t),
+        i = e.unsubscribe.bind(e);
+      return this.withUnsubscribeOverride(e, i, t);
+    }
+    takeWhile(e) {
+      const t = new D(),
+        n = (i) => {
+          e(i) ? t.notify(i) : t.unsubscribe(n);
+        };
+      this.subscribe(n);
+      const i = t.unsubscribe.bind(t);
+      return this.withUnsubscribeOverride(t, i, n);
+    }
+    filter(e) {
+      const t = new D(),
+        n = (n) => {
+          e(n) && t.notify(n);
+        };
+      this.subscribe(n);
+      const i = t.unsubscribe.bind(t);
+      return this.withUnsubscribeOverride(t, i, n);
+    }
+    merge(...e) {
+      const t = new D(),
+        n = [];
+      e.forEach((e) => {
+        const i = e.subscribe((e) => {
+          t.notify(e);
+        });
+        n.push(i);
+      });
+      const i = t.unsubscribeAll.bind(t);
+      return (
+        (t.unsubscribe = () => {
+          n.forEach((e) => e.unsubscribe()), i();
+        }),
+        t
+      );
+    }
+    withUnsubscribeOverride(e, t, n) {
+      return (
+        (e.unsubscribe = (e) => {
+          t(e), this.unsubscribe(n);
+        }),
+        e
+      );
+    }
+    unsubscribeAll() {
+      this.subscribers = [];
+    }
+  }
+  class R {
+    constructor(e, t) {
+      var n, i;
+      (this.signalBuffer = []),
+        (this.itemLimit =
+          null !== (n = null == t ? void 0 : t.itemLimit) && void 0 !== n
+            ? n
+            : 50),
+        (this.sendTimeout =
+          null !== (i = null == t ? void 0 : t.sendTimeout) && void 0 !== i
+            ? i
+            : 250),
+        (this.paused = (null == t ? void 0 : t.paused) || !1),
+        (this.sendFn = e),
+        (this.flushInterval = -1),
+        this.paused || this.start(),
+        document.addEventListener("visibilitychange", () => {
+          "hidden" === document.visibilityState && this.flush();
+        });
+    }
+    addItem(e) {
+      this.paused ||
+        (this.signalBuffer.push(e),
+        this.signalBuffer.length >= this.itemLimit && this.flush());
+    }
+    start() {
+      (this.paused = !1),
+        this.sendTimeout > 0 &&
+          (this.flushInterval = window.setInterval(
+            () => this.flush(),
+            this.sendTimeout
+          ));
+    }
+    pause() {
+      (this.paused = !0), clearInterval(this.flushInterval);
+    }
+    groupItems(e) {
+      const t = new Map();
+      return (
+        e.forEach((e) => {
+          const n = JSON.stringify(e.meta);
+          let i = t.get(n);
+          (i = void 0 === i ? [e] : [...i, e]), t.set(n, i);
+        }),
+        Array.from(t.values())
+      );
+    }
+    flush() {
+      if (this.paused || 0 === this.signalBuffer.length) return;
+      this.groupItems(this.signalBuffer).forEach(this.sendFn),
+        (this.signalBuffer = []);
+    }
+  }
+  var U;
+  (e.TransportItemType = void 0),
+    ((U = e.TransportItemType || (e.TransportItemType = {})).EXCEPTION =
+      "exception"),
+    (U.LOG = "log"),
+    (U.MEASUREMENT = "measurement"),
+    (U.TRACE = "trace"),
+    (U.EVENT = "event");
+  const B = {
+    [e.TransportItemType.EXCEPTION]: "exceptions",
+    [e.TransportItemType.LOG]: "logs",
+    [e.TransportItemType.MEASUREMENT]: "measurements",
+    [e.TransportItemType.TRACE]: "traces",
+    [e.TransportItemType.EVENT]: "events",
+  };
+  function F(e, t, n, i) {
+    var r;
+    t.debug("Initializing transports");
+    const o = [];
+    let s = n.paused,
+      a = [];
+    const u = (e) => {
+        let t = e;
+        for (const e of a) {
+          const i = t.map(e).filter(Boolean);
+          if (0 === i.length) return [];
+          t = z(i, n);
+        }
+        return t;
+      },
+      c = (e) => {
+        const n = u(e);
+        if (0 !== n.length)
+          for (const e of o)
+            t.debug(`Transporting item using ${e.name}\n`, n),
+              e.isBatched() && e.send(n);
+      };
+    let l;
+    (null === (r = n.batching) || void 0 === r ? void 0 : r.enabled) &&
+      (l = new R(c, {
+        sendTimeout: n.batching.sendTimeout,
+        itemLimit: n.batching.itemLimit,
+        paused: s,
+      }));
+    return {
+      add: (...r) => {
+        t.debug("Adding transports"),
+          r.forEach((r) => {
+            t.debug(`Adding "${r.name}" transport`);
+            o.some((e) => e === r)
+              ? t.warn(`Transport ${r.name} is already added`)
+              : ((r.unpatchedConsole = e),
+                (r.internalLogger = t),
+                (r.config = n),
+                (r.metas = i),
+                o.push(r));
+          });
+      },
+      addBeforeSendHooks: (...e) => {
+        t.debug("Adding beforeSendHooks\n", a),
+          e.forEach((e) => {
+            e && a.push(e);
+          });
+      },
+      getBeforeSendHooks: () => [...a],
+      execute: (e) => {
+        var i;
+        s ||
+          ((null === (i = n.batching) || void 0 === i ? void 0 : i.enabled) &&
+            (null == l || l.addItem(e)),
+          ((e) => {
+            var i, r;
+            if (
+              (null === (i = n.batching) || void 0 === i
+                ? void 0
+                : i.enabled) &&
+              o.every((e) => e.isBatched())
+            )
+              return;
+            const [s] = u([e]);
+            if (void 0 !== s)
+              for (const e of o)
+                t.debug(`Transporting item using ${e.name}\n`, s),
+                  e.isBatched()
+                    ? (null === (r = n.batching) || void 0 === r
+                        ? void 0
+                        : r.enabled) || e.send([s])
+                    : e.send(s);
+          })(e));
+      },
+      isPaused: () => s,
+      pause: () => {
+        t.debug("Pausing transports"), null == l || l.pause(), (s = !0);
+      },
+      remove: (...e) => {
+        t.debug("Removing transports"),
+          e.forEach((e) => {
+            t.debug(`Removing "${e.name}" transport`);
+            const n = o.indexOf(e);
+            -1 !== n
+              ? o.splice(n, 1)
+              : t.warn(`Transport "${e.name}" is not added`);
+          });
+      },
+      removeBeforeSendHooks: (...e) => {
+        a.filter((t) => !e.includes(t));
+      },
+      get transports() {
+        return [...o];
+      },
+      unpause: () => {
+        t.debug("Unpausing transports"), null == l || l.start(), (s = !1);
+      },
+    };
+  }
+  function z(t, n) {
+    if (n.preserveOriginalError)
+      for (const n of t)
+        n.type === e.TransportItemType.EXCEPTION &&
+          delete n.payload.originalError;
+    return t;
+  }
+  var q;
+  (e.InternalLoggerLevel = void 0),
+    ((q = e.InternalLoggerLevel || (e.InternalLoggerLevel = {}))[(q.OFF = 0)] =
+      "OFF"),
+    (q[(q.ERROR = 1)] = "ERROR"),
+    (q[(q.WARN = 2)] = "WARN"),
+    (q[(q.INFO = 3)] = "INFO"),
+    (q[(q.VERBOSE = 4)] = "VERBOSE");
+  const V = { debug: C, error: C, info: C, prefix: "Faro", warn: C },
+    $ = e.InternalLoggerLevel.ERROR,
+    G = Object.assign({}, console);
+  let H = G;
+  function W(e) {
+    var t;
+    return (H = null !== (t = e.unpatchedConsole) && void 0 !== t ? t : H), H;
+  }
+  function K(t = G, n = $) {
+    const i = V;
+    return (
+      n > e.InternalLoggerLevel.OFF &&
+        ((i.error =
+          n >= e.InternalLoggerLevel.ERROR
+            ? function (...e) {
+                t.error(`${i.prefix}\n`, ...e);
+              }
+            : C),
+        (i.warn =
+          n >= e.InternalLoggerLevel.WARN
+            ? function (...e) {
+                t.warn(`${i.prefix}\n`, ...e);
+              }
+            : C),
+        (i.info =
+          n >= e.InternalLoggerLevel.INFO
+            ? function (...e) {
+                t.info(`${i.prefix}\n`, ...e);
+              }
+            : C),
+        (i.debug =
+          n >= e.InternalLoggerLevel.VERBOSE
+            ? function (...e) {
+                t.debug(`${i.prefix}\n`, ...e);
+              }
+            : C)),
+      i
+    );
+  }
+  let X = V;
+  function J(e, t) {
+    return (X = K(e, t.internalLoggerLevel)), X;
+  }
+  class Z {
+    constructor() {
+      (this.unpatchedConsole = G),
+        (this.internalLogger = V),
+        (this.config = {}),
+        (this.metas = {});
+    }
+    logDebug(...e) {
+      this.internalLogger.debug(`${this.name}\n`, ...e);
+    }
+    logInfo(...e) {
+      this.internalLogger.info(`${this.name}\n`, ...e);
+    }
+    logWarn(...e) {
+      this.internalLogger.warn(`${this.name}\n`, ...e);
+    }
+    logError(...e) {
+      this.internalLogger.error(`${this.name}\n`, ...e);
+    }
+  }
+  class Y extends Z {
+    isBatched() {
+      return !1;
+    }
+    getIgnoreUrls() {
+      return [];
+    }
+  }
+  function Q(e, t) {
+    var n, i;
+    if (void 0 === t) return e;
+    if (void 0 === e) return { resourceSpans: t };
+    const r = null === (n = e.resourceSpans) || void 0 === n ? void 0 : n[0];
+    if (void 0 === r) return e;
+    const o = (null == r ? void 0 : r.scopeSpans) || [],
+      s =
+        (null === (i = null == t ? void 0 : t[0]) || void 0 === i
+          ? void 0
+          : i.scopeSpans) || [];
+    return Object.assign(Object.assign({}, e), {
+      resourceSpans: [
+        Object.assign(Object.assign({}, r), { scopeSpans: [...o, ...s] }),
+      ],
+    });
+  }
+  function ee(t) {
+    let n = { meta: {} };
+    return (
+      void 0 !== t[0] && (n.meta = t[0].meta),
+      t.forEach((t) => {
+        switch (t.type) {
+          case e.TransportItemType.LOG:
+          case e.TransportItemType.EVENT:
+          case e.TransportItemType.EXCEPTION:
+          case e.TransportItemType.MEASUREMENT:
+            const i = B[t.type],
+              r = n[i];
+            n = Object.assign(Object.assign({}, n), {
+              [i]: void 0 === r ? [t.payload] : [...r, t.payload],
+            });
+            break;
+          case e.TransportItemType.TRACE:
+            n = Object.assign(Object.assign({}, n), {
+              traces: Q(n.traces, t.payload.resourceSpans),
+            });
+        }
+      }),
+      n
+    );
+  }
+  const te = "user-action-start",
+    ne = "user-action-end",
+    ie = "user-action-cancel",
+    re = "user-action-halt";
+  const oe = "Error",
+    se = (e) => e.map((e) => (u(e) ? N(e) : String(e))).join(" ");
+  let ae;
+  function ue({
+    internalLogger: t,
+    config: n,
+    metas: i,
+    transports: s,
+    tracesApi: a,
+    actionBuffer: c,
+    getMessage: d,
+  }) {
+    var f;
+    t.debug("Initializing exceptions API");
+    let p = null;
+    ae = null !== (f = n.parseStacktrace) && void 0 !== f ? f : ae;
+    const g = (e) => {
+        t.debug("Changing stacktrace parser"), (ae = null != e ? e : ae);
+      },
+      { ignoreErrors: v = [], preserveOriginalError: h } = n;
+    return (
+      g(n.parseStacktrace),
+      {
+        changeStacktraceParser: g,
+        getStacktraceParser: () => ae,
+        pushError: (
+          f,
+          {
+            skipDedupe: g,
+            stackFrames: b,
+            type: w,
+            context: y,
+            spanContext: E,
+            timestampOverwriteMs: O,
+            originalError: x,
+          } = {}
+        ) => {
+          if (
+            !(function (e, t) {
+              const { message: n, name: i, stack: r } = t;
+              return (
+                (s = e),
+                (a = n + " " + i + " " + r),
+                s.some((e) => (o(e) ? a.includes(e) : !!a.match(e)))
+              );
+              var s, a;
+            })(v, null != x ? x : f)
+          )
+            try {
+              const o = _(
+                  Object.assign(
+                    Object.assign(
+                      {},
+                      (function (e) {
+                        let t = e.cause;
+                        m(t)
+                          ? (t = e.cause.toString())
+                          : null !== t && (u(e.cause) || l(e.cause))
+                          ? (t = N(e.cause))
+                          : null != t && (t = e.cause.toString());
+                        return null == t ? {} : { cause: t };
+                      })(null != x ? x : f)
+                    ),
+                    null != y ? y : {}
+                  )
+                ),
+                v = {
+                  meta: i.value,
+                  payload: Object.assign(
+                    Object.assign(
+                      {
+                        type: w || f.name || oe,
+                        value: f.message,
+                        timestamp: O ? k(O) : I(),
+                        trace: E
+                          ? { trace_id: E.traceId, span_id: E.spanId }
+                          : a.getTraceContext(),
+                      },
+                      S(o) ? {} : { context: o }
+                    ),
+                    h ? { originalError: x } : {}
+                  ),
+                  type: e.TransportItemType.EXCEPTION,
+                };
+              (null ==
+              (b =
+                null != b
+                  ? b
+                  : f.stack
+                  ? null == ae
+                    ? void 0
+                    : ae(f).frames
+                  : void 0)
+                ? void 0
+                : b.length) && (v.payload.stacktrace = { frames: b });
+              const L = {
+                type: v.payload.type,
+                value: v.payload.value,
+                stackTrace: v.payload.stacktrace,
+                context: v.payload.context,
+              };
+              if (!g && n.dedupe && !r(p) && T(L, p))
+                return void t.debug(
+                  "Skipping error push because it is the same as the last one\n",
+                  v.payload
+                );
+              (p = L), t.debug("Pushing exception\n", v);
+              const C = d();
+              C && C.type === te ? c.addItem(v) : s.execute(v);
+            } catch (e) {
+              t.error("Error pushing event", e);
+            }
+        },
+      }
+    );
+  }
+  const ce = (e) =>
+    e
+      .map((e) => {
+        try {
+          return String(e);
+        } catch (e) {
+          return "";
+        }
+      })
+      .join(" ");
+  class le {
+    constructor() {
+      this.buffer = [];
+    }
+    addItem(e) {
+      this.buffer.push(e);
+    }
+    flushBuffer(e) {
+      if (c(e)) for (const t of this.buffer) e(t);
+      this.buffer.length = 0;
+    }
+    size() {
+      return this.buffer.length;
+    }
+  }
+  function de({ apiMessageBus: t, transports: n, config: i }) {
+    const r = new le(),
+      o = i.trackUserActionsExcludeItem;
+    let s;
+    t.subscribe((t) => {
+      if (te !== t.type && re !== t.type) {
+        if (t.type === ne) {
+          const { id: i, name: a } = t;
+          return (
+            r.flushBuffer((t) => {
+              if (
+                (function (t, n) {
+                  return (
+                    (null == n ? void 0 : n(t)) ||
+                    (t.type === e.TransportItemType.MEASUREMENT &&
+                      "web-vitals" === t.payload.type)
+                  );
+                })(t, o)
+              )
+                return void n.execute(t);
+              const r = Object.assign(Object.assign({}, t), {
+                payload: Object.assign(Object.assign({}, t.payload), {
+                  action: { parentId: i, name: a },
+                }),
+              });
+              n.execute(r);
+            }),
+            void (s = void 0)
+          );
+        }
+        t.type === ie &&
+          ((s = void 0),
+          r.flushBuffer((e) => {
+            n.execute(e);
+          }));
+      } else s = t;
+    });
+    return { actionBuffer: r, getMessage: () => s };
+  }
+  const fe = new D();
+  function pe(t, n, i, s, a) {
+    n.debug("Initializing API");
+    const { actionBuffer: u, getMessage: c } = de({
+        apiMessageBus: fe,
+        transports: a,
+        config: i,
+      }),
+      l = (function (t, n, i, r, o) {
+        let s;
+        return (
+          n.debug("Initializing traces API"),
+          {
+            getOTEL: () => s,
+            getTraceContext: () => {
+              const e =
+                null == s ? void 0 : s.trace.getSpanContext(s.context.active());
+              return e ? { trace_id: e.traceId, span_id: e.spanId } : void 0;
+            },
+            initOTEL: (e, t) => {
+              n.debug("Initializing OpenTelemetry"),
+                (s = { trace: e, context: t });
+            },
+            isOTELInitialized: () => !!s,
+            pushTraces: (t) => {
+              try {
+                const i = {
+                  type: e.TransportItemType.TRACE,
+                  payload: t,
+                  meta: r.value,
+                };
+                n.debug("Pushing trace\n", i), o.execute(i);
+              } catch (e) {
+                n.error("Error pushing trace\n", e);
+              }
+            },
+          }
+        );
+      })(0, n, 0, s, a),
+      d = {
+        unpatchedConsole: t,
+        internalLogger: n,
+        config: i,
+        metas: s,
+        transports: a,
+        tracesApi: l,
+        actionBuffer: u,
+        getMessage: c,
+      };
+    return Object.assign(
+      Object.assign(
+        Object.assign(
+          Object.assign(
+            Object.assign(Object.assign({}, l), ue(d)),
+            (function ({ internalLogger: e, metas: t }) {
+              let n, i, r, s;
+              e.debug("Initializing meta API");
+              const a = (e) => {
+                  i && t.remove(i), (i = { user: e }), t.add(i);
+                },
+                u = (e, i) => {
+                  var r;
+                  const o = null == i ? void 0 : i.overrides,
+                    s = o
+                      ? {
+                          overrides: Object.assign(
+                            Object.assign(
+                              {},
+                              null === (r = null == n ? void 0 : n.session) ||
+                                void 0 === r
+                                ? void 0
+                                : r.overrides
+                            ),
+                            o
+                          ),
+                        }
+                      : {};
+                  n && t.remove(n),
+                    (n = {
+                      session: Object.assign(
+                        Object.assign({}, S(e) ? void 0 : e),
+                        s
+                      ),
+                    }),
+                    t.add(n);
+                },
+                c = () => t.value.session,
+                l = () => t.value.page;
+              return {
+                setUser: a,
+                resetUser: a,
+                setSession: u,
+                resetSession: u,
+                getSession: c,
+                setView: (e, n) => {
+                  var i;
+                  if (
+                    ((null == n ? void 0 : n.overrides) &&
+                      u(c(), { overrides: n.overrides }),
+                    (null === (i = null == r ? void 0 : r.view) || void 0 === i
+                      ? void 0
+                      : i.name) === (null == e ? void 0 : e.name))
+                  )
+                    return;
+                  const o = r;
+                  (r = { view: e }), t.add(r), o && t.remove(o);
+                },
+                getView: () => t.value.view,
+                setPage: (e) => {
+                  var n;
+                  const i = o(e)
+                    ? Object.assign(
+                        Object.assign(
+                          {},
+                          null !== (n = null == s ? void 0 : s.page) &&
+                            void 0 !== n
+                            ? n
+                            : l()
+                        ),
+                        { id: e }
+                      )
+                    : e;
+                  s && t.remove(s), (s = { page: i }), t.add(s);
+                },
+                getPage: l,
+              };
+            })(d)
+          ),
+          (function ({
+            internalLogger: t,
+            config: n,
+            metas: i,
+            transports: o,
+            tracesApi: s,
+            actionBuffer: a,
+            getMessage: u,
+          }) {
+            var c;
+            t.debug("Initializing logs API");
+            let l = null;
+            const d =
+              null !== (c = n.logArgsSerializer) && void 0 !== c ? c : ce;
+            return {
+              pushLog: (
+                c,
+                {
+                  context: f,
+                  level: p,
+                  skipDedupe: g,
+                  spanContext: m,
+                  timestampOverwriteMs: v,
+                } = {}
+              ) => {
+                try {
+                  const h = _(f),
+                    b = {
+                      type: e.TransportItemType.LOG,
+                      payload: {
+                        message: d(c),
+                        level: null != p ? p : x,
+                        context: S(h) ? void 0 : h,
+                        timestamp: v ? k(v) : I(),
+                        trace: m
+                          ? { trace_id: m.traceId, span_id: m.spanId }
+                          : s.getTraceContext(),
+                      },
+                      meta: i.value,
+                    },
+                    w = {
+                      message: b.payload.message,
+                      level: b.payload.level,
+                      context: b.payload.context,
+                    };
+                  if (!g && n.dedupe && !r(l) && T(w, l))
+                    return void t.debug(
+                      "Skipping log push because it is the same as the last one\n",
+                      b.payload
+                    );
+                  (l = w), t.debug("Pushing log\n", b);
+                  const y = u();
+                  y && y.type === te ? a.addItem(b) : o.execute(b);
+                } catch (e) {
+                  t.error("Error pushing log\n", e);
+                }
+              },
+            };
+          })(d)
+        ),
+        (function ({
+          internalLogger: t,
+          config: n,
+          metas: i,
+          transports: o,
+          tracesApi: s,
+          actionBuffer: a,
+          getMessage: u,
+        }) {
+          t.debug("Initializing measurements API");
+          let c = null;
+          return {
+            pushMeasurement: (
+              l,
+              {
+                skipDedupe: d,
+                context: f,
+                spanContext: p,
+                timestampOverwriteMs: g,
+              } = {}
+            ) => {
+              try {
+                const m = _(f),
+                  v = {
+                    type: e.TransportItemType.MEASUREMENT,
+                    payload: Object.assign(Object.assign({}, l), {
+                      trace: p
+                        ? { trace_id: p.traceId, span_id: p.spanId }
+                        : s.getTraceContext(),
+                      timestamp: g ? k(g) : I(),
+                      context: S(m) ? void 0 : m,
+                    }),
+                    meta: i.value,
+                  },
+                  h = {
+                    type: v.payload.type,
+                    values: v.payload.values,
+                    context: v.payload.context,
+                  };
+                if (!d && n.dedupe && !r(c) && T(h, c))
+                  return void t.debug(
+                    "Skipping measurement push because it is the same as the last one\n",
+                    v.payload
+                  );
+                (c = h), t.debug("Pushing measurement\n", v);
+                const b = u();
+                b && b.type === te ? a.addItem(v) : o.execute(v);
+              } catch (e) {
+                t.error("Error pushing measurement\n", e);
+              }
+            },
+          };
+        })(d)
+      ),
+      (function ({
+        internalLogger: t,
+        config: n,
+        metas: i,
+        transports: o,
+        tracesApi: s,
+        actionBuffer: a,
+        getMessage: u,
+      }) {
+        let c = null;
+        return {
+          pushEvent: (
+            l,
+            d,
+            f,
+            {
+              skipDedupe: p,
+              spanContext: g,
+              timestampOverwriteMs: m,
+              customPayloadTransformer: v = (e) => e,
+            } = {}
+          ) => {
+            try {
+              const h = _(d),
+                b = {
+                  meta: i.value,
+                  payload: v({
+                    name: l,
+                    domain: null != f ? f : n.eventDomain,
+                    attributes: S(h) ? void 0 : h,
+                    timestamp: m ? k(m) : I(),
+                    trace: g
+                      ? { trace_id: g.traceId, span_id: g.spanId }
+                      : s.getTraceContext(),
+                  }),
+                  type: e.TransportItemType.EVENT,
+                },
+                w = {
+                  name: b.payload.name,
+                  attributes: b.payload.attributes,
+                  domain: b.payload.domain,
+                };
+              if (!p && n.dedupe && !r(c) && T(w, c))
+                return void t.debug(
+                  "Skipping event push because it is the same as the last one\n",
+                  b.payload
+                );
+              (c = w), t.debug("Pushing event\n", b);
+              const y = u();
+              y && y.type === te ? a.addItem(b) : o.execute(b);
+            } catch (e) {
+              t.error("Error pushing event", e);
+            }
+          },
+        };
+      })(d)
+    );
+  }
+  class ge extends Z {
+    constructor() {
+      super(...arguments), (this.api = {}), (this.transports = {});
+    }
+  }
+  const me = "1.18.1";
+  const ve = "_faroInternal";
+  function he(e) {
+    e.config.isolate
+      ? e.internalLogger.debug(
+          "Skipping registering internal Faro instance on global object"
+        )
+      : (e.internalLogger.debug(
+          "Registering internal Faro instance on global object"
+        ),
+        Object.defineProperty(j, ve, {
+          configurable: !1,
+          enumerable: !1,
+          writable: !1,
+          value: e,
+        }));
+  }
+  function be() {
+    return ve in j;
+  }
+  function we(t, n, i, r, o, s, a) {
+    return (
+      n.debug("Initializing Faro"),
+      (e.faro = {
+        api: s,
+        config: i,
+        instrumentations: a,
+        internalLogger: n,
+        metas: r,
+        pause: o.pause,
+        transports: o,
+        unpatchedConsole: t,
+        unpause: o.unpause,
+      }),
+      he(e.faro),
+      (function (e) {
+        if (e.config.preventGlobalExposure)
+          e.internalLogger.debug(
+            "Skipping registering public Faro instance in the global scope"
+          );
+        else {
+          if (
+            (e.internalLogger.debug(
+              `Registering public faro reference in the global scope using "${e.config.globalObjectKey}" key`
+            ),
+            e.config.globalObjectKey in j)
+          )
+            return void e.internalLogger.warn(
+              `Skipping global registration due to key "${e.config.globalObjectKey}" being used already. Please set "globalObjectKey" to something else or set "preventGlobalExposure" to "true"`
+            );
+          Object.defineProperty(j, e.config.globalObjectKey, {
+            configurable: !1,
+            writable: !1,
+            value: e,
+          });
+        }
+      })(e.faro),
+      e.faro
+    );
+  }
+  function ye(e) {
+    const t = W(e),
+      n = J(t, e);
+    if (be() && !e.isolate)
+      return void n.error(
+        'Faro is already registered. Either add instrumentations, transports etc. to the global faro instance or use the "isolate" property'
+      );
+    n.debug("Initializing");
+    const i = (function (e, t) {
+        let n = [],
+          i = [];
+        const r = () =>
+            n.reduce((e, t) => Object.assign(e, c(t) ? t() : t), {}),
+          o = () => {
+            if (i.length) {
+              const e = r();
+              i.forEach((t) => t(e));
+            }
+          };
+        return {
+          add: (...e) => {
+            t.debug("Adding metas\n", e), n.push(...e), o();
+          },
+          remove: (...e) => {
+            t.debug("Removing metas\n", e),
+              (n = n.filter((t) => !e.includes(t))),
+              o();
+          },
+          addListener: (e) => {
+            t.debug("Adding metas listener\n", e), i.push(e);
+          },
+          removeListener: (e) => {
+            t.debug("Removing metas listener\n", e),
+              (i = i.filter((t) => t !== e));
+          },
+          get value() {
+            return r();
+          },
+        };
+      })(0, n),
+      r = F(t, n, e, i),
+      o = pe(t, n, e, i, r),
+      s = (function (e, t, n, i, r, o) {
+        t.debug("Initializing instrumentations");
+        const s = [];
+        return {
+          add: (...a) => {
+            t.debug("Adding instrumentations"),
+              a.forEach((a) => {
+                t.debug(`Adding "${a.name}" instrumentation`),
+                  s.some((e) => e.name === a.name)
+                    ? t.warn(`Instrumentation ${a.name} is already added`)
+                    : ((a.unpatchedConsole = e),
+                      (a.internalLogger = t),
+                      (a.config = n),
+                      (a.metas = i),
+                      (a.transports = r),
+                      (a.api = o),
+                      s.push(a),
+                      a.initialize());
+              });
+          },
+          get instrumentations() {
+            return [...s];
+          },
+          remove: (...e) => {
+            t.debug("Removing instrumentations"),
+              e.forEach((e) => {
+                var n, i;
+                t.debug(`Removing "${e.name}" instrumentation`);
+                const r = s.reduce(
+                  (t, n, i) => (null === t && n.name === e.name ? i : null),
+                  null
+                );
+                r
+                  ? (null === (i = (n = s[r]).destroy) ||
+                      void 0 === i ||
+                      i.call(n),
+                    s.splice(r, 1))
+                  : t.warn(`Instrumentation "${e.name}" is not added`);
+              });
+          },
+        };
+      })(t, n, e, i, r, o),
+      a = we(t, n, e, i, r, o, s);
+    return (
+      (function (e) {
+        var t, n;
+        const i = {
+          sdk: { version: me },
+          app: {
+            bundleId:
+              e.config.app.name &&
+              ((r = e.config.app.name),
+              null == j ? void 0 : j[`__faroBundleId_${r}`]),
+          },
+        };
+        var r;
+        const o =
+          null === (t = e.config.sessionTracking) || void 0 === t
+            ? void 0
+            : t.session;
+        o && e.api.setSession(o),
+          e.config.app &&
+            (i.app = Object.assign(Object.assign({}, e.config.app), i.app)),
+          e.config.user && (i.user = e.config.user),
+          e.config.view && (i.view = e.config.view),
+          e.metas.add(
+            i,
+            ...(null !== (n = e.config.metas) && void 0 !== n ? n : [])
+          );
+      })(a),
+      (function (e) {
+        e.transports.add(...e.config.transports),
+          e.transports.addBeforeSendHooks(e.config.beforeSend);
+      })(a),
+      (function (e) {
+        e.instrumentations.add(...e.config.instrumentations);
+      })(a),
+      a
+    );
+  }
+  e.faro = {};
+  const Se = "faro",
+    Te = { enabled: !0, sendTimeout: 250, itemLimit: 50 },
+    Ee = "view_changed",
+    Ie = "session_start",
+    ke = "session_resume",
+    Oe = "session_extend",
+    xe = "service_name_override",
+    Le = "unknown";
+  var Ce,
+    Ae = { exports: {} },
+    Pe = Ae.exports;
+  var Me =
+    (Ce ||
+      ((Ce = 1),
+      (function (e, t) {
+        !(function (n, i) {
+          var r = "function",
+            o = "undefined",
+            s = "object",
+            a = "string",
+            u = "major",
+            c = "model",
+            l = "name",
+            d = "type",
+            f = "vendor",
+            p = "version",
+            g = "architecture",
+            m = "console",
+            v = "mobile",
+            h = "tablet",
+            b = "smarttv",
+            w = "wearable",
+            y = "embedded",
+            S = "Amazon",
+            T = "Apple",
+            E = "ASUS",
+            I = "BlackBerry",
+            k = "Browser",
+            O = "Chrome",
+            x = "Firefox",
+            L = "Google",
+            C = "Huawei",
+            A = "LG",
+            P = "Microsoft",
+            M = "Motorola",
+            j = "Opera",
+            N = "Samsung",
+            _ = "Sharp",
+            D = "Sony",
+            R = "Xiaomi",
+            U = "Zebra",
+            B = "Facebook",
+            F = "Chromium OS",
+            z = "Mac OS",
+            q = " Browser",
+            V = function (e) {
+              for (var t = {}, n = 0; n < e.length; n++)
+                t[e[n].toUpperCase()] = e[n];
+              return t;
+            },
+            $ = function (e, t) {
+              return typeof e === a && -1 !== G(t).indexOf(G(e));
+            },
+            G = function (e) {
+              return e.toLowerCase();
+            },
+            H = function (e, t) {
+              if (typeof e === a)
+                return (
+                  (e = e.replace(/^\s\s*/, "")),
+                  typeof t === o ? e : e.substring(0, 500)
+                );
+            },
+            W = function (e, t) {
+              for (var n, o, a, u, c, l, d = 0; d < t.length && !c; ) {
+                var f = t[d],
+                  p = t[d + 1];
+                for (n = o = 0; n < f.length && !c && f[n]; )
+                  if ((c = f[n++].exec(e)))
+                    for (a = 0; a < p.length; a++)
+                      (l = c[++o]),
+                        typeof (u = p[a]) === s && u.length > 0
+                          ? 2 === u.length
+                            ? typeof u[1] == r
+                              ? (this[u[0]] = u[1].call(this, l))
+                              : (this[u[0]] = u[1])
+                            : 3 === u.length
+                            ? typeof u[1] !== r || (u[1].exec && u[1].test)
+                              ? (this[u[0]] = l ? l.replace(u[1], u[2]) : i)
+                              : (this[u[0]] = l ? u[1].call(this, l, u[2]) : i)
+                            : 4 === u.length &&
+                              (this[u[0]] = l
+                                ? u[3].call(this, l.replace(u[1], u[2]))
+                                : i)
+                          : (this[u] = l || i);
+                d += 2;
+              }
+            },
+            K = function (e, t) {
+              for (var n in t)
+                if (typeof t[n] === s && t[n].length > 0) {
+                  for (var r = 0; r < t[n].length; r++)
+                    if ($(t[n][r], e)) return "?" === n ? i : n;
+                } else if ($(t[n], e)) return "?" === n ? i : n;
+              return t.hasOwnProperty("*") ? t["*"] : e;
+            },
+            X = {
+              ME: "4.90",
+              "NT 3.11": "NT3.51",
+              "NT 4.0": "NT4.0",
+              2e3: "NT 5.0",
+              XP: ["NT 5.1", "NT 5.2"],
+              Vista: "NT 6.0",
+              7: "NT 6.1",
+              8: "NT 6.2",
+              8.1: "NT 6.3",
+              10: ["NT 6.4", "NT 10.0"],
+              RT: "ARM",
+            },
+            J = {
+              browser: [
+                [/\b(?:crmo|crios)\/([\w\.]+)/i],
+                [p, [l, "Chrome"]],
+                [/edg(?:e|ios|a)?\/([\w\.]+)/i],
+                [p, [l, "Edge"]],
+                [
+                  /(opera mini)\/([-\w\.]+)/i,
+                  /(opera [mobiletab]{3,6})\b.+version\/([-\w\.]+)/i,
+                  /(opera)(?:.+version\/|[\/ ]+)([\w\.]+)/i,
+                ],
+                [l, p],
+                [/opios[\/ ]+([\w\.]+)/i],
+                [p, [l, j + " Mini"]],
+                [/\bop(?:rg)?x\/([\w\.]+)/i],
+                [p, [l, j + " GX"]],
+                [/\bopr\/([\w\.]+)/i],
+                [p, [l, j]],
+                [/\bb[ai]*d(?:uhd|[ub]*[aekoprswx]{5,6})[\/ ]?([\w\.]+)/i],
+                [p, [l, "Baidu"]],
+                [/\b(?:mxbrowser|mxios|myie2)\/?([-\w\.]*)\b/i],
+                [p, [l, "Maxthon"]],
+                [
+                  /(kindle)\/([\w\.]+)/i,
+                  /(lunascape|maxthon|netfront|jasmine|blazer|sleipnir)[\/ ]?([\w\.]*)/i,
+                  /(avant|iemobile|slim(?:browser|boat|jet))[\/ ]?([\d\.]*)/i,
+                  /(?:ms|\()(ie) ([\w\.]+)/i,
+                  /(flock|rockmelt|midori|epiphany|silk|skyfire|ovibrowser|bolt|iron|vivaldi|iridium|phantomjs|bowser|qupzilla|falkon|rekonq|puffin|brave|whale(?!.+naver)|qqbrowserlite|duckduckgo|klar|helio|(?=comodo_)?dragon)\/([-\w\.]+)/i,
+                  /(heytap|ovi|115)browser\/([\d\.]+)/i,
+                  /(weibo)__([\d\.]+)/i,
+                ],
+                [l, p],
+                [/quark(?:pc)?\/([-\w\.]+)/i],
+                [p, [l, "Quark"]],
+                [/\bddg\/([\w\.]+)/i],
+                [p, [l, "DuckDuckGo"]],
+                [/(?:\buc? ?browser|(?:juc.+)ucweb)[\/ ]?([\w\.]+)/i],
+                [p, [l, "UC" + k]],
+                [
+                  /microm.+\bqbcore\/([\w\.]+)/i,
+                  /\bqbcore\/([\w\.]+).+microm/i,
+                  /micromessenger\/([\w\.]+)/i,
+                ],
+                [p, [l, "WeChat"]],
+                [/konqueror\/([\w\.]+)/i],
+                [p, [l, "Konqueror"]],
+                [/trident.+rv[: ]([\w\.]{1,9})\b.+like gecko/i],
+                [p, [l, "IE"]],
+                [/ya(?:search)?browser\/([\w\.]+)/i],
+                [p, [l, "Yandex"]],
+                [/slbrowser\/([\w\.]+)/i],
+                [p, [l, "Smart Lenovo " + k]],
+                [/(avast|avg)\/([\w\.]+)/i],
+                [[l, /(.+)/, "$1 Secure " + k], p],
+                [/\bfocus\/([\w\.]+)/i],
+                [p, [l, x + " Focus"]],
+                [/\bopt\/([\w\.]+)/i],
+                [p, [l, j + " Touch"]],
+                [/coc_coc\w+\/([\w\.]+)/i],
+                [p, [l, "Coc Coc"]],
+                [/dolfin\/([\w\.]+)/i],
+                [p, [l, "Dolphin"]],
+                [/coast\/([\w\.]+)/i],
+                [p, [l, j + " Coast"]],
+                [/miuibrowser\/([\w\.]+)/i],
+                [p, [l, "MIUI" + q]],
+                [/fxios\/([\w\.-]+)/i],
+                [p, [l, x]],
+                [/\bqihoobrowser\/?([\w\.]*)/i],
+                [p, [l, "360"]],
+                [/\b(qq)\/([\w\.]+)/i],
+                [[l, /(.+)/, "$1Browser"], p],
+                [/(oculus|sailfish|huawei|vivo|pico)browser\/([\w\.]+)/i],
+                [[l, /(.+)/, "$1" + q], p],
+                [/samsungbrowser\/([\w\.]+)/i],
+                [p, [l, N + " Internet"]],
+                [/metasr[\/ ]?([\d\.]+)/i],
+                [p, [l, "Sogou Explorer"]],
+                [/(sogou)mo\w+\/([\d\.]+)/i],
+                [[l, "Sogou Mobile"], p],
+                [
+                  /(electron)\/([\w\.]+) safari/i,
+                  /(tesla)(?: qtcarbrowser|\/(20\d\d\.[-\w\.]+))/i,
+                  /m?(qqbrowser|2345(?=browser|chrome|explorer))\w*[\/ ]?v?([\w\.]+)/i,
+                ],
+                [l, p],
+                [/(lbbrowser|rekonq)/i, /\[(linkedin)app\]/i],
+                [l],
+                [
+                  /ome\/([\w\.]+) \w* ?(iron) saf/i,
+                  /ome\/([\w\.]+).+qihu (360)[es]e/i,
+                ],
+                [p, l],
+                [/((?:fban\/fbios|fb_iab\/fb4a)(?!.+fbav)|;fbav\/([\w\.]+);)/i],
+                [[l, B], p],
+                [
+                  /(Klarna)\/([\w\.]+)/i,
+                  /(kakao(?:talk|story))[\/ ]([\w\.]+)/i,
+                  /(naver)\(.*?(\d+\.[\w\.]+).*\)/i,
+                  /safari (line)\/([\w\.]+)/i,
+                  /\b(line)\/([\w\.]+)\/iab/i,
+                  /(alipay)client\/([\w\.]+)/i,
+                  /(twitter)(?:and| f.+e\/([\w\.]+))/i,
+                  /(chromium|instagram|snapchat)[\/ ]([-\w\.]+)/i,
+                ],
+                [l, p],
+                [/\bgsa\/([\w\.]+) .*safari\//i],
+                [p, [l, "GSA"]],
+                [/musical_ly(?:.+app_?version\/|_)([\w\.]+)/i],
+                [p, [l, "TikTok"]],
+                [/headlesschrome(?:\/([\w\.]+)| )/i],
+                [p, [l, O + " Headless"]],
+                [/ wv\).+(chrome)\/([\w\.]+)/i],
+                [[l, O + " WebView"], p],
+                [/droid.+ version\/([\w\.]+)\b.+(?:mobile safari|safari)/i],
+                [p, [l, "Android " + k]],
+                [/(chrome|omniweb|arora|[tizenoka]{5} ?browser)\/v?([\w\.]+)/i],
+                [l, p],
+                [/version\/([\w\.\,]+) .*mobile\/\w+ (safari)/i],
+                [p, [l, "Mobile Safari"]],
+                [/version\/([\w(\.|\,)]+) .*(mobile ?safari|safari)/i],
+                [p, l],
+                [/webkit.+?(mobile ?safari|safari)(\/[\w\.]+)/i],
+                [
+                  l,
+                  [
+                    p,
+                    K,
+                    {
+                      "1.0": "/8",
+                      1.2: "/1",
+                      1.3: "/3",
+                      "2.0": "/412",
+                      "2.0.2": "/416",
+                      "2.0.3": "/417",
+                      "2.0.4": "/419",
+                      "?": "/",
+                    },
+                  ],
+                ],
+                [/(webkit|khtml)\/([\w\.]+)/i],
+                [l, p],
+                [/(navigator|netscape\d?)\/([-\w\.]+)/i],
+                [[l, "Netscape"], p],
+                [/(wolvic|librewolf)\/([\w\.]+)/i],
+                [l, p],
+                [/mobile vr; rv:([\w\.]+)\).+firefox/i],
+                [p, [l, x + " Reality"]],
+                [
+                  /ekiohf.+(flow)\/([\w\.]+)/i,
+                  /(swiftfox)/i,
+                  /(icedragon|iceweasel|camino|chimera|fennec|maemo browser|minimo|conkeror)[\/ ]?([\w\.\+]+)/i,
+                  /(seamonkey|k-meleon|icecat|iceape|firebird|phoenix|palemoon|basilisk|waterfox)\/([-\w\.]+)$/i,
+                  /(firefox)\/([\w\.]+)/i,
+                  /(mozilla)\/([\w\.]+) .+rv\:.+gecko\/\d+/i,
+                  /(polaris|lynx|dillo|icab|doris|amaya|w3m|netsurf|obigo|mosaic|(?:go|ice|up)[\. ]?browser)[-\/ ]?v?([\w\.]+)/i,
+                  /(links) \(([\w\.]+)/i,
+                ],
+                [l, [p, /_/g, "."]],
+                [/(cobalt)\/([\w\.]+)/i],
+                [l, [p, /master.|lts./, ""]],
+              ],
+              cpu: [
+                [/(?:(amd|x(?:(?:86|64)[-_])?|wow|win)64)[;\)]/i],
+                [[g, "amd64"]],
+                [/(ia32(?=;))/i],
+                [[g, G]],
+                [/((?:i[346]|x)86)[;\)]/i],
+                [[g, "ia32"]],
+                [/\b(aarch64|arm(v?8e?l?|_?64))\b/i],
+                [[g, "arm64"]],
+                [/\b(arm(?:v[67])?ht?n?[fl]p?)\b/i],
+                [[g, "armhf"]],
+                [/windows (ce|mobile); ppc;/i],
+                [[g, "arm"]],
+                [/((?:ppc|powerpc)(?:64)?)(?: mac|;|\))/i],
+                [[g, /ower/, "", G]],
+                [/(sun4\w)[;\)]/i],
+                [[g, "sparc"]],
+                [
+                  /((?:avr32|ia64(?=;))|68k(?=\))|\barm(?=v(?:[1-7]|[5-7]1)l?|;|eabi)|(?=atmel )avr|(?:irix|mips|sparc)(?:64)?\b|pa-risc)/i,
+                ],
+                [[g, G]],
+              ],
+              device: [
+                [
+                  /\b(sch-i[89]0\d|shw-m380s|sm-[ptx]\w{2,4}|gt-[pn]\d{2,4}|sgh-t8[56]9|nexus 10)/i,
+                ],
+                [c, [f, N], [d, h]],
+                [
+                  /\b((?:s[cgp]h|gt|sm)-(?![lr])\w+|sc[g-]?[\d]+a?|galaxy nexus)/i,
+                  /samsung[- ]((?!sm-[lr])[-\w]+)/i,
+                  /sec-(sgh\w+)/i,
+                ],
+                [c, [f, N], [d, v]],
+                [/(?:\/|\()(ip(?:hone|od)[\w, ]*)(?:\/|;)/i],
+                [c, [f, T], [d, v]],
+                [
+                  /\((ipad);[-\w\),; ]+apple/i,
+                  /applecoremedia\/[\w\.]+ \((ipad)/i,
+                  /\b(ipad)\d\d?,\d\d?[;\]].+ios/i,
+                ],
+                [c, [f, T], [d, h]],
+                [/(macintosh);/i],
+                [c, [f, T]],
+                [/\b(sh-?[altvz]?\d\d[a-ekm]?)/i],
+                [c, [f, _], [d, v]],
+                [/(?:honor)([-\w ]+)[;\)]/i],
+                [c, [f, "Honor"], [d, v]],
+                [/\b((?:ag[rs][23]?|bah2?|sht?|btv)-a?[lw]\d{2})\b(?!.+d\/s)/i],
+                [c, [f, C], [d, h]],
+                [
+                  /(?:huawei)([-\w ]+)[;\)]/i,
+                  /\b(nexus 6p|\w{2,4}e?-[atu]?[ln][\dx][012359c][adn]?)\b(?!.+d\/s)/i,
+                ],
+                [c, [f, C], [d, v]],
+                [
+                  /\b(poco[\w ]+|m2\d{3}j\d\d[a-z]{2})(?: bui|\))/i,
+                  /\b; (\w+) build\/hm\1/i,
+                  /\b(hm[-_ ]?note?[_ ]?(?:\d\w)?) bui/i,
+                  /\b(redmi[\-_ ]?(?:note|k)?[\w_ ]+)(?: bui|\))/i,
+                  /oid[^\)]+; (m?[12][0-389][01]\w{3,6}[c-y])( bui|; wv|\))/i,
+                  /\b(mi[-_ ]?(?:a\d|one|one[_ ]plus|note lte|max|cc)?[_ ]?(?:\d?\w?)[_ ]?(?:plus|se|lite|pro)?)(?: bui|\))/i,
+                ],
+                [
+                  [c, /_/g, " "],
+                  [f, R],
+                  [d, v],
+                ],
+                [
+                  /oid[^\)]+; (2\d{4}(283|rpbf)[cgl])( bui|\))/i,
+                  /\b(mi[-_ ]?(?:pad)(?:[\w_ ]+))(?: bui|\))/i,
+                ],
+                [
+                  [c, /_/g, " "],
+                  [f, R],
+                  [d, h],
+                ],
+                [
+                  /; (\w+) bui.+ oppo/i,
+                  /\b(cph[12]\d{3}|p(?:af|c[al]|d\w|e[ar])[mt]\d0|x9007|a101op)\b/i,
+                ],
+                [c, [f, "OPPO"], [d, v]],
+                [/\b(opd2\d{3}a?) bui/i],
+                [c, [f, "OPPO"], [d, h]],
+                [/vivo (\w+)(?: bui|\))/i, /\b(v[12]\d{3}\w?[at])(?: bui|;)/i],
+                [c, [f, "Vivo"], [d, v]],
+                [/\b(rmx[1-3]\d{3})(?: bui|;|\))/i],
+                [c, [f, "Realme"], [d, v]],
+                [
+                  /\b(milestone|droid(?:[2-4x]| (?:bionic|x2|pro|razr))?:?( 4g)?)\b[\w ]+build\//i,
+                  /\bmot(?:orola)?[- ](\w*)/i,
+                  /((?:moto[\w\(\) ]+|xt\d{3,4}|nexus 6)(?= bui|\)))/i,
+                ],
+                [c, [f, M], [d, v]],
+                [/\b(mz60\d|xoom[2 ]{0,2}) build\//i],
+                [c, [f, M], [d, h]],
+                [
+                  /((?=lg)?[vl]k\-?\d{3}) bui| 3\.[-\w; ]{10}lg?-([06cv9]{3,4})/i,
+                ],
+                [c, [f, A], [d, h]],
+                [
+                  /(lm(?:-?f100[nv]?|-[\w\.]+)(?= bui|\))|nexus [45])/i,
+                  /\blg[-e;\/ ]+((?!browser|netcast|android tv)\w+)/i,
+                  /\blg-?([\d\w]+) bui/i,
+                ],
+                [c, [f, A], [d, v]],
+                [
+                  /(ideatab[-\w ]+)/i,
+                  /lenovo ?(s[56]000[-\w]+|tab(?:[\w ]+)|yt[-\d\w]{6}|tb[-\d\w]{6})/i,
+                ],
+                [c, [f, "Lenovo"], [d, h]],
+                [
+                  /(?:maemo|nokia).*(n900|lumia \d+)/i,
+                  /nokia[-_ ]?([-\w\.]*)/i,
+                ],
+                [
+                  [c, /_/g, " "],
+                  [f, "Nokia"],
+                  [d, v],
+                ],
+                [/(pixel c)\b/i],
+                [c, [f, L], [d, h]],
+                [/droid.+; (pixel[\daxl ]{0,6})(?: bui|\))/i],
+                [c, [f, L], [d, v]],
+                [
+                  /droid.+; (a?\d[0-2]{2}so|[c-g]\d{4}|so[-gl]\w+|xq-a\w[4-7][12])(?= bui|\).+chrome\/(?![1-6]{0,1}\d\.))/i,
+                ],
+                [c, [f, D], [d, v]],
+                [/sony tablet [ps]/i, /\b(?:sony)?sgp\w+(?: bui|\))/i],
+                [
+                  [c, "Xperia Tablet"],
+                  [f, D],
+                  [d, h],
+                ],
+                [
+                  / (kb2005|in20[12]5|be20[12][59])\b/i,
+                  /(?:one)?(?:plus)? (a\d0\d\d)(?: b|\))/i,
+                ],
+                [c, [f, "OnePlus"], [d, v]],
+                [
+                  /(alexa)webm/i,
+                  /(kf[a-z]{2}wi|aeo(?!bc)\w\w)( bui|\))/i,
+                  /(kf[a-z]+)( bui|\)).+silk\//i,
+                ],
+                [c, [f, S], [d, h]],
+                [/((?:sd|kf)[0349hijorstuw]+)( bui|\)).+silk\//i],
+                [
+                  [c, /(.+)/g, "Fire Phone $1"],
+                  [f, S],
+                  [d, v],
+                ],
+                [/(playbook);[-\w\),; ]+(rim)/i],
+                [c, f, [d, h]],
+                [/\b((?:bb[a-f]|st[hv])100-\d)/i, /\(bb10; (\w+)/i],
+                [c, [f, I], [d, v]],
+                [
+                  /(?:\b|asus_)(transfo[prime ]{4,10} \w+|eeepc|slider \w+|nexus 7|padfone|p00[cj])/i,
+                ],
+                [c, [f, E], [d, h]],
+                [/ (z[bes]6[027][012][km][ls]|zenfone \d\w?)\b/i],
+                [c, [f, E], [d, v]],
+                [/(nexus 9)/i],
+                [c, [f, "HTC"], [d, h]],
+                [
+                  /(htc)[-;_ ]{1,2}([\w ]+(?=\)| bui)|\w+)/i,
+                  /(zte)[- ]([\w ]+?)(?: bui|\/|\))/i,
+                  /(alcatel|geeksphone|nexian|panasonic(?!(?:;|\.))|sony(?!-bra))[-_ ]?([-\w]*)/i,
+                ],
+                [f, [c, /_/g, " "], [d, v]],
+                [
+                  /droid [\w\.]+; ((?:8[14]9[16]|9(?:0(?:48|60|8[01])|1(?:3[27]|66)|2(?:6[69]|9[56])|466))[gqswx])\w*(\)| bui)/i,
+                ],
+                [c, [f, "TCL"], [d, h]],
+                [/(itel) ((\w+))/i],
+                [
+                  [f, G],
+                  c,
+                  [d, K, { tablet: ["p10001l", "w7001"], "*": "mobile" }],
+                ],
+                [/droid.+; ([ab][1-7]-?[0178a]\d\d?)/i],
+                [c, [f, "Acer"], [d, h]],
+                [/droid.+; (m[1-5] note) bui/i, /\bmz-([-\w]{2,})/i],
+                [c, [f, "Meizu"], [d, v]],
+                [/; ((?:power )?armor(?:[\w ]{0,8}))(?: bui|\))/i],
+                [c, [f, "Ulefone"], [d, v]],
+                [
+                  /; (energy ?\w+)(?: bui|\))/i,
+                  /; energizer ([\w ]+)(?: bui|\))/i,
+                ],
+                [c, [f, "Energizer"], [d, v]],
+                [
+                  /; cat (b35);/i,
+                  /; (b15q?|s22 flip|s48c|s62 pro)(?: bui|\))/i,
+                ],
+                [c, [f, "Cat"], [d, v]],
+                [/((?:new )?andromax[\w- ]+)(?: bui|\))/i],
+                [c, [f, "Smartfren"], [d, v]],
+                [/droid.+; (a(?:015|06[35]|142p?))/i],
+                [c, [f, "Nothing"], [d, v]],
+                [
+                  /(blackberry|benq|palm(?=\-)|sonyericsson|acer|asus|dell|meizu|motorola|polytron|infinix|tecno|micromax|advan)[-_ ]?([-\w]*)/i,
+                  /; (imo) ((?!tab)[\w ]+?)(?: bui|\))/i,
+                  /(hp) ([\w ]+\w)/i,
+                  /(asus)-?(\w+)/i,
+                  /(microsoft); (lumia[\w ]+)/i,
+                  /(lenovo)[-_ ]?([-\w]+)/i,
+                  /(jolla)/i,
+                  /(oppo) ?([\w ]+) bui/i,
+                ],
+                [f, c, [d, v]],
+                [
+                  /(imo) (tab \w+)/i,
+                  /(kobo)\s(ereader|touch)/i,
+                  /(archos) (gamepad2?)/i,
+                  /(hp).+(touchpad(?!.+tablet)|tablet)/i,
+                  /(kindle)\/([\w\.]+)/i,
+                  /(nook)[\w ]+build\/(\w+)/i,
+                  /(dell) (strea[kpr\d ]*[\dko])/i,
+                  /(le[- ]+pan)[- ]+(\w{1,9}) bui/i,
+                  /(trinity)[- ]*(t\d{3}) bui/i,
+                  /(gigaset)[- ]+(q\w{1,9}) bui/i,
+                  /(vodafone) ([\w ]+)(?:\)| bui)/i,
+                ],
+                [f, c, [d, h]],
+                [/(surface duo)/i],
+                [c, [f, P], [d, h]],
+                [/droid [\d\.]+; (fp\du?)(?: b|\))/i],
+                [c, [f, "Fairphone"], [d, v]],
+                [/(u304aa)/i],
+                [c, [f, "AT&T"], [d, v]],
+                [/\bsie-(\w*)/i],
+                [c, [f, "Siemens"], [d, v]],
+                [/\b(rct\w+) b/i],
+                [c, [f, "RCA"], [d, h]],
+                [/\b(venue[\d ]{2,7}) b/i],
+                [c, [f, "Dell"], [d, h]],
+                [/\b(q(?:mv|ta)\w+) b/i],
+                [c, [f, "Verizon"], [d, h]],
+                [/\b(?:barnes[& ]+noble |bn[rt])([\w\+ ]*) b/i],
+                [c, [f, "Barnes & Noble"], [d, h]],
+                [/\b(tm\d{3}\w+) b/i],
+                [c, [f, "NuVision"], [d, h]],
+                [/\b(k88) b/i],
+                [c, [f, "ZTE"], [d, h]],
+                [/\b(nx\d{3}j) b/i],
+                [c, [f, "ZTE"], [d, v]],
+                [/\b(gen\d{3}) b.+49h/i],
+                [c, [f, "Swiss"], [d, v]],
+                [/\b(zur\d{3}) b/i],
+                [c, [f, "Swiss"], [d, h]],
+                [/\b((zeki)?tb.*\b) b/i],
+                [c, [f, "Zeki"], [d, h]],
+                [/\b([yr]\d{2}) b/i, /\b(dragon[- ]+touch |dt)(\w{5}) b/i],
+                [[f, "Dragon Touch"], c, [d, h]],
+                [/\b(ns-?\w{0,9}) b/i],
+                [c, [f, "Insignia"], [d, h]],
+                [/\b((nxa|next)-?\w{0,9}) b/i],
+                [c, [f, "NextBook"], [d, h]],
+                [/\b(xtreme\_)?(v(1[045]|2[015]|[3469]0|7[05])) b/i],
+                [[f, "Voice"], c, [d, v]],
+                [/\b(lvtel\-)?(v1[12]) b/i],
+                [[f, "LvTel"], c, [d, v]],
+                [/\b(ph-1) /i],
+                [c, [f, "Essential"], [d, v]],
+                [/\b(v(100md|700na|7011|917g).*\b) b/i],
+                [c, [f, "Envizen"], [d, h]],
+                [/\b(trio[-\w\. ]+) b/i],
+                [c, [f, "MachSpeed"], [d, h]],
+                [/\btu_(1491) b/i],
+                [c, [f, "Rotor"], [d, h]],
+                [/(shield[\w ]+) b/i],
+                [c, [f, "Nvidia"], [d, h]],
+                [/(sprint) (\w+)/i],
+                [f, c, [d, v]],
+                [/(kin\.[onetw]{3})/i],
+                [
+                  [c, /\./g, " "],
+                  [f, P],
+                  [d, v],
+                ],
+                [/droid.+; (cc6666?|et5[16]|mc[239][23]x?|vc8[03]x?)\)/i],
+                [c, [f, U], [d, h]],
+                [/droid.+; (ec30|ps20|tc[2-8]\d[kx])\)/i],
+                [c, [f, U], [d, v]],
+                [/smart-tv.+(samsung)/i],
+                [f, [d, b]],
+                [/hbbtv.+maple;(\d+)/i],
+                [
+                  [c, /^/, "SmartTV"],
+                  [f, N],
+                  [d, b],
+                ],
+                [/(nux; netcast.+smarttv|lg (netcast\.tv-201\d|android tv))/i],
+                [
+                  [f, A],
+                  [d, b],
+                ],
+                [/(apple) ?tv/i],
+                [f, [c, T + " TV"], [d, b]],
+                [/crkey/i],
+                [
+                  [c, O + "cast"],
+                  [f, L],
+                  [d, b],
+                ],
+                [/droid.+aft(\w+)( bui|\))/i],
+                [c, [f, S], [d, b]],
+                [/\(dtv[\);].+(aquos)/i, /(aquos-tv[\w ]+)\)/i],
+                [c, [f, _], [d, b]],
+                [/(bravia[\w ]+)( bui|\))/i],
+                [c, [f, D], [d, b]],
+                [/(mitv-\w{5}) bui/i],
+                [c, [f, R], [d, b]],
+                [/Hbbtv.*(technisat) (.*);/i],
+                [f, c, [d, b]],
+                [
+                  /\b(roku)[\dx]*[\)\/]((?:dvp-)?[\d\.]*)/i,
+                  /hbbtv\/\d+\.\d+\.\d+ +\([\w\+ ]*; *([\w\d][^;]*);([^;]*)/i,
+                ],
+                [
+                  [f, H],
+                  [c, H],
+                  [d, b],
+                ],
+                [/\b(android tv|smart[- ]?tv|opera tv|tv; rv:)\b/i],
+                [[d, b]],
+                [/(ouya)/i, /(nintendo) ([wids3utch]+)/i],
+                [f, c, [d, m]],
+                [/droid.+; (shield) bui/i],
+                [c, [f, "Nvidia"], [d, m]],
+                [/(playstation [345portablevi]+)/i],
+                [c, [f, D], [d, m]],
+                [/\b(xbox(?: one)?(?!; xbox))[\); ]/i],
+                [c, [f, P], [d, m]],
+                [/\b(sm-[lr]\d\d[05][fnuw]?s?)\b/i],
+                [c, [f, N], [d, w]],
+                [/((pebble))app/i],
+                [f, c, [d, w]],
+                [/(watch)(?: ?os[,\/]|\d,\d\/)[\d\.]+/i],
+                [c, [f, T], [d, w]],
+                [/droid.+; (glass) \d/i],
+                [c, [f, L], [d, w]],
+                [/droid.+; (wt63?0{2,3})\)/i],
+                [c, [f, U], [d, w]],
+                [/droid.+; (glass) \d/i],
+                [c, [f, L], [d, w]],
+                [/(pico) (4|neo3(?: link|pro)?)/i],
+                [f, c, [d, w]],
+                [/; (quest( \d| pro)?)/i],
+                [c, [f, B], [d, w]],
+                [/(tesla)(?: qtcarbrowser|\/[-\w\.]+)/i],
+                [f, [d, y]],
+                [/(aeobc)\b/i],
+                [c, [f, S], [d, y]],
+                [
+                  /droid .+?; ([^;]+?)(?: bui|; wv\)|\) applew).+? mobile safari/i,
+                ],
+                [c, [d, v]],
+                [/droid .+?; ([^;]+?)(?: bui|\) applew).+?(?! mobile) safari/i],
+                [c, [d, h]],
+                [/\b((tablet|tab)[;\/]|focus\/\d(?!.+mobile))/i],
+                [[d, h]],
+                [
+                  /(phone|mobile(?:[;\/]| [ \w\/\.]*safari)|pda(?=.+windows ce))/i,
+                ],
+                [[d, v]],
+                [/(android[-\w\. ]{0,9});.+buil/i],
+                [c, [f, "Generic"]],
+              ],
+              engine: [
+                [/windows.+ edge\/([\w\.]+)/i],
+                [p, [l, "EdgeHTML"]],
+                [/(arkweb)\/([\w\.]+)/i],
+                [l, p],
+                [/webkit\/537\.36.+chrome\/(?!27)([\w\.]+)/i],
+                [p, [l, "Blink"]],
+                [
+                  /(presto)\/([\w\.]+)/i,
+                  /(webkit|trident|netfront|netsurf|amaya|lynx|w3m|goanna|servo)\/([\w\.]+)/i,
+                  /ekioh(flow)\/([\w\.]+)/i,
+                  /(khtml|tasman|links)[\/ ]\(?([\w\.]+)/i,
+                  /(icab)[\/ ]([23]\.[\d\.]+)/i,
+                  /\b(libweb)/i,
+                ],
+                [l, p],
+                [/rv\:([\w\.]{1,9})\b.+(gecko)/i],
+                [p, l],
+              ],
+              os: [
+                [/microsoft (windows) (vista|xp)/i],
+                [l, p],
+                [/(windows (?:phone(?: os)?|mobile))[\/ ]?([\d\.\w ]*)/i],
+                [l, [p, K, X]],
+                [
+                  /windows nt 6\.2; (arm)/i,
+                  /windows[\/ ]?([ntce\d\. ]+\w)(?!.+xbox)/i,
+                  /(?:win(?=3|9|n)|win 9x )([nt\d\.]+)/i,
+                ],
+                [
+                  [p, K, X],
+                  [l, "Windows"],
+                ],
+                [
+                  /ip[honead]{2,4}\b(?:.*os ([\w]+) like mac|; opera)/i,
+                  /(?:ios;fbsv\/|iphone.+ios[\/ ])([\d\.]+)/i,
+                  /cfnetwork\/.+darwin/i,
+                ],
+                [
+                  [p, /_/g, "."],
+                  [l, "iOS"],
+                ],
+                [
+                  /(mac os x) ?([\w\. ]*)/i,
+                  /(macintosh|mac_powerpc\b)(?!.+haiku)/i,
+                ],
+                [
+                  [l, z],
+                  [p, /_/g, "."],
+                ],
+                [/droid ([\w\.]+)\b.+(android[- ]x86|harmonyos)/i],
+                [p, l],
+                [
+                  /(android|webos|qnx|bada|rim tablet os|maemo|meego|sailfish|openharmony)[-\/ ]?([\w\.]*)/i,
+                  /(blackberry)\w*\/([\w\.]*)/i,
+                  /(tizen|kaios)[\/ ]([\w\.]+)/i,
+                  /\((series40);/i,
+                ],
+                [l, p],
+                [/\(bb(10);/i],
+                [p, [l, I]],
+                [/(?:symbian ?os|symbos|s60(?=;)|series60)[-\/ ]?([\w\.]*)/i],
+                [p, [l, "Symbian"]],
+                [
+                  /mozilla\/[\d\.]+ \((?:mobile|tablet|tv|mobile; [\w ]+); rv:.+ gecko\/([\w\.]+)/i,
+                ],
+                [p, [l, x + " OS"]],
+                [/web0s;.+rt(tv)/i, /\b(?:hp)?wos(?:browser)?\/([\w\.]+)/i],
+                [p, [l, "webOS"]],
+                [/watch(?: ?os[,\/]|\d,\d\/)([\d\.]+)/i],
+                [p, [l, "watchOS"]],
+                [/crkey\/([\d\.]+)/i],
+                [p, [l, O + "cast"]],
+                [/(cros) [\w]+(?:\)| ([\w\.]+)\b)/i],
+                [[l, F], p],
+                [
+                  /panasonic;(viera)/i,
+                  /(netrange)mmh/i,
+                  /(nettv)\/(\d+\.[\w\.]+)/i,
+                  /(nintendo|playstation) ([wids345portablevuch]+)/i,
+                  /(xbox); +xbox ([^\);]+)/i,
+                  /\b(joli|palm)\b ?(?:os)?\/?([\w\.]*)/i,
+                  /(mint)[\/\(\) ]?(\w*)/i,
+                  /(mageia|vectorlinux)[; ]/i,
+                  /([kxln]?ubuntu|debian|suse|opensuse|gentoo|arch(?= linux)|slackware|fedora|mandriva|centos|pclinuxos|red ?hat|zenwalk|linpus|raspbian|plan 9|minix|risc os|contiki|deepin|manjaro|elementary os|sabayon|linspire)(?: gnu\/linux)?(?: enterprise)?(?:[- ]linux)?(?:-gnu)?[-\/ ]?(?!chrom|package)([-\w\.]*)/i,
+                  /(hurd|linux) ?([\w\.]*)/i,
+                  /(gnu) ?([\w\.]*)/i,
+                  /\b([-frentopcghs]{0,5}bsd|dragonfly)[\/ ]?(?!amd|[ix346]{1,2}86)([\w\.]*)/i,
+                  /(haiku) (\w+)/i,
+                ],
+                [l, p],
+                [/(sunos) ?([\w\.\d]*)/i],
+                [[l, "Solaris"], p],
+                [
+                  /((?:open)?solaris)[-\/ ]?([\w\.]*)/i,
+                  /(aix) ((\d)(?=\.|\)| )[\w\.])*/i,
+                  /\b(beos|os\/2|amigaos|morphos|openvms|fuchsia|hp-ux|serenityos)/i,
+                  /(unix) ?([\w\.]*)/i,
+                ],
+                [l, p],
+              ],
+            },
+            Z = function (e, t) {
+              if ((typeof e === s && ((t = e), (e = i)), !(this instanceof Z)))
+                return new Z(e, t).getResult();
+              var m = typeof n !== o && n.navigator ? n.navigator : i,
+                b = e || (m && m.userAgent ? m.userAgent : ""),
+                w = m && m.userAgentData ? m.userAgentData : i,
+                y = t
+                  ? (function (e, t) {
+                      var n = {};
+                      for (var i in e)
+                        t[i] && t[i].length % 2 == 0
+                          ? (n[i] = t[i].concat(e[i]))
+                          : (n[i] = e[i]);
+                      return n;
+                    })(J, t)
+                  : J,
+                S = m && m.userAgent == b;
+              return (
+                (this.getBrowser = function () {
+                  var e,
+                    t = {};
+                  return (
+                    (t[l] = i),
+                    (t[p] = i),
+                    W.call(t, b, y.browser),
+                    (t[u] =
+                      typeof (e = t[p]) === a
+                        ? e.replace(/[^\d\.]/g, "").split(".")[0]
+                        : i),
+                    S &&
+                      m &&
+                      m.brave &&
+                      typeof m.brave.isBrave == r &&
+                      (t[l] = "Brave"),
+                    t
+                  );
+                }),
+                (this.getCPU = function () {
+                  var e = {};
+                  return (e[g] = i), W.call(e, b, y.cpu), e;
+                }),
+                (this.getDevice = function () {
+                  var e = {};
+                  return (
+                    (e[f] = i),
+                    (e[c] = i),
+                    (e[d] = i),
+                    W.call(e, b, y.device),
+                    S && !e[d] && w && w.mobile && (e[d] = v),
+                    S &&
+                      "Macintosh" == e[c] &&
+                      m &&
+                      typeof m.standalone !== o &&
+                      m.maxTouchPoints &&
+                      m.maxTouchPoints > 2 &&
+                      ((e[c] = "iPad"), (e[d] = h)),
+                    e
+                  );
+                }),
+                (this.getEngine = function () {
+                  var e = {};
+                  return (e[l] = i), (e[p] = i), W.call(e, b, y.engine), e;
+                }),
+                (this.getOS = function () {
+                  var e = {};
+                  return (
+                    (e[l] = i),
+                    (e[p] = i),
+                    W.call(e, b, y.os),
+                    S &&
+                      !e[l] &&
+                      w &&
+                      w.platform &&
+                      "Unknown" != w.platform &&
+                      (e[l] = w.platform
+                        .replace(/chrome os/i, F)
+                        .replace(/macos/i, z)),
+                    e
+                  );
+                }),
+                (this.getResult = function () {
+                  return {
+                    ua: this.getUA(),
+                    browser: this.getBrowser(),
+                    engine: this.getEngine(),
+                    os: this.getOS(),
+                    device: this.getDevice(),
+                    cpu: this.getCPU(),
+                  };
+                }),
+                (this.getUA = function () {
+                  return b;
+                }),
+                (this.setUA = function (e) {
+                  return (
+                    (b = typeof e === a && e.length > 500 ? H(e, 500) : e), this
+                  );
+                }),
+                this.setUA(b),
+                this
+              );
+            };
+          (Z.VERSION = "1.0.40"),
+            (Z.BROWSER = V([l, p, u])),
+            (Z.CPU = V([g])),
+            (Z.DEVICE = V([c, f, d, m, v, b, h, w, y])),
+            (Z.ENGINE = Z.OS = V([l, p])),
+            e.exports && (t = e.exports = Z),
+            (t.UAParser = Z);
+          var Y = typeof n !== o && (n.jQuery || n.Zepto);
+          if (Y && !Y.ua) {
+            var Q = new Z();
+            (Y.ua = Q.getResult()),
+              (Y.ua.get = function () {
+                return Q.getUA();
+              }),
+              (Y.ua.set = function (e) {
+                Q.setUA(e);
+                var t = Q.getResult();
+                for (var n in t) Y.ua[n] = t[n];
+              });
+          }
+        })("object" == typeof window ? window : Pe);
+      })(Ae, Ae.exports)),
+    Ae.exports);
+  const je = () => {
+    const e = new Me.UAParser(),
+      { name: t, version: n } = e.getBrowser(),
+      { name: i, version: r } = e.getOS(),
+      o = e.getUA(),
+      s = navigator.language,
+      a = navigator.userAgent.includes("Mobi"),
+      u = (function () {
+        if (!t || !n) return;
+        if ("userAgentData" in navigator && navigator.userAgentData)
+          return navigator.userAgentData.brands;
+        return;
+      })();
+    return {
+      browser: {
+        name: null != t ? t : Le,
+        version: null != n ? n : Le,
+        os: `${null != i ? i : Le} ${null != r ? r : Le}`,
+        userAgent: null != o ? o : Le,
+        language: null != s ? s : Le,
+        mobile: a,
+        brands: null != u ? u : Le,
+        viewportWidth: `${window.innerWidth}`,
+        viewportHeight: `${window.innerHeight}`,
+      },
+    };
+  };
+  function Ne(t) {
+    var n, i, r, o;
+    return {
+      id:
+        null !==
+          (o =
+            null ===
+              (r =
+                null ===
+                  (i =
+                    null === (n = e.faro.config) || void 0 === n
+                      ? void 0
+                      : n.sessionTracking) || void 0 === i
+                  ? void 0
+                  : i.generateSessionId) || void 0 === r
+              ? void 0
+              : r.call(i)) && void 0 !== o
+          ? o
+          : M(),
+      attributes: t,
+    };
+  }
+  const _e = { session: "sessionStorage", local: "localStorage" };
+  function De(t) {
+    var n;
+    try {
+      let e;
+      e = window[t];
+      const n = "__faro_storage_test__";
+      return e.setItem(n, n), e.removeItem(n), !0;
+    } catch (i) {
+      return (
+        null === (n = e.faro.internalLogger) ||
+          void 0 === n ||
+          n.info(`Web storage of type ${t} is not available. Reason: ${i}`),
+        !1
+      );
+    }
+  }
+  function Re(e, t) {
+    return qe(t) ? window[t].getItem(e) : null;
+  }
+  function Ue(e, t, n) {
+    if (qe(n))
+      try {
+        window[n].setItem(e, t);
+      } catch (e) {}
+  }
+  function Be(e, t) {
+    qe(t) && window[t].removeItem(e);
+  }
+  const Fe = De(_e.local),
+    ze = De(_e.session);
+  function qe(e) {
+    return e === _e.local ? Fe : e === _e.session && ze;
+  }
+  function Ve(e, t) {
+    let n,
+      i = !1;
+    const r = () => {
+      null != n ? (e(...n), (n = null), setTimeout(r, t)) : (i = !1);
+    };
+    return (...o) => {
+      i ? (n = o) : (e(...o), (i = !0), setTimeout(r, t));
+    };
+  }
+  function $e() {
+    return e.faro.transports.transports.flatMap((e) => e.getIgnoreUrls());
+  }
+  function Ge(e = "") {
+    return $e().some((t) => e && null != e.match(t));
+  }
+  function He(e) {
+    return o(e)
+      ? e
+      : e instanceof URL
+      ? e.href
+      : !S(e) && c(null == e ? void 0 : e.toString)
+      ? e.toString()
+      : void 0;
+  }
+  const We = "com.grafana.faro.session",
+    Ke = 144e5,
+    Xe = 9e5,
+    Je = Xe,
+    Ze = { enabled: !0, persistent: !1, maxSessionPersistenceTime: Je };
+  function Ye() {
+    var t, n, i;
+    const r = e.faro.config.sessionTracking;
+    let o =
+      null !==
+        (i =
+          null !==
+            (n =
+              null === (t = null == r ? void 0 : r.sampler) || void 0 === t
+                ? void 0
+                : t.call(r, { metas: e.faro.metas.value })) && void 0 !== n
+            ? n
+            : null == r
+            ? void 0
+            : r.samplingRate) && void 0 !== i
+        ? i
+        : 1;
+    if ("number" != typeof o) {
+      o = 0;
+    }
+    return Math.random() < o;
+  }
+  function Qe({
+    sessionId: t,
+    started: n,
+    lastActivity: i,
+    isSampled: r = !0,
+  } = {}) {
+    var o, s;
+    const a = E(),
+      u =
+        null ===
+          (s =
+            null === (o = e.faro.config) || void 0 === o
+              ? void 0
+              : o.sessionTracking) || void 0 === s
+          ? void 0
+          : s.generateSessionId;
+    return (
+      null == t && (t = "function" == typeof u ? u() : M()),
+      {
+        sessionId: t,
+        lastActivity: null != i ? i : a,
+        started: null != n ? n : a,
+        isSampled: r,
+      }
+    );
+  }
+  function et(e) {
+    if (null == e) return !1;
+    const t = E();
+    if (!(t - e.started < Ke)) return !1;
+    return t - e.lastActivity < Xe;
+  }
+  function tt({ fetchUserSession: t, storeUserSession: n }) {
+    return function ({ forceSessionExtend: i } = { forceSessionExtend: !1 }) {
+      var r, o, s;
+      if (!t || !n) return;
+      const a = e.faro.config.sessionTracking,
+        u = null == a ? void 0 : a.persistent;
+      if ((u && !Fe) || (!u && !ze)) return;
+      const c = t();
+      if (!1 === i && et(c))
+        n(Object.assign(Object.assign({}, c), { lastActivity: E() }));
+      else {
+        let t = nt(Qe({ isSampled: Ye() }), c);
+        n(t),
+          null === (r = e.faro.api) ||
+            void 0 === r ||
+            r.setSession(t.sessionMeta),
+          null === (o = null == a ? void 0 : a.onSessionChange) ||
+            void 0 === o ||
+            o.call(
+              a,
+              null !== (s = null == c ? void 0 : c.sessionMeta) && void 0 !== s
+                ? s
+                : null,
+              t.sessionMeta
+            );
+      }
+    };
+  }
+  function nt(t, n) {
+    var i, r, o, s, a, u, c;
+    const l = Object.assign(Object.assign({}, t), {
+        sessionMeta: {
+          id: t.sessionId,
+          attributes: Object.assign(
+            Object.assign(
+              Object.assign(
+                {},
+                null ===
+                  (r =
+                    null === (i = e.faro.config.sessionTracking) || void 0 === i
+                      ? void 0
+                      : i.session) || void 0 === r
+                  ? void 0
+                  : r.attributes
+              ),
+              null !==
+                (s =
+                  null === (o = e.faro.metas.value.session) || void 0 === o
+                    ? void 0
+                    : o.attributes) && void 0 !== s
+                ? s
+                : {}
+            ),
+            { isSampled: t.isSampled.toString() }
+          ),
+        },
+      }),
+      d =
+        null !==
+          (u =
+            null === (a = e.faro.metas.value.session) || void 0 === a
+              ? void 0
+              : a.overrides) && void 0 !== u
+          ? u
+          : null === (c = null == n ? void 0 : n.sessionMeta) || void 0 === c
+          ? void 0
+          : c.overrides;
+    S(d) || (l.sessionMeta.overrides = d);
+    const f = null == n ? void 0 : n.sessionId;
+    return null != f && (l.sessionMeta.attributes.previousSession = f), l;
+  }
+  function it({ fetchUserSession: t, storeUserSession: n }) {
+    return function (i) {
+      const r = i.session,
+        o = t();
+      let s = null == r ? void 0 : r.id;
+      const a = null == r ? void 0 : r.attributes,
+        u = null == r ? void 0 : r.overrides,
+        c = null == o ? void 0 : o.sessionMeta,
+        l = null == c ? void 0 : c.overrides,
+        d = !!u && !T(u, l),
+        f = !!a && !T(a, null == c ? void 0 : c.attributes);
+      if ((!!r && s !== (null == o ? void 0 : o.sessionId)) || f || d) {
+        const t = nt(Qe({ sessionId: s, isSampled: Ye() }), o);
+        n(t),
+          (function (t, n = {}, i = {}) {
+            var r, o, s;
+            if (!t) return;
+            const a = n.serviceName,
+              u =
+                null !==
+                  (s =
+                    null !== (r = i.serviceName) && void 0 !== r
+                      ? r
+                      : null === (o = e.faro.metas.value.app) || void 0 === o
+                      ? void 0
+                      : o.name) && void 0 !== s
+                  ? s
+                  : "";
+            a &&
+              a !== u &&
+              e.faro.api.pushEvent(xe, {
+                serviceName: a,
+                previousServiceName: u,
+              });
+          })(d, u, l),
+          e.faro.api.setSession(t.sessionMeta);
+      }
+    };
+  }
+  class rt {
+    constructor() {
+      (this.updateSession = Ve(() => this.updateUserSession(), 1e3)),
+        (this.updateUserSession = tt({
+          fetchUserSession: rt.fetchUserSession,
+          storeUserSession: rt.storeUserSession,
+        })),
+        this.init();
+    }
+    static removeUserSession() {
+      Be(We, rt.storageTypeLocal);
+    }
+    static storeUserSession(e) {
+      Ue(We, N(e), rt.storageTypeLocal);
+    }
+    static fetchUserSession() {
+      const e = Re(We, rt.storageTypeLocal);
+      return e ? JSON.parse(e) : null;
+    }
+    init() {
+      document.addEventListener("visibilitychange", () => {
+        "visible" === document.visibilityState && this.updateSession();
+      }),
+        e.faro.metas.addListener(
+          it({
+            fetchUserSession: rt.fetchUserSession,
+            storeUserSession: rt.storeUserSession,
+          })
+        );
+    }
+  }
+  rt.storageTypeLocal = _e.local;
+  class ot {
+    constructor() {
+      (this.updateSession = Ve(() => this.updateUserSession(), 1e3)),
+        (this.updateUserSession = tt({
+          fetchUserSession: ot.fetchUserSession,
+          storeUserSession: ot.storeUserSession,
+        })),
+        this.init();
+    }
+    static removeUserSession() {
+      Be(We, ot.storageTypeSession);
+    }
+    static storeUserSession(e) {
+      Ue(We, N(e), ot.storageTypeSession);
+    }
+    static fetchUserSession() {
+      const e = Re(We, ot.storageTypeSession);
+      return e ? JSON.parse(e) : null;
+    }
+    init() {
+      document.addEventListener("visibilitychange", () => {
+        "visible" === document.visibilityState && this.updateSession();
+      }),
+        e.faro.metas.addListener(
+          it({
+            fetchUserSession: ot.fetchUserSession,
+            storeUserSession: ot.storeUserSession,
+          })
+        );
+    }
+  }
+  function st(e) {
+    return (null == e ? void 0 : e.persistent) ? rt : ot;
+  }
+  ot.storageTypeSession = _e.session;
+  class at extends ge {
+    constructor() {
+      super(...arguments),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-session"),
+        (this.version = me);
+    }
+    sendSessionStartEvent(e) {
+      var t, n;
+      const i = e.session;
+      if (
+        i &&
+        i.id !==
+          (null === (t = this.notifiedSession) || void 0 === t ? void 0 : t.id)
+      ) {
+        if (
+          this.notifiedSession &&
+          this.notifiedSession.id ===
+            (null === (n = i.attributes) || void 0 === n
+              ? void 0
+              : n.previousSession)
+        )
+          return (
+            this.api.pushEvent(Oe, {}, void 0, { skipDedupe: !0 }),
+            void (this.notifiedSession = i)
+          );
+        (this.notifiedSession = i),
+          this.api.pushEvent(Ie, {}, void 0, { skipDedupe: !0 });
+      }
+    }
+    createInitialSession(e, t) {
+      var n, i, r, o, s, a;
+      let u,
+        c,
+        l = e.fetchUserSession();
+      if (t.persistent && t.maxSessionPersistenceTime && l) {
+        const e = E();
+        l.lastActivity < e - t.maxSessionPersistenceTime &&
+          (rt.removeUserSession(), (l = null));
+      }
+      if (et(l)) {
+        const e = null == l ? void 0 : l.sessionId;
+        c = Qe({
+          sessionId: e,
+          isSampled: l.isSampled || !1,
+          started: null == l ? void 0 : l.started,
+        });
+        const r = null == l ? void 0 : l.sessionMeta,
+          o = Object.assign(
+            Object.assign(
+              {},
+              null === (n = t.session) || void 0 === n ? void 0 : n.overrides
+            ),
+            null == r ? void 0 : r.overrides
+          );
+        (c.sessionMeta = Object.assign(Object.assign({}, t.session), {
+          id: e,
+          attributes: Object.assign(
+            Object.assign(
+              Object.assign(
+                {},
+                null === (i = t.session) || void 0 === i ? void 0 : i.attributes
+              ),
+              null == r ? void 0 : r.attributes
+            ),
+            { isSampled: c.isSampled.toString() }
+          ),
+          overrides: o,
+        })),
+          (u = ke);
+      } else {
+        const e =
+          null !==
+            (o = null === (r = t.session) || void 0 === r ? void 0 : r.id) &&
+          void 0 !== o
+            ? o
+            : Ne().id;
+        c = Qe({ sessionId: e, isSampled: Ye() });
+        const n =
+          null === (s = t.session) || void 0 === s ? void 0 : s.overrides;
+        (c.sessionMeta = Object.assign(
+          {
+            id: e,
+            attributes: Object.assign(
+              { isSampled: c.isSampled.toString() },
+              null === (a = t.session) || void 0 === a ? void 0 : a.attributes
+            ),
+          },
+          n ? { overrides: n } : {}
+        )),
+          (u = Ie);
+      }
+      return { initialSession: c, lifecycleType: u };
+    }
+    registerBeforeSendHook(e) {
+      var t;
+      const { updateSession: n } = new e();
+      null === (t = this.transports) ||
+        void 0 === t ||
+        t.addBeforeSendHooks((e) => {
+          var t, i, r;
+          n();
+          const o =
+            null === (t = e.meta.session) || void 0 === t
+              ? void 0
+              : t.attributes;
+          if (o && "true" === (null == o ? void 0 : o.isSampled)) {
+            let t = JSON.parse(JSON.stringify(e));
+            const n =
+              null === (i = t.meta.session) || void 0 === i
+                ? void 0
+                : i.attributes;
+            return (
+              null == n || delete n.isSampled,
+              0 === Object.keys(null != n ? n : {}).length &&
+                (null === (r = t.meta.session) ||
+                  void 0 === r ||
+                  delete r.attributes),
+              t
+            );
+          }
+          return null;
+        });
+    }
+    initialize() {
+      this.logDebug("init session instrumentation");
+      const e = this.config.sessionTracking;
+      if (null == e ? void 0 : e.enabled) {
+        const t = st(e);
+        this.registerBeforeSendHook(t);
+        const { initialSession: n, lifecycleType: i } =
+          this.createInitialSession(t, e);
+        t.storeUserSession(n);
+        const r = n.sessionMeta;
+        (this.notifiedSession = r),
+          this.api.setSession(r),
+          i === Ie && this.api.pushEvent(Ie, {}, void 0, { skipDedupe: !0 }),
+          i === ke && this.api.pushEvent(ke, {}, void 0, { skipDedupe: !0 });
+      }
+      this.metas.addListener(this.sendSessionStartEvent.bind(this));
+    }
+  }
+  const ut = "DOMError",
+    ct = "DOMException",
+    lt = "Non-Error exception captured with keys:",
+    dt = "?",
+    ft =
+      /^(?:[Uu]ncaught (?:exception: )?)?(?:((?:Eval|Internal|Range|Reference|Syntax|Type|URI|)Error): )?(.*)$/i;
+  const pt = "\n",
+    gt = "eval",
+    mt = "?",
+    vt = "@",
+    ht =
+      /^\s*at (?:(.*\).*?|.*?) ?\((?:address at )?)?((?:file|https?|blob|chrome-extension|address|native|eval|webpack|<anonymous>|[-a-z]+:|.*bundle|\/)?.*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i,
+    bt = /\((\S*)(?::(\d+))(?::(\d+))\)/,
+    wt = "eval",
+    yt = "address at ",
+    St = yt.length,
+    Tt =
+      /^\s*(.*?)(?:\((.*?)\))?(?:^|@)?((?:file|https?|blob|chrome|webpack|resource|moz-extension|safari-extension|safari-web-extension|capacitor)?:\/.*?|\[native code]|[^@]*(?:bundle|\d+\.js)|\/[\w\-. /=]+)(?::(\d+))?(?::(\d+))?\s*$/i,
+    Et = /(\S+) line (\d+)(?: > eval line \d+)* > eval/i,
+    It = " > eval",
+    kt = "safari-extension",
+    Ot = "safari-web-extension",
+    xt = /Minified React error #\d+;/i;
+  function Lt(e, t, n, i) {
+    const r = { filename: e || document.location.href, function: t || mt };
+    return void 0 !== n && (r.lineno = n), void 0 !== i && (r.colno = i), r;
+  }
+  function Ct(e, t) {
+    const n = null == e ? void 0 : e.includes(kt),
+      i = !n && (null == e ? void 0 : e.includes(Ot));
+    return n || i
+      ? [
+          (null == e ? void 0 : e.includes(vt)) ? e.split(vt)[0] : e,
+          n ? `${kt}:${t}` : `${Ot}:${t}`,
+        ]
+      : [e, t];
+  }
+  function At(e) {
+    let t = [];
+    e.stacktrace
+      ? (t = e.stacktrace.split(pt).filter((e, t) => t % 2 == 0))
+      : e.stack && (t = e.stack.split(pt));
+    const n = t.reduce((t, n, i) => {
+      let r, o, a, u, c;
+      if ((r = ht.exec(n))) {
+        if (
+          ((o = r[1]),
+          (a = r[2]),
+          (u = r[3]),
+          (c = r[4]),
+          null == a ? void 0 : a.startsWith(wt))
+        ) {
+          const e = bt.exec(a);
+          e && ((a = e[1]), (u = e[2]), (c = e[3]));
+        }
+        (a = (null == a ? void 0 : a.startsWith(yt)) ? a.substring(St) : a),
+          ([o, a] = Ct(o, a));
+      } else if ((r = Tt.exec(n))) {
+        if (
+          ((o = r[1]), (a = r[3]), (u = r[4]), (c = r[5]), a && a.includes(It))
+        ) {
+          const e = Et.exec(a);
+          e && ((o = o || gt), (a = e[1]), (u = e[2]));
+        } else
+          0 === i &&
+            !c &&
+            s(e.columnNumber) &&
+            (c = String(e.columnNumber + 1));
+        [o, a] = Ct(o, a);
+      }
+      return (
+        (a || o) &&
+          t.push(Lt(a, o, u ? Number(u) : void 0, c ? Number(c) : void 0)),
+        t
+      );
+    }, []);
+    return xt.test(e.message) ? n.slice(1) : n;
+  }
+  function Pt(e) {
+    return { frames: At(e) };
+  }
+  function Mt(e) {
+    let t,
+      n,
+      i,
+      r,
+      o = [];
+    if (v(e) && e.error)
+      (t = e.error.message), (n = e.error.name), (o = At(e.error));
+    else if ((i = h(e)) || b(e)) {
+      const { name: r, message: o } = e;
+      (n = null != r ? r : i ? ut : ct), (t = o ? `${n}: ${o}` : n);
+    } else
+      m(e)
+        ? ((t = e.message), (o = At(e)))
+        : (u(e) || (r = p(e))) &&
+          ((n = r ? e.constructor.name : void 0),
+          (t = `${lt} ${Object.keys(e)}`));
+    return [t, n, o];
+  }
+  function jt(e) {
+    const [t, n, i, r, s] = e;
+    let a,
+      u,
+      c = [];
+    const l = o(t),
+      d = Lt(n, dt, i, r);
+    return (
+      s || !l
+        ? (([a, u, c] = Mt(null != s ? s : t)), 0 === c.length && (c = [d]))
+        : l &&
+          (([a, u] = (function (e) {
+            var t, n;
+            const i = e.match(ft),
+              r =
+                null !== (t = null == i ? void 0 : i[1]) && void 0 !== t
+                  ? t
+                  : oe;
+            return [
+              null !== (n = null == i ? void 0 : i[2]) && void 0 !== n ? n : e,
+              r,
+            ];
+          })(t)),
+          (c = [d])),
+      { value: a, type: u, stackFrames: c }
+    );
+  }
+  function Nt(e, t) {
+    return m(e[0]) ? jt(e) : { value: t(e) };
+  }
+  class _t extends ge {
+    constructor(e = {}) {
+      super(),
+        (this.options = e),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-console"),
+        (this.version = me),
+        (this.errorSerializer = ce);
+    }
+    initialize() {
+      var t, n, i, r;
+      this.options = Object.assign(
+        Object.assign({}, this.options),
+        this.config.consoleInstrumentation
+      );
+      const o =
+        (null === (t = this.options) || void 0 === t
+          ? void 0
+          : t.serializeErrors) ||
+        !!(null === (n = this.options) || void 0 === n
+          ? void 0
+          : n.errorSerializer);
+      (this.errorSerializer = o
+        ? null !==
+            (r =
+              null === (i = this.options) || void 0 === i
+                ? void 0
+                : i.errorSerializer) && void 0 !== r
+          ? r
+          : se
+        : ce),
+        L.filter((e) => {
+          var t, n;
+          return !(
+            null !==
+              (n =
+                null === (t = this.options) || void 0 === t
+                  ? void 0
+                  : t.disabledLevels) && void 0 !== n
+              ? n
+              : _t.defaultDisabledLevels
+          ).includes(e);
+        }).forEach((t) => {
+          console[t] = (...n) => {
+            var i, r;
+            try {
+              if (
+                t !== e.LogLevel.ERROR ||
+                (null === (i = this.options) || void 0 === i
+                  ? void 0
+                  : i.consoleErrorAsLog)
+              )
+                if (
+                  t === e.LogLevel.ERROR &&
+                  (null === (r = this.options) || void 0 === r
+                    ? void 0
+                    : r.consoleErrorAsLog)
+                ) {
+                  const {
+                    value: e,
+                    type: i,
+                    stackFrames: r,
+                  } = Nt(n, this.errorSerializer);
+                  this.api.pushLog(e ? [_t.consoleErrorPrefix + e] : n, {
+                    level: t,
+                    context: {
+                      value: null != e ? e : "",
+                      type: null != i ? i : "",
+                      stackFrames: (null == r ? void 0 : r.length) ? se(r) : "",
+                    },
+                  });
+                } else this.api.pushLog(n, { level: t });
+              else {
+                const {
+                  value: e,
+                  type: t,
+                  stackFrames: i,
+                } = Nt(n, this.errorSerializer);
+                if (e && !t && !i)
+                  return void this.api.pushError(
+                    new Error(_t.consoleErrorPrefix + e)
+                  );
+                this.api.pushError(new Error(_t.consoleErrorPrefix + e), {
+                  type: t,
+                  stackFrames: i,
+                });
+              }
+            } catch (e) {
+              this.logError(e);
+            } finally {
+              this.unpatchedConsole[t](...n);
+            }
+          };
+        });
+    }
+  }
+  (_t.defaultDisabledLevels = [
+    e.LogLevel.DEBUG,
+    e.LogLevel.TRACE,
+    e.LogLevel.LOG,
+  ]),
+    (_t.consoleErrorPrefix = "console.error: ");
+  class Dt extends ge {
+    constructor() {
+      super(...arguments),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-errors"),
+        (this.version = me);
+    }
+    initialize() {
+      var e;
+      this.logDebug("Initializing"),
+        (function (e) {
+          const t = window.onerror;
+          window.onerror = (...n) => {
+            try {
+              const { value: t, type: i, stackFrames: r } = jt(n),
+                o = n[4];
+              if (t) {
+                const n = { type: i, stackFrames: r };
+                null != o && (n.originalError = o),
+                  e.pushError(new Error(t), n);
+              }
+            } finally {
+              null == t || t.apply(window, n);
+            }
+          };
+        })(this.api),
+        (e = this.api),
+        window.addEventListener("unhandledrejection", (t) => {
+          var n, i;
+          let r,
+            o,
+            s = t;
+          s.reason
+            ? (s = t.reason)
+            : (null === (n = t.detail) || void 0 === n ? void 0 : n.reason) &&
+              (s = null === (i = t.detail) || void 0 === i ? void 0 : i.reason);
+          let a = [];
+          d(s)
+            ? ((r = `Non-Error promise rejection captured with value: ${String(
+                s
+              )}`),
+              (o = "UnhandledRejection"))
+            : ([r, o, a] = Mt(s)),
+            r && e.pushError(new Error(r), { type: o, stackFrames: a });
+        });
+    }
+  }
+  class Rt extends ge {
+    constructor() {
+      super(...arguments),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-view"),
+        (this.version = me);
+    }
+    sendViewChangedEvent(e) {
+      var t, n, i, r;
+      const o = e.view;
+      o &&
+        o.name !==
+          (null === (t = this.notifiedView) || void 0 === t
+            ? void 0
+            : t.name) &&
+        (this.api.pushEvent(
+          Ee,
+          {
+            fromView:
+              null !==
+                (i =
+                  null === (n = this.notifiedView) || void 0 === n
+                    ? void 0
+                    : n.name) && void 0 !== i
+                ? i
+                : Le,
+            toView: null !== (r = o.name) && void 0 !== r ? r : Le,
+          },
+          void 0,
+          { skipDedupe: !0 }
+        ),
+        (this.notifiedView = o));
+    }
+    initialize() {
+      this.metas.addListener(this.sendViewChangedEvent.bind(this));
+    }
+  }
+  var Ut,
+    Bt,
+    Ft,
+    zt,
+    qt,
+    Vt = -1,
+    $t = function (e) {
+      addEventListener(
+        "pageshow",
+        function (t) {
+          t.persisted && ((Vt = t.timeStamp), e(t));
+        },
+        !0
+      );
+    },
+    Gt = function () {
+      var e =
+        self.performance &&
+        performance.getEntriesByType &&
+        performance.getEntriesByType("navigation")[0];
+      if (e && e.responseStart > 0 && e.responseStart < performance.now())
+        return e;
+    },
+    Ht = function () {
+      var e = Gt();
+      return (e && e.activationStart) || 0;
+    },
+    Wt = function (e, t) {
+      var n = Gt(),
+        i = "navigate";
+      return (
+        Vt >= 0
+          ? (i = "back-forward-cache")
+          : n &&
+            (document.prerendering || Ht() > 0
+              ? (i = "prerender")
+              : document.wasDiscarded
+              ? (i = "restore")
+              : n.type && (i = n.type.replace(/_/g, "-"))),
+        {
+          name: e,
+          value: void 0 === t ? -1 : t,
+          rating: "good",
+          delta: 0,
+          entries: [],
+          id: "v4-"
+            .concat(Date.now(), "-")
+            .concat(Math.floor(8999999999999 * Math.random()) + 1e12),
+          navigationType: i,
+        }
+      );
+    },
+    Kt = function (e, t, n) {
+      try {
+        if (PerformanceObserver.supportedEntryTypes.includes(e)) {
+          var i = new PerformanceObserver(function (e) {
+            Promise.resolve().then(function () {
+              t(e.getEntries());
+            });
+          });
+          return (
+            i.observe(Object.assign({ type: e, buffered: !0 }, n || {})), i
+          );
+        }
+      } catch (e) {}
+    },
+    Xt = function (e, t, n, i) {
+      var r, o;
+      return function (s) {
+        t.value >= 0 &&
+          (s || i) &&
+          ((o = t.value - (r || 0)) || void 0 === r) &&
+          ((r = t.value),
+          (t.delta = o),
+          (t.rating = (function (e, t) {
+            return e > t[1] ? "poor" : e > t[0] ? "needs-improvement" : "good";
+          })(t.value, n)),
+          e(t));
+      };
+    },
+    Jt = function (e) {
+      requestAnimationFrame(function () {
+        return requestAnimationFrame(function () {
+          return e();
+        });
+      });
+    },
+    Zt = function (e) {
+      document.addEventListener("visibilitychange", function () {
+        "hidden" === document.visibilityState && e();
+      });
+    },
+    Yt = function (e) {
+      var t = !1;
+      return function () {
+        t || (e(), (t = !0));
+      };
+    },
+    Qt = -1,
+    en = function () {
+      return "hidden" !== document.visibilityState || document.prerendering
+        ? 1 / 0
+        : 0;
+    },
+    tn = function (e) {
+      "hidden" === document.visibilityState &&
+        Qt > -1 &&
+        ((Qt = "visibilitychange" === e.type ? e.timeStamp : 0), rn());
+    },
+    nn = function () {
+      addEventListener("visibilitychange", tn, !0),
+        addEventListener("prerenderingchange", tn, !0);
+    },
+    rn = function () {
+      removeEventListener("visibilitychange", tn, !0),
+        removeEventListener("prerenderingchange", tn, !0);
+    },
+    on = function () {
+      return (
+        Qt < 0 &&
+          ((Qt = en()),
+          nn(),
+          $t(function () {
+            setTimeout(function () {
+              (Qt = en()), nn();
+            }, 0);
+          })),
+        {
+          get firstHiddenTime() {
+            return Qt;
+          },
+        }
+      );
+    },
+    sn = function (e) {
+      document.prerendering
+        ? addEventListener(
+            "prerenderingchange",
+            function () {
+              return e();
+            },
+            !0
+          )
+        : e();
+    },
+    an = [1800, 3e3],
+    un = function (e, t) {
+      (t = t || {}),
+        sn(function () {
+          var n,
+            i = on(),
+            r = Wt("FCP"),
+            o = Kt("paint", function (e) {
+              e.forEach(function (e) {
+                "first-contentful-paint" === e.name &&
+                  (o.disconnect(),
+                  e.startTime < i.firstHiddenTime &&
+                    ((r.value = Math.max(e.startTime - Ht(), 0)),
+                    r.entries.push(e),
+                    n(!0)));
+              });
+            });
+          o &&
+            ((n = Xt(e, r, an, t.reportAllChanges)),
+            $t(function (i) {
+              (r = Wt("FCP")),
+                (n = Xt(e, r, an, t.reportAllChanges)),
+                Jt(function () {
+                  (r.value = performance.now() - i.timeStamp), n(!0);
+                });
+            }));
+        });
+    },
+    cn = [0.1, 0.25],
+    ln = 0,
+    dn = 1 / 0,
+    fn = 0,
+    pn = function (e) {
+      e.forEach(function (e) {
+        e.interactionId &&
+          ((dn = Math.min(dn, e.interactionId)),
+          (fn = Math.max(fn, e.interactionId)),
+          (ln = fn ? (fn - dn) / 7 + 1 : 0));
+      });
+    },
+    gn = function () {
+      return Ut ? ln : performance.interactionCount || 0;
+    },
+    mn = [],
+    vn = new Map(),
+    hn = 0,
+    bn = [],
+    wn = function (e) {
+      if (
+        (bn.forEach(function (t) {
+          return t(e);
+        }),
+        e.interactionId || "first-input" === e.entryType)
+      ) {
+        var t = mn[mn.length - 1],
+          n = vn.get(e.interactionId);
+        if (n || mn.length < 10 || e.duration > t.latency) {
+          if (n)
+            e.duration > n.latency
+              ? ((n.entries = [e]), (n.latency = e.duration))
+              : e.duration === n.latency &&
+                e.startTime === n.entries[0].startTime &&
+                n.entries.push(e);
+          else {
+            var i = { id: e.interactionId, latency: e.duration, entries: [e] };
+            vn.set(i.id, i), mn.push(i);
+          }
+          mn.sort(function (e, t) {
+            return t.latency - e.latency;
+          }),
+            mn.length > 10 &&
+              mn.splice(10).forEach(function (e) {
+                return vn.delete(e.id);
+              });
+        }
+      }
+    },
+    yn = function (e) {
+      var t = self.requestIdleCallback || self.setTimeout,
+        n = -1;
+      return (
+        (e = Yt(e)),
+        "hidden" === document.visibilityState ? e() : ((n = t(e)), Zt(e)),
+        n
+      );
+    },
+    Sn = [200, 500],
+    Tn = [2500, 4e3],
+    En = {},
+    In = [800, 1800],
+    kn = function e(t) {
+      document.prerendering
+        ? sn(function () {
+            return e(t);
+          })
+        : "complete" !== document.readyState
+        ? addEventListener(
+            "load",
+            function () {
+              return e(t);
+            },
+            !0
+          )
+        : setTimeout(t, 0);
+    },
+    On = { passive: !0, capture: !0 },
+    xn = new Date(),
+    Ln = function (e, t) {
+      Bt ||
+        ((Bt = t), (Ft = e), (zt = new Date()), Pn(removeEventListener), Cn());
+    },
+    Cn = function () {
+      if (Ft >= 0 && Ft < zt - xn) {
+        var e = {
+          entryType: "first-input",
+          name: Bt.type,
+          target: Bt.target,
+          cancelable: Bt.cancelable,
+          startTime: Bt.timeStamp,
+          processingStart: Bt.timeStamp + Ft,
+        };
+        qt.forEach(function (t) {
+          t(e);
+        }),
+          (qt = []);
+      }
+    },
+    An = function (e) {
+      if (e.cancelable) {
+        var t =
+          (e.timeStamp > 1e12 ? new Date() : performance.now()) - e.timeStamp;
+        "pointerdown" == e.type
+          ? (function (e, t) {
+              var n = function () {
+                  Ln(e, t), r();
+                },
+                i = function () {
+                  r();
+                },
+                r = function () {
+                  removeEventListener("pointerup", n, On),
+                    removeEventListener("pointercancel", i, On);
+                };
+              addEventListener("pointerup", n, On),
+                addEventListener("pointercancel", i, On);
+            })(t, e)
+          : Ln(t, e);
+      }
+    },
+    Pn = function (e) {
+      ["mousedown", "keydown", "touchstart", "pointerdown"].forEach(function (
+        t
+      ) {
+        return e(t, An, On);
+      });
+    },
+    Mn = [100, 300];
+  class jn {
+    constructor(e, t) {
+      (this.pushMeasurement = e), (this.webVitalConfig = t);
+    }
+    initialize() {
+      Object.entries(jn.mapping).forEach(([e, t]) => {
+        var n;
+        t(
+          (t) => {
+            this.pushMeasurement({
+              type: "web-vitals",
+              values: { [e]: t.value },
+            });
+          },
+          {
+            reportAllChanges:
+              null === (n = this.webVitalConfig) || void 0 === n
+                ? void 0
+                : n.reportAllChanges,
+          }
+        );
+      });
+    }
+  }
+  jn.mapping = {
+    cls: function (e, t) {
+      (t = t || {}),
+        un(
+          Yt(function () {
+            var n,
+              i = Wt("CLS", 0),
+              r = 0,
+              o = [],
+              s = function (e) {
+                e.forEach(function (e) {
+                  if (!e.hadRecentInput) {
+                    var t = o[0],
+                      n = o[o.length - 1];
+                    r &&
+                    e.startTime - n.startTime < 1e3 &&
+                    e.startTime - t.startTime < 5e3
+                      ? ((r += e.value), o.push(e))
+                      : ((r = e.value), (o = [e]));
+                  }
+                }),
+                  r > i.value && ((i.value = r), (i.entries = o), n());
+              },
+              a = Kt("layout-shift", s);
+            a &&
+              ((n = Xt(e, i, cn, t.reportAllChanges)),
+              Zt(function () {
+                s(a.takeRecords()), n(!0);
+              }),
+              $t(function () {
+                (r = 0),
+                  (i = Wt("CLS", 0)),
+                  (n = Xt(e, i, cn, t.reportAllChanges)),
+                  Jt(function () {
+                    return n();
+                  });
+              }),
+              setTimeout(n, 0));
+          })
+        );
+    },
+    fcp: un,
+    fid: function (e, t) {
+      (t = t || {}),
+        sn(function () {
+          var n,
+            i = on(),
+            r = Wt("FID"),
+            o = function (e) {
+              e.startTime < i.firstHiddenTime &&
+                ((r.value = e.processingStart - e.startTime),
+                r.entries.push(e),
+                n(!0));
+            },
+            s = function (e) {
+              e.forEach(o);
+            },
+            a = Kt("first-input", s);
+          (n = Xt(e, r, Mn, t.reportAllChanges)),
+            a &&
+              (Zt(
+                Yt(function () {
+                  s(a.takeRecords()), a.disconnect();
+                })
+              ),
+              $t(function () {
+                var i;
+                (r = Wt("FID")),
+                  (n = Xt(e, r, Mn, t.reportAllChanges)),
+                  (qt = []),
+                  (Ft = -1),
+                  (Bt = null),
+                  Pn(addEventListener),
+                  (i = o),
+                  qt.push(i),
+                  Cn();
+              }));
+        });
+    },
+    inp: function (e, t) {
+      "PerformanceEventTiming" in self &&
+        "interactionId" in PerformanceEventTiming.prototype &&
+        ((t = t || {}),
+        sn(function () {
+          var n;
+          "interactionCount" in performance ||
+            Ut ||
+            (Ut = Kt("event", pn, {
+              type: "event",
+              buffered: !0,
+              durationThreshold: 0,
+            }));
+          var i,
+            r = Wt("INP"),
+            o = function (e) {
+              yn(function () {
+                e.forEach(wn);
+                var t = (function () {
+                  var e = Math.min(mn.length - 1, Math.floor((gn() - hn) / 50));
+                  return mn[e];
+                })();
+                t &&
+                  t.latency !== r.value &&
+                  ((r.value = t.latency), (r.entries = t.entries), i());
+              });
+            },
+            s = Kt("event", o, {
+              durationThreshold:
+                null !== (n = t.durationThreshold) && void 0 !== n ? n : 40,
+            });
+          (i = Xt(e, r, Sn, t.reportAllChanges)),
+            s &&
+              (s.observe({ type: "first-input", buffered: !0 }),
+              Zt(function () {
+                o(s.takeRecords()), i(!0);
+              }),
+              $t(function () {
+                (hn = gn()),
+                  (mn.length = 0),
+                  vn.clear(),
+                  (r = Wt("INP")),
+                  (i = Xt(e, r, Sn, t.reportAllChanges));
+              }));
+        }));
+    },
+    lcp: function (e, t) {
+      (t = t || {}),
+        sn(function () {
+          var n,
+            i = on(),
+            r = Wt("LCP"),
+            o = function (e) {
+              t.reportAllChanges || (e = e.slice(-1)),
+                e.forEach(function (e) {
+                  e.startTime < i.firstHiddenTime &&
+                    ((r.value = Math.max(e.startTime - Ht(), 0)),
+                    (r.entries = [e]),
+                    n());
+                });
+            },
+            s = Kt("largest-contentful-paint", o);
+          if (s) {
+            n = Xt(e, r, Tn, t.reportAllChanges);
+            var a = Yt(function () {
+              En[r.id] ||
+                (o(s.takeRecords()), s.disconnect(), (En[r.id] = !0), n(!0));
+            });
+            ["keydown", "click"].forEach(function (e) {
+              addEventListener(
+                e,
+                function () {
+                  return yn(a);
+                },
+                { once: !0, capture: !0 }
+              );
+            }),
+              Zt(a),
+              $t(function (i) {
+                (r = Wt("LCP")),
+                  (n = Xt(e, r, Tn, t.reportAllChanges)),
+                  Jt(function () {
+                    (r.value = performance.now() - i.timeStamp),
+                      (En[r.id] = !0),
+                      n(!0);
+                  });
+              });
+          }
+        });
+    },
+    ttfb: function (e, t) {
+      t = t || {};
+      var n = Wt("TTFB"),
+        i = Xt(e, n, In, t.reportAllChanges);
+      kn(function () {
+        var r = Gt();
+        r &&
+          ((n.value = Math.max(r.responseStart - Ht(), 0)),
+          (n.entries = [r]),
+          i(!0),
+          $t(function () {
+            (n = Wt("TTFB", 0)), (i = Xt(e, n, In, t.reportAllChanges))(!0);
+          }));
+      });
+    },
+  };
+  var Nn,
+    _n,
+    Dn = function () {
+      var e =
+        self.performance &&
+        performance.getEntriesByType &&
+        performance.getEntriesByType("navigation")[0];
+      if (e && e.responseStart > 0 && e.responseStart < performance.now())
+        return e;
+    },
+    Rn = function (e) {
+      if ("loading" === document.readyState) return "loading";
+      var t = Dn();
+      if (t) {
+        if (e < t.domInteractive) return "loading";
+        if (
+          0 === t.domContentLoadedEventStart ||
+          e < t.domContentLoadedEventStart
+        )
+          return "dom-interactive";
+        if (0 === t.domComplete || e < t.domComplete)
+          return "dom-content-loaded";
+      }
+      return "complete";
+    },
+    Un = function (e) {
+      var t = e.nodeName;
+      return 1 === e.nodeType
+        ? t.toLowerCase()
+        : t.toUpperCase().replace(/^#/, "");
+    },
+    Bn = function (e, t) {
+      var n = "";
+      try {
+        for (; e && 9 !== e.nodeType; ) {
+          var i = e,
+            r = i.id
+              ? "#" + i.id
+              : Un(i) +
+                (i.classList &&
+                i.classList.value &&
+                i.classList.value.trim() &&
+                i.classList.value.trim().length
+                  ? "." + i.classList.value.trim().replace(/\s+/g, ".")
+                  : "");
+          if (n.length + r.length > (t || 100) - 1) return n || r;
+          if (((n = n ? r + ">" + n : r), i.id)) break;
+          e = i.parentNode;
+        }
+      } catch (e) {}
+      return n;
+    },
+    Fn = -1,
+    zn = function () {
+      return Fn;
+    },
+    qn = function (e) {
+      addEventListener(
+        "pageshow",
+        function (t) {
+          t.persisted && ((Fn = t.timeStamp), e(t));
+        },
+        !0
+      );
+    },
+    Vn = function () {
+      var e = Dn();
+      return (e && e.activationStart) || 0;
+    },
+    $n = function (e, t) {
+      var n = Dn(),
+        i = "navigate";
+      return (
+        zn() >= 0
+          ? (i = "back-forward-cache")
+          : n &&
+            (document.prerendering || Vn() > 0
+              ? (i = "prerender")
+              : document.wasDiscarded
+              ? (i = "restore")
+              : n.type && (i = n.type.replace(/_/g, "-"))),
+        {
+          name: e,
+          value: void 0 === t ? -1 : t,
+          rating: "good",
+          delta: 0,
+          entries: [],
+          id: "v4-"
+            .concat(Date.now(), "-")
+            .concat(Math.floor(8999999999999 * Math.random()) + 1e12),
+          navigationType: i,
+        }
+      );
+    },
+    Gn = function (e, t, n) {
+      try {
+        if (PerformanceObserver.supportedEntryTypes.includes(e)) {
+          var i = new PerformanceObserver(function (e) {
+            Promise.resolve().then(function () {
+              t(e.getEntries());
+            });
+          });
+          return (
+            i.observe(Object.assign({ type: e, buffered: !0 }, n || {})), i
+          );
+        }
+      } catch (e) {}
+    },
+    Hn = function (e, t, n, i) {
+      var r, o;
+      return function (s) {
+        t.value >= 0 &&
+          (s || i) &&
+          ((o = t.value - (r || 0)) || void 0 === r) &&
+          ((r = t.value),
+          (t.delta = o),
+          (t.rating = (function (e, t) {
+            return e > t[1] ? "poor" : e > t[0] ? "needs-improvement" : "good";
+          })(t.value, n)),
+          e(t));
+      };
+    },
+    Wn = function (e) {
+      requestAnimationFrame(function () {
+        return requestAnimationFrame(function () {
+          return e();
+        });
+      });
+    },
+    Kn = function (e) {
+      document.addEventListener("visibilitychange", function () {
+        "hidden" === document.visibilityState && e();
+      });
+    },
+    Xn = function (e) {
+      var t = !1;
+      return function () {
+        t || (e(), (t = !0));
+      };
+    },
+    Jn = -1,
+    Zn = function () {
+      return "hidden" !== document.visibilityState || document.prerendering
+        ? 1 / 0
+        : 0;
+    },
+    Yn = function (e) {
+      "hidden" === document.visibilityState &&
+        Jn > -1 &&
+        ((Jn = "visibilitychange" === e.type ? e.timeStamp : 0), ei());
+    },
+    Qn = function () {
+      addEventListener("visibilitychange", Yn, !0),
+        addEventListener("prerenderingchange", Yn, !0);
+    },
+    ei = function () {
+      removeEventListener("visibilitychange", Yn, !0),
+        removeEventListener("prerenderingchange", Yn, !0);
+    },
+    ti = function () {
+      return (
+        Jn < 0 &&
+          ((Jn = Zn()),
+          Qn(),
+          qn(function () {
+            setTimeout(function () {
+              (Jn = Zn()), Qn();
+            }, 0);
+          })),
+        {
+          get firstHiddenTime() {
+            return Jn;
+          },
+        }
+      );
+    },
+    ni = function (e) {
+      document.prerendering
+        ? addEventListener(
+            "prerenderingchange",
+            function () {
+              return e();
+            },
+            !0
+          )
+        : e();
+    },
+    ii = [1800, 3e3],
+    ri = function (e, t) {
+      (t = t || {}),
+        ni(function () {
+          var n,
+            i = ti(),
+            r = $n("FCP"),
+            o = Gn("paint", function (e) {
+              e.forEach(function (e) {
+                "first-contentful-paint" === e.name &&
+                  (o.disconnect(),
+                  e.startTime < i.firstHiddenTime &&
+                    ((r.value = Math.max(e.startTime - Vn(), 0)),
+                    r.entries.push(e),
+                    n(!0)));
+              });
+            });
+          o &&
+            ((n = Hn(e, r, ii, t.reportAllChanges)),
+            qn(function (i) {
+              (r = $n("FCP")),
+                (n = Hn(e, r, ii, t.reportAllChanges)),
+                Wn(function () {
+                  (r.value = performance.now() - i.timeStamp), n(!0);
+                });
+            }));
+        });
+    },
+    oi = [0.1, 0.25],
+    si = 0,
+    ai = 1 / 0,
+    ui = 0,
+    ci = function (e) {
+      e.forEach(function (e) {
+        e.interactionId &&
+          ((ai = Math.min(ai, e.interactionId)),
+          (ui = Math.max(ui, e.interactionId)),
+          (si = ui ? (ui - ai) / 7 + 1 : 0));
+      });
+    },
+    li = function () {
+      return Nn ? si : performance.interactionCount || 0;
+    },
+    di = function () {
+      "interactionCount" in performance ||
+        Nn ||
+        (Nn = Gn("event", ci, {
+          type: "event",
+          buffered: !0,
+          durationThreshold: 0,
+        }));
+    },
+    fi = [],
+    pi = new Map(),
+    gi = 0,
+    mi = [],
+    vi = function (e) {
+      if (
+        (mi.forEach(function (t) {
+          return t(e);
+        }),
+        e.interactionId || "first-input" === e.entryType)
+      ) {
+        var t = fi[fi.length - 1],
+          n = pi.get(e.interactionId);
+        if (n || fi.length < 10 || e.duration > t.latency) {
+          if (n)
+            e.duration > n.latency
+              ? ((n.entries = [e]), (n.latency = e.duration))
+              : e.duration === n.latency &&
+                e.startTime === n.entries[0].startTime &&
+                n.entries.push(e);
+          else {
+            var i = { id: e.interactionId, latency: e.duration, entries: [e] };
+            pi.set(i.id, i), fi.push(i);
+          }
+          fi.sort(function (e, t) {
+            return t.latency - e.latency;
+          }),
+            fi.length > 10 &&
+              fi.splice(10).forEach(function (e) {
+                return pi.delete(e.id);
+              });
+        }
+      }
+    },
+    hi = function (e) {
+      var t = self.requestIdleCallback || self.setTimeout,
+        n = -1;
+      return (
+        (e = Xn(e)),
+        "hidden" === document.visibilityState ? e() : ((n = t(e)), Kn(e)),
+        n
+      );
+    },
+    bi = [200, 500],
+    wi = function (e, t) {
+      "PerformanceEventTiming" in self &&
+        "interactionId" in PerformanceEventTiming.prototype &&
+        ((t = t || {}),
+        ni(function () {
+          var n;
+          di();
+          var i,
+            r = $n("INP"),
+            o = function (e) {
+              hi(function () {
+                e.forEach(vi);
+                var t = (function () {
+                  var e = Math.min(fi.length - 1, Math.floor((li() - gi) / 50));
+                  return fi[e];
+                })();
+                t &&
+                  t.latency !== r.value &&
+                  ((r.value = t.latency), (r.entries = t.entries), i());
+              });
+            },
+            s = Gn("event", o, {
+              durationThreshold:
+                null !== (n = t.durationThreshold) && void 0 !== n ? n : 40,
+            });
+          (i = Hn(e, r, bi, t.reportAllChanges)),
+            s &&
+              (s.observe({ type: "first-input", buffered: !0 }),
+              Kn(function () {
+                o(s.takeRecords()), i(!0);
+              }),
+              qn(function () {
+                (gi = li()),
+                  (fi.length = 0),
+                  pi.clear(),
+                  (r = $n("INP")),
+                  (i = Hn(e, r, bi, t.reportAllChanges));
+              }));
+        }));
+    },
+    yi = [],
+    Si = [],
+    Ti = 0,
+    Ei = new WeakMap(),
+    Ii = new Map(),
+    ki = -1,
+    Oi = function (e) {
+      (yi = yi.concat(e)), xi();
+    },
+    xi = function () {
+      ki < 0 && (ki = hi(Li));
+    },
+    Li = function () {
+      Ii.size > 10 &&
+        Ii.forEach(function (e, t) {
+          pi.has(t) || Ii.delete(t);
+        });
+      var e = fi.map(function (e) {
+          return Ei.get(e.entries[0]);
+        }),
+        t = Si.length - 50;
+      Si = Si.filter(function (n, i) {
+        return i >= t || e.includes(n);
+      });
+      for (var n = new Set(), i = 0; i < Si.length; i++) {
+        var r = Si[i];
+        ji(r.startTime, r.processingEnd).forEach(function (e) {
+          n.add(e);
+        });
+      }
+      var o = yi.length - 1 - 50;
+      (yi = yi.filter(function (e, t) {
+        return (e.startTime > Ti && t > o) || n.has(e);
+      })),
+        (ki = -1);
+    };
+  mi.push(
+    function (e) {
+      e.interactionId &&
+        e.target &&
+        !Ii.has(e.interactionId) &&
+        Ii.set(e.interactionId, e.target);
+    },
+    function (e) {
+      var t,
+        n = e.startTime + e.duration;
+      Ti = Math.max(Ti, e.processingEnd);
+      for (var i = Si.length - 1; i >= 0; i--) {
+        var r = Si[i];
+        if (Math.abs(n - r.renderTime) <= 8) {
+          ((t = r).startTime = Math.min(e.startTime, t.startTime)),
+            (t.processingStart = Math.min(
+              e.processingStart,
+              t.processingStart
+            )),
+            (t.processingEnd = Math.max(e.processingEnd, t.processingEnd)),
+            t.entries.push(e);
+          break;
+        }
+      }
+      t ||
+        ((t = {
+          startTime: e.startTime,
+          processingStart: e.processingStart,
+          processingEnd: e.processingEnd,
+          renderTime: n,
+          entries: [e],
+        }),
+        Si.push(t)),
+        (e.interactionId || "first-input" === e.entryType) && Ei.set(e, t),
+        xi();
+    }
+  );
+  var Ci,
+    Ai,
+    Pi,
+    Mi,
+    ji = function (e, t) {
+      for (var n, i = [], r = 0; (n = yi[r]); r++)
+        if (!(n.startTime + n.duration < e)) {
+          if (n.startTime > t) break;
+          i.push(n);
+        }
+      return i;
+    },
+    Ni = [2500, 4e3],
+    _i = {},
+    Di = [800, 1800],
+    Ri = function e(t) {
+      document.prerendering
+        ? ni(function () {
+            return e(t);
+          })
+        : "complete" !== document.readyState
+        ? addEventListener(
+            "load",
+            function () {
+              return e(t);
+            },
+            !0
+          )
+        : setTimeout(t, 0);
+    },
+    Ui = function (e, t) {
+      t = t || {};
+      var n = $n("TTFB"),
+        i = Hn(e, n, Di, t.reportAllChanges);
+      Ri(function () {
+        var r = Dn();
+        r &&
+          ((n.value = Math.max(r.responseStart - Vn(), 0)),
+          (n.entries = [r]),
+          i(!0),
+          qn(function () {
+            (n = $n("TTFB", 0)), (i = Hn(e, n, Di, t.reportAllChanges))(!0);
+          }));
+      });
+    },
+    Bi = { passive: !0, capture: !0 },
+    Fi = new Date(),
+    zi = function (e, t) {
+      Ci ||
+        ((Ci = t), (Ai = e), (Pi = new Date()), $i(removeEventListener), qi());
+    },
+    qi = function () {
+      if (Ai >= 0 && Ai < Pi - Fi) {
+        var e = {
+          entryType: "first-input",
+          name: Ci.type,
+          target: Ci.target,
+          cancelable: Ci.cancelable,
+          startTime: Ci.timeStamp,
+          processingStart: Ci.timeStamp + Ai,
+        };
+        Mi.forEach(function (t) {
+          t(e);
+        }),
+          (Mi = []);
+      }
+    },
+    Vi = function (e) {
+      if (e.cancelable) {
+        var t =
+          (e.timeStamp > 1e12 ? new Date() : performance.now()) - e.timeStamp;
+        "pointerdown" == e.type
+          ? (function (e, t) {
+              var n = function () {
+                  zi(e, t), r();
+                },
+                i = function () {
+                  r();
+                },
+                r = function () {
+                  removeEventListener("pointerup", n, Bi),
+                    removeEventListener("pointercancel", i, Bi);
+                };
+              addEventListener("pointerup", n, Bi),
+                addEventListener("pointercancel", i, Bi);
+            })(t, e)
+          : zi(t, e);
+      }
+    },
+    $i = function (e) {
+      ["mousedown", "keydown", "touchstart", "pointerdown"].forEach(function (
+        t
+      ) {
+        return e(t, Vi, Bi);
+      });
+    },
+    Gi = [100, 300],
+    Hi = function (e, t) {
+      !(function (e, t) {
+        (t = t || {}),
+          ni(function () {
+            var n,
+              i = ti(),
+              r = $n("FID"),
+              o = function (e) {
+                e.startTime < i.firstHiddenTime &&
+                  ((r.value = e.processingStart - e.startTime),
+                  r.entries.push(e),
+                  n(!0));
+              },
+              s = function (e) {
+                e.forEach(o);
+              },
+              a = Gn("first-input", s);
+            (n = Hn(e, r, Gi, t.reportAllChanges)),
+              a &&
+                (Kn(
+                  Xn(function () {
+                    s(a.takeRecords()), a.disconnect();
+                  })
+                ),
+                qn(function () {
+                  var i;
+                  (r = $n("FID")),
+                    (n = Hn(e, r, Gi, t.reportAllChanges)),
+                    (Mi = []),
+                    (Ai = -1),
+                    (Ci = null),
+                    $i(addEventListener),
+                    (i = o),
+                    Mi.push(i),
+                    qi();
+                }));
+          });
+      })(function (t) {
+        var n = (function (e) {
+          var t = e.entries[0],
+            n = {
+              eventTarget: Bn(t.target),
+              eventType: t.name,
+              eventTime: t.startTime,
+              eventEntry: t,
+              loadState: Rn(t.startTime),
+            };
+          return Object.assign(e, { attribution: n });
+        })(t);
+        e(n);
+      }, t);
+    };
+  const Wi = "com.grafana.faro.lastNavigationId",
+    Ki = "load_state",
+    Xi = "time_to_first_byte";
+  class Ji {
+    constructor(e, t) {
+      (this.corePushMeasurement = e), (this.webVitalConfig = t);
+    }
+    initialize() {
+      this.measureCLS(),
+        this.measureFCP(),
+        this.measureFID(),
+        this.measureINP(),
+        this.measureLCP(),
+        this.measureTTFB();
+    }
+    measureCLS() {
+      var e;
+      !(function (e, t) {
+        !(function (e, t) {
+          (t = t || {}),
+            ri(
+              Xn(function () {
+                var n,
+                  i = $n("CLS", 0),
+                  r = 0,
+                  o = [],
+                  s = function (e) {
+                    e.forEach(function (e) {
+                      if (!e.hadRecentInput) {
+                        var t = o[0],
+                          n = o[o.length - 1];
+                        r &&
+                        e.startTime - n.startTime < 1e3 &&
+                        e.startTime - t.startTime < 5e3
+                          ? ((r += e.value), o.push(e))
+                          : ((r = e.value), (o = [e]));
+                      }
+                    }),
+                      r > i.value && ((i.value = r), (i.entries = o), n());
+                  },
+                  a = Gn("layout-shift", s);
+                a &&
+                  ((n = Hn(e, i, oi, t.reportAllChanges)),
+                  Kn(function () {
+                    s(a.takeRecords()), n(!0);
+                  }),
+                  qn(function () {
+                    (r = 0),
+                      (i = $n("CLS", 0)),
+                      (n = Hn(e, i, oi, t.reportAllChanges)),
+                      Wn(function () {
+                        return n();
+                      });
+                  }),
+                  setTimeout(n, 0));
+              })
+            );
+        })(function (t) {
+          var n = (function (e) {
+            var t,
+              n = {};
+            if (e.entries.length) {
+              var i = e.entries.reduce(function (e, t) {
+                return e && e.value > t.value ? e : t;
+              });
+              if (i && i.sources && i.sources.length) {
+                var r =
+                  (t = i.sources).find(function (e) {
+                    return e.node && 1 === e.node.nodeType;
+                  }) || t[0];
+                r &&
+                  (n = {
+                    largestShiftTarget: Bn(r.node),
+                    largestShiftTime: i.startTime,
+                    largestShiftValue: i.value,
+                    largestShiftSource: r,
+                    largestShiftEntry: i,
+                    loadState: Rn(i.startTime),
+                  });
+              }
+            }
+            return Object.assign(e, { attribution: n });
+          })(t);
+          e(n);
+        }, t);
+      })(
+        (e) => {
+          const {
+              loadState: t,
+              largestShiftValue: n,
+              largestShiftTime: i,
+              largestShiftTarget: r,
+            } = e.attribution,
+            o = this.buildInitialValues(e);
+          this.addIfPresent(o, "largest_shift_value", n),
+            this.addIfPresent(o, "largest_shift_time", i);
+          const s = this.buildInitialContext(e);
+          this.addIfPresent(s, Ki, t),
+            this.addIfPresent(s, "largest_shift_target", r),
+            this.pushMeasurement(o, s);
+        },
+        {
+          reportAllChanges:
+            null === (e = this.webVitalConfig) || void 0 === e
+              ? void 0
+              : e.reportAllChanges,
+        }
+      );
+    }
+    measureFCP() {
+      var e;
+      !(function (e, t) {
+        ri(function (t) {
+          var n = (function (e) {
+            var t = {
+              timeToFirstByte: 0,
+              firstByteToFCP: e.value,
+              loadState: Rn(zn()),
+            };
+            if (e.entries.length) {
+              var n = Dn(),
+                i = e.entries[e.entries.length - 1];
+              if (n) {
+                var r = n.activationStart || 0,
+                  o = Math.max(0, n.responseStart - r);
+                t = {
+                  timeToFirstByte: o,
+                  firstByteToFCP: e.value - o,
+                  loadState: Rn(e.entries[0].startTime),
+                  navigationEntry: n,
+                  fcpEntry: i,
+                };
+              }
+            }
+            return Object.assign(e, { attribution: t });
+          })(t);
+          e(n);
+        }, t);
+      })(
+        (e) => {
+          const {
+              firstByteToFCP: t,
+              timeToFirstByte: n,
+              loadState: i,
+            } = e.attribution,
+            r = this.buildInitialValues(e);
+          this.addIfPresent(r, "first_byte_to_fcp", t),
+            this.addIfPresent(r, Xi, n);
+          const o = this.buildInitialContext(e);
+          this.addIfPresent(o, Ki, i), this.pushMeasurement(r, o);
+        },
+        {
+          reportAllChanges:
+            null === (e = this.webVitalConfig) || void 0 === e
+              ? void 0
+              : e.reportAllChanges,
+        }
+      );
+    }
+    measureFID() {
+      var e;
+      Hi(
+        (e) => {
+          const {
+              eventTime: t,
+              eventTarget: n,
+              eventType: i,
+              loadState: r,
+            } = e.attribution,
+            o = this.buildInitialValues(e);
+          this.addIfPresent(o, "event_time", t);
+          const s = this.buildInitialContext(e);
+          this.addIfPresent(s, "event_target", n),
+            this.addIfPresent(s, "event_type", i),
+            this.addIfPresent(s, Ki, r),
+            this.pushMeasurement(o, s);
+        },
+        {
+          reportAllChanges:
+            null === (e = this.webVitalConfig) || void 0 === e
+              ? void 0
+              : e.reportAllChanges,
+        }
+      );
+    }
+    measureINP() {
+      var e;
+      !(function (e, t) {
+        _n || (_n = Gn("long-animation-frame", Oi)),
+          wi(function (t) {
+            var n = (function (e) {
+              var t = e.entries[0],
+                n = Ei.get(t),
+                i = t.processingStart,
+                r = n.processingEnd,
+                o = n.entries.sort(function (e, t) {
+                  return e.processingStart - t.processingStart;
+                }),
+                s = ji(t.startTime, r),
+                a = e.entries.find(function (e) {
+                  return e.target;
+                }),
+                u = (a && a.target) || Ii.get(t.interactionId),
+                c = [t.startTime + t.duration, r].concat(
+                  s.map(function (e) {
+                    return e.startTime + e.duration;
+                  })
+                ),
+                l = Math.max.apply(Math, c),
+                d = {
+                  interactionTarget: Bn(u),
+                  interactionTargetElement: u,
+                  interactionType: t.name.startsWith("key")
+                    ? "keyboard"
+                    : "pointer",
+                  interactionTime: t.startTime,
+                  nextPaintTime: l,
+                  processedEventEntries: o,
+                  longAnimationFrameEntries: s,
+                  inputDelay: i - t.startTime,
+                  processingDuration: r - i,
+                  presentationDelay: Math.max(l - r, 0),
+                  loadState: Rn(t.startTime),
+                };
+              return Object.assign(e, { attribution: d });
+            })(t);
+            e(n);
+          }, t);
+      })(
+        (e) => {
+          const {
+              interactionTime: t,
+              presentationDelay: n,
+              inputDelay: i,
+              processingDuration: r,
+              nextPaintTime: o,
+              loadState: s,
+              interactionTarget: a,
+              interactionType: u,
+            } = e.attribution,
+            c = this.buildInitialValues(e);
+          this.addIfPresent(c, "interaction_time", t),
+            this.addIfPresent(c, "presentation_delay", n),
+            this.addIfPresent(c, "input_delay", i),
+            this.addIfPresent(c, "processing_duration", r),
+            this.addIfPresent(c, "next_paint_time", o);
+          const l = this.buildInitialContext(e);
+          this.addIfPresent(l, Ki, s),
+            this.addIfPresent(l, "interaction_target", a),
+            this.addIfPresent(l, "interaction_type", u),
+            this.pushMeasurement(c, l);
+        },
+        {
+          reportAllChanges:
+            null === (e = this.webVitalConfig) || void 0 === e
+              ? void 0
+              : e.reportAllChanges,
+        }
+      );
+    }
+    measureLCP() {
+      var e;
+      !(function (e, t) {
+        !(function (e, t) {
+          (t = t || {}),
+            ni(function () {
+              var n,
+                i = ti(),
+                r = $n("LCP"),
+                o = function (e) {
+                  t.reportAllChanges || (e = e.slice(-1)),
+                    e.forEach(function (e) {
+                      e.startTime < i.firstHiddenTime &&
+                        ((r.value = Math.max(e.startTime - Vn(), 0)),
+                        (r.entries = [e]),
+                        n());
+                    });
+                },
+                s = Gn("largest-contentful-paint", o);
+              if (s) {
+                n = Hn(e, r, Ni, t.reportAllChanges);
+                var a = Xn(function () {
+                  _i[r.id] ||
+                    (o(s.takeRecords()),
+                    s.disconnect(),
+                    (_i[r.id] = !0),
+                    n(!0));
+                });
+                ["keydown", "click"].forEach(function (e) {
+                  addEventListener(
+                    e,
+                    function () {
+                      return hi(a);
+                    },
+                    { once: !0, capture: !0 }
+                  );
+                }),
+                  Kn(a),
+                  qn(function (i) {
+                    (r = $n("LCP")),
+                      (n = Hn(e, r, Ni, t.reportAllChanges)),
+                      Wn(function () {
+                        (r.value = performance.now() - i.timeStamp),
+                          (_i[r.id] = !0),
+                          n(!0);
+                      });
+                  });
+              }
+            });
+        })(function (t) {
+          var n = (function (e) {
+            var t = {
+              timeToFirstByte: 0,
+              resourceLoadDelay: 0,
+              resourceLoadDuration: 0,
+              elementRenderDelay: e.value,
+            };
+            if (e.entries.length) {
+              var n = Dn();
+              if (n) {
+                var i = n.activationStart || 0,
+                  r = e.entries[e.entries.length - 1],
+                  o =
+                    r.url &&
+                    performance
+                      .getEntriesByType("resource")
+                      .filter(function (e) {
+                        return e.name === r.url;
+                      })[0],
+                  s = Math.max(0, n.responseStart - i),
+                  a = Math.max(s, o ? (o.requestStart || o.startTime) - i : 0),
+                  u = Math.max(a, o ? o.responseEnd - i : 0),
+                  c = Math.max(u, r.startTime - i);
+                (t = {
+                  element: Bn(r.element),
+                  timeToFirstByte: s,
+                  resourceLoadDelay: a - s,
+                  resourceLoadDuration: u - a,
+                  elementRenderDelay: c - u,
+                  navigationEntry: n,
+                  lcpEntry: r,
+                }),
+                  r.url && (t.url = r.url),
+                  o && (t.lcpResourceEntry = o);
+              }
+            }
+            return Object.assign(e, { attribution: t });
+          })(t);
+          e(n);
+        }, t);
+      })(
+        (e) => {
+          const {
+              elementRenderDelay: t,
+              resourceLoadDelay: n,
+              resourceLoadDuration: i,
+              timeToFirstByte: r,
+              element: o,
+            } = e.attribution,
+            s = this.buildInitialValues(e);
+          this.addIfPresent(s, "element_render_delay", t),
+            this.addIfPresent(s, "resource_load_delay", n),
+            this.addIfPresent(s, "resource_load_duration", i),
+            this.addIfPresent(s, Xi, r);
+          const a = this.buildInitialContext(e);
+          this.addIfPresent(a, "element", o), this.pushMeasurement(s, a);
+        },
+        {
+          reportAllChanges:
+            null === (e = this.webVitalConfig) || void 0 === e
+              ? void 0
+              : e.reportAllChanges,
+        }
+      );
+    }
+    measureTTFB() {
+      var e;
+      !(function (e, t) {
+        Ui(function (t) {
+          var n = (function (e) {
+            var t = {
+              waitingDuration: 0,
+              cacheDuration: 0,
+              dnsDuration: 0,
+              connectionDuration: 0,
+              requestDuration: 0,
+            };
+            if (e.entries.length) {
+              var n = e.entries[0],
+                i = n.activationStart || 0,
+                r = Math.max((n.workerStart || n.fetchStart) - i, 0),
+                o = Math.max(n.domainLookupStart - i, 0),
+                s = Math.max(n.connectStart - i, 0),
+                a = Math.max(n.connectEnd - i, 0);
+              t = {
+                waitingDuration: r,
+                cacheDuration: o - r,
+                dnsDuration: s - o,
+                connectionDuration: a - s,
+                requestDuration: e.value - a,
+                navigationEntry: n,
+              };
+            }
+            return Object.assign(e, { attribution: t });
+          })(t);
+          e(n);
+        }, t);
+      })(
+        (e) => {
+          const {
+              dnsDuration: t,
+              connectionDuration: n,
+              requestDuration: i,
+              waitingDuration: r,
+              cacheDuration: o,
+            } = e.attribution,
+            s = this.buildInitialValues(e);
+          this.addIfPresent(s, "dns_duration", t),
+            this.addIfPresent(s, "connection_duration", n),
+            this.addIfPresent(s, "request_duration", i),
+            this.addIfPresent(s, "waiting_duration", r),
+            this.addIfPresent(s, "cache_duration", o);
+          const a = this.buildInitialContext(e);
+          this.pushMeasurement(s, a);
+        },
+        {
+          reportAllChanges:
+            null === (e = this.webVitalConfig) || void 0 === e
+              ? void 0
+              : e.reportAllChanges,
+        }
+      );
+    }
+    buildInitialValues(e) {
+      const t = e.name.toLowerCase();
+      return { [t]: e.value, delta: e.delta };
+    }
+    buildInitialContext(e) {
+      var t;
+      const n = null !== (t = Re(Wi, _e.session)) && void 0 !== t ? t : Le;
+      return {
+        id: e.id,
+        rating: e.rating,
+        navigation_type: e.navigationType,
+        navigation_entry_id: n,
+      };
+    }
+    pushMeasurement(e, t) {
+      this.corePushMeasurement(
+        { type: "web-vitals", values: e },
+        { context: t }
+      );
+    }
+    addIfPresent(e, t, n) {
+      n && (e[t] = n);
+    }
+  }
+  class Zi extends ge {
+    constructor() {
+      super(...arguments),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-web-vitals"),
+        (this.version = me);
+    }
+    initialize() {
+      this.logDebug("Initializing");
+      this.intializeWebVitalsInstrumentation().initialize();
+    }
+    intializeWebVitalsInstrumentation() {
+      var e, t, n;
+      return !1 ===
+        (null === (e = this.config) || void 0 === e
+          ? void 0
+          : e.trackWebVitalsAttribution) ||
+        !1 ===
+          (null ===
+            (n =
+              null === (t = this.config) || void 0 === t
+                ? void 0
+                : t.webVitalsInstrumentation) || void 0 === n
+            ? void 0
+            : n.trackAttribution)
+        ? new jn(this.api.pushMeasurement, this.config.webVitalsInstrumentation)
+        : new Ji(
+            this.api.pushMeasurement,
+            this.config.webVitalsInstrumentation
+          );
+    }
+  }
+  function Yi(e, t) {
+    var n = {};
+    for (var i in e)
+      Object.prototype.hasOwnProperty.call(e, i) &&
+        t.indexOf(i) < 0 &&
+        (n[i] = e[i]);
+    if (null != e && "function" == typeof Object.getOwnPropertySymbols) {
+      var r = 0;
+      for (i = Object.getOwnPropertySymbols(e); r < i.length; r++)
+        t.indexOf(i[r]) < 0 &&
+          Object.prototype.propertyIsEnumerable.call(e, i[r]) &&
+          (n[i[r]] = e[i[r]]);
+    }
+    return n;
+  }
+  function Qi(e, t, n, i) {
+    return new (n || (n = Promise))(function (r, o) {
+      function s(e) {
+        try {
+          u(i.next(e));
+        } catch (e) {
+          o(e);
+        }
+      }
+      function a(e) {
+        try {
+          u(i.throw(e));
+        } catch (e) {
+          o(e);
+        }
+      }
+      function u(e) {
+        var t;
+        e.done
+          ? r(e.value)
+          : ((t = e.value),
+            t instanceof n
+              ? t
+              : new n(function (e) {
+                  e(t);
+                })).then(s, a);
+      }
+      u((i = i.apply(e, t || [])).next());
+    });
+  }
+  "function" == typeof SuppressedError && SuppressedError;
+  const er = "resource",
+    tr = /^00-[a-f0-9]{32}-[a-f0-9]{16}-[0-9]{1,2}$/;
+  function nr(e = []) {
+    for (const t of e)
+      if ("traceparent" === t.name) {
+        if (!tr.test(t.description)) continue;
+        const [, e, n] = t.description.split("-");
+        if (null != e && null != n) return { traceId: e, spanId: n };
+        break;
+      }
+  }
+  function ir(e, t = {}) {
+    for (const [n, i] of Object.entries(t)) {
+      const t = e[n];
+      return null != t && (l(i) ? i.includes(t) : t === i);
+    }
+    return !0;
+  }
+  function rr(e) {
+    const {
+      connectEnd: t,
+      connectStart: n,
+      decodedBodySize: i,
+      domainLookupEnd: r,
+      domainLookupStart: o,
+      duration: s,
+      encodedBodySize: a,
+      fetchStart: u,
+      initiatorType: c,
+      name: l,
+      nextHopProtocol: d,
+      redirectEnd: f,
+      redirectStart: p,
+      renderBlockingStatus: g,
+      requestStart: m,
+      responseEnd: v,
+      responseStart: h,
+      responseStatus: b,
+      secureConnectionStart: w,
+      transferSize: y,
+      workerStart: S,
+    } = e;
+    return {
+      name: l,
+      duration: sr(s),
+      tcpHandshakeTime: sr(t - n),
+      dnsLookupTime: sr(r - o),
+      tlsNegotiationTime: sr(t - w),
+      responseStatus: sr(b),
+      redirectTime: sr(f - p),
+      requestTime: sr(h - m),
+      responseTime: sr(v - h),
+      fetchTime: sr(v - u),
+      serviceWorkerTime: sr(u - S),
+      decodedBodySize: sr(i),
+      encodedBodySize: sr(a),
+      cacheHitStatus: (function () {
+        let e = "fullLoad";
+        0 === y
+          ? i > 0 && (e = "cache")
+          : null != b
+          ? 304 === b && (e = "conditionalFetch")
+          : a > 0 && y < a && (e = "conditionalFetch");
+        return e;
+      })(),
+      renderBlockingStatus: sr(g),
+      protocol: d,
+      initiatorType: c,
+      visibilityState: document.visibilityState,
+      ttfb: sr(h - m),
+      transferSize: sr(y),
+    };
+  }
+  function or(e) {
+    const {
+        activationStart: t,
+        domComplete: n,
+        domContentLoadedEventEnd: i,
+        domContentLoadedEventStart: r,
+        domInteractive: o,
+        fetchStart: s,
+        loadEventEnd: a,
+        loadEventStart: u,
+        responseStart: c,
+        type: l,
+      } = e,
+      d = (function () {
+        var e;
+        if (
+          null !=
+          (null === (e = performance.timing) || void 0 === e
+            ? void 0
+            : e.domLoading)
+        )
+          return performance.timing.domLoading - performance.timeOrigin;
+        return null;
+      })();
+    return Object.assign(Object.assign({}, rr(e)), {
+      pageLoadTime: sr(n - s),
+      documentParsingTime: sr(d ? o - d : null),
+      domProcessingTime: sr(n - o),
+      domContentLoadHandlerTime: sr(i - r),
+      onLoadTime: sr(a - u),
+      ttfb: sr(Math.max(c - (null != t ? t : 0), 0)),
+      type: l,
+    });
+  }
+  function sr(e) {
+    return null == e
+      ? Le
+      : "number" == typeof e
+      ? Math.round(e > 0 ? e : 0).toString()
+      : e.toString();
+  }
+  const ar = { initiatorType: ["xmlhttprequest", "fetch"] };
+  const ur = new D();
+  class cr extends ge {
+    constructor() {
+      super(...arguments),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-performance"),
+        (this.version = me);
+    }
+    initialize() {
+      "PerformanceObserver" in window
+        ? (function (e) {
+            if ("complete" === document.readyState) e();
+            else {
+              const t = () => {
+                "complete" === document.readyState &&
+                  (e(), document.removeEventListener("readystatechange", t));
+              };
+              document.addEventListener("readystatechange", t);
+            }
+          })(() =>
+            Qi(this, void 0, void 0, function* () {
+              const t = this.api.pushEvent,
+                { faroNavigationId: n } = yield (function (e) {
+                  let t;
+                  const n = new Promise((e) => {
+                    t = e;
+                  });
+                  return (
+                    new PerformanceObserver((n) => {
+                      var i;
+                      const [r] = n.getEntries();
+                      if (null == r || Ge(r.name)) return;
+                      const o = r.toJSON();
+                      let s = nr(null == o ? void 0 : o.serverTiming);
+                      const a =
+                          null !== (i = Re(Wi, _e.session)) && void 0 !== i
+                            ? i
+                            : Le,
+                        u = Object.assign(Object.assign({}, or(o)), {
+                          faroNavigationId: M(),
+                          faroPreviousNavigationId: a,
+                        });
+                      Ue(Wi, u.faroNavigationId, _e.session),
+                        e("faro.performance.navigation", u, void 0, {
+                          spanContext: s,
+                          timestampOverwriteMs:
+                            performance.timeOrigin + o.startTime,
+                        }),
+                        t(u);
+                    }).observe({ type: "navigation", buffered: !0 }),
+                    n
+                  );
+                })(t);
+              null != n &&
+                (function (t, n, i) {
+                  const r = e.faro.config.trackResources;
+                  new PerformanceObserver((o) => {
+                    const s = o.getEntries();
+                    for (const o of s) {
+                      if (Ge(o.name)) return;
+                      const s = o.toJSON();
+                      let a = nr(null == s ? void 0 : s.serverTiming);
+                      if ((null == r && ir(s, ar)) || r) {
+                        const r = Object.assign(Object.assign({}, rr(s)), {
+                          faroNavigationId: t,
+                          faroResourceId: M(),
+                        });
+                        e.faro.config.trackUserActionsPreview &&
+                          (null == i || i.notify({ type: er })),
+                          n("faro.performance.resource", r, void 0, {
+                            spanContext: a,
+                            timestampOverwriteMs:
+                              performance.timeOrigin + s.startTime,
+                          });
+                      }
+                    }
+                  }).observe({ type: er, buffered: !0 });
+                })(n, t, ur);
+            })
+          )
+        : this.logDebug(
+            "performance observer not supported. Disable performance instrumentation."
+          );
+    }
+  }
+  const lr = "resource-entry",
+    dr = "http-request-start",
+    fr = "http-request-end",
+    pr = "dom-mutation",
+    gr = "data-faro-user-action-name";
+  const mr = "fetch",
+    vr = "xhr";
+  function hr() {
+    const e = new D();
+    function t(t) {
+      e.notify({ type: dr, request: t });
+    }
+    function n(t) {
+      e.notify({ type: fr, request: t });
+    }
+    return (
+      (function ({ onRequestEnd: e, onRequestStart: t }) {
+        const n = window.fetch;
+        window.fetch = function () {
+          var i, r;
+          const o = null !== (i = He(arguments[0])) && void 0 !== i ? i : "",
+            s = Ge(o),
+            a = (null !== (r = arguments[1]) && void 0 !== r ? r : {}).method,
+            u = M();
+          return (
+            s || t({ url: o, method: a, requestId: u, apiType: mr }),
+            n
+              .apply(this, arguments)
+              .then(
+                (t) => (
+                  s || e({ url: o, method: a, requestId: u, apiType: mr }), t
+                )
+              )
+              .catch((t) => {
+                throw (
+                  (s || e({ url: o, method: a, requestId: u, apiType: mr }), t)
+                );
+              })
+          );
+        };
+      })({ onRequestStart: t, onRequestEnd: n }),
+      (function ({ onRequestStart: e, onRequestEnd: t }) {
+        const n = XMLHttpRequest.prototype.open;
+        XMLHttpRequest.prototype.open = function () {
+          const i = arguments[1],
+            r = Ge(i),
+            o = arguments[0],
+            s = M();
+          this.addEventListener("loadstart", function () {
+            r || e({ url: i, method: o, requestId: s, apiType: vr });
+          }),
+            this.addEventListener("load", function () {
+              r || t({ url: i, method: o, requestId: s, apiType: vr });
+            }),
+            this.addEventListener("error", function () {
+              r || t({ url: i, method: o, requestId: s, apiType: vr });
+            }),
+            this.addEventListener("abort", function () {
+              r || t({ url: i, method: o, requestId: s, apiType: vr });
+            }),
+            n.apply(this, arguments);
+        };
+      })({ onRequestStart: t, onRequestEnd: n }),
+      e
+    );
+  }
+  function br(e) {
+    const { api: t, config: n } = e,
+      i = hr(),
+      r = (function () {
+        const e = new D();
+        return (
+          new MutationObserver((t, n) => {
+            e.notify({ type: pr });
+          }).observe(document, {
+            attributes: !0,
+            childList: !0,
+            subtree: !0,
+            characterData: !0,
+          }),
+          e
+        );
+      })(),
+      o = (function () {
+        const e = new D();
+        return (
+          ur.subscribe((t) => {
+            t.type === er && e.notify({ type: lr });
+          }),
+          e
+        );
+      })();
+    let s,
+      a = !1;
+    return function (e) {
+      var u;
+      let c;
+      const l = "apiEvent" === (d = e).type && "string" == typeof d.name;
+      var d;
+      if (
+        ((c = l
+          ? e.name
+          : (function (e, t) {
+              const n = (function (e) {
+                  const t = e.split("data-")[1],
+                    n =
+                      null == t
+                        ? void 0
+                        : t.replace(/-(.)/g, (e, t) => t.toUpperCase());
+                  return null == n ? void 0 : n.replace(/-/g, "");
+                })(t),
+                i = e.dataset;
+              for (const e in i) if (e === n) return i[e];
+              return;
+            })(
+              e.target,
+              null !== (u = n.trackUserActionsDataAttributeName) && void 0 !== u
+                ? u
+                : "faroUserActionName"
+            )),
+        a || null == c)
+      )
+        return;
+      a = !0;
+      const f = E();
+      let p;
+      const g = M();
+      fe.notify({ type: te, name: c, startTime: f, parentId: g }),
+        (s = yr(
+          s,
+          () => {
+            (p = E()),
+              (a = !1),
+              (function (e, t) {
+                fe.notify({ type: ie, name: e, parentId: t });
+              })(c, g);
+          },
+          100
+        ));
+      const m = new Map();
+      let v,
+        h = !1;
+      const b = new D()
+        .merge(i, r, o)
+        .takeWhile(() => a)
+        .filter((e) => !!(!h || (Tr(e) && m.has(e.request.requestId))))
+        .subscribe((n) => {
+          (function (e) {
+            return e.type === dr;
+          })(n) && m.set(n.request.requestId, n.request),
+            Tr(n) && m.delete(n.request.requestId),
+            (s = yr(
+              s,
+              () => {
+                p = E();
+                const n = Object.assign(
+                    {
+                      api: t,
+                      userActionName: c,
+                      startTime: f,
+                      endTime: p,
+                      actionId: g,
+                      event: e,
+                    },
+                    l ? { attributes: e.attributes } : {}
+                  ),
+                  i = m.size > 0;
+                h && !i && (clearTimeout(v), (h = !1)),
+                  i
+                    ? ((h = !0),
+                      fe.notify({
+                        type: re,
+                        name: c,
+                        parentId: g,
+                        reason: "pending-requests",
+                        haltTime: E(),
+                      }),
+                      (v = yr(
+                        void 0,
+                        () => {
+                          Sr(b), wr(n), (a = !1), (h = !1);
+                        },
+                        1e4
+                      )))
+                    : (Sr(b), wr(n), (a = !1), (h = !1));
+              },
+              100
+            ));
+        });
+    };
+  }
+  function wr(e) {
+    const {
+        api: t,
+        userActionName: n,
+        startTime: i,
+        endTime: r,
+        actionId: o,
+        event: s,
+        attributes: a,
+      } = e,
+      u = r - i,
+      c = s.type;
+    fe.notify({
+      type: ne,
+      name: n,
+      id: o,
+      startTime: i,
+      endTime: r,
+      duration: u,
+      eventType: c,
+    }),
+      t.pushEvent(
+        n,
+        Object.assign(
+          {
+            userActionStartTime: i.toString(),
+            userActionEndTime: r.toString(),
+            userActionDuration: u.toString(),
+            userActionEventType: c,
+          },
+          _(a)
+        ),
+        void 0,
+        {
+          timestampOverwriteMs: i,
+          customPayloadTransformer: (e) => ((e.action = { id: o, name: n }), e),
+        }
+      );
+  }
+  function yr(e, t, n) {
+    return (
+      e && clearTimeout(e),
+      (e = setTimeout(() => {
+        t();
+      }, n))
+    );
+  }
+  function Sr(e) {
+    null == e || e.unsubscribe(), (e = void 0);
+  }
+  function Tr(e) {
+    return e.type === fr;
+  }
+  let Er;
+  class Ir extends ge {
+    constructor() {
+      super(...arguments),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-user-action"),
+        (this.version = me);
+    }
+    initialize() {
+      (Er = br(e.faro)),
+        window.addEventListener("pointerdown", Er),
+        window.addEventListener("keydown", Er);
+    }
+  }
+  function kr(e = {}) {
+    const t = [new Ir(), new Dt(), new Zi(), new at(), new Rt()];
+    return (
+      !1 !== e.enablePerformanceInstrumentation && t.unshift(new cr()),
+      !1 !== e.captureConsole &&
+        t.push(new _t({ disabledLevels: e.captureConsoleDisabledLevels })),
+      t
+    );
+  }
+  const Or = "browser",
+    xr = () => {
+      const e = window.k6;
+      return {
+        k6: Object.assign(
+          { isK6Browser: !0 },
+          (null == e ? void 0 : e.testRunId) && {
+            testRunId: null == e ? void 0 : e.testRunId,
+          }
+        ),
+      };
+    };
+  let Lr, Cr;
+  function Ar({ generatePageId: e, initialPageMeta: t } = {}) {
+    return () => {
+      const n = location.href;
+      return (
+        c(e) && Lr !== n && ((Lr = n), (Cr = e(location))),
+        {
+          page: Object.assign(
+            Object.assign({ url: n }, Cr ? { id: Cr } : {}),
+            t
+          ),
+        }
+      );
+    };
+  }
+  class Pr extends Y {
+    constructor(e) {
+      var t, n, i, r;
+      super(),
+        (this.options = e),
+        (this.name = "@grafana/faro-web-sdk:transport-fetch"),
+        (this.version = me),
+        (this.disabledUntil = new Date()),
+        (this.rateLimitBackoffMs =
+          null !== (t = e.defaultRateLimitBackoffMs) && void 0 !== t ? t : 5e3),
+        (this.getNow =
+          null !== (n = e.getNow) && void 0 !== n ? n : () => Date.now()),
+        (this.promiseBuffer = A({
+          size: null !== (i = e.bufferSize) && void 0 !== i ? i : 30,
+          concurrency: null !== (r = e.concurrency) && void 0 !== r ? r : 5,
+        }));
+    }
+    send(e) {
+      return Qi(this, void 0, void 0, function* () {
+        try {
+          if (this.disabledUntil > new Date(this.getNow()))
+            return (
+              this.logWarn(
+                `Dropping transport item due to too many requests. Backoff until ${this.disabledUntil}`
+              ),
+              Promise.resolve()
+            );
+          yield this.promiseBuffer.add(() => {
+            const t = JSON.stringify(ee(e)),
+              { url: n, requestOptions: i, apiKey: r } = this.options,
+              o = null != i ? i : {},
+              { headers: s } = o,
+              a = Yi(o, ["headers"]);
+            let u;
+            const c = this.metas.value.session;
+            return (
+              null != c && (u = c.id),
+              fetch(
+                n,
+                Object.assign(
+                  {
+                    method: "POST",
+                    headers: Object.assign(
+                      Object.assign(
+                        Object.assign(
+                          { "Content-Type": "application/json" },
+                          null != s ? s : {}
+                        ),
+                        r ? { "x-api-key": r } : {}
+                      ),
+                      u ? { "x-faro-session-id": u } : {}
+                    ),
+                    body: t,
+                    keepalive: t.length <= 6e4,
+                  },
+                  null != a ? a : {}
+                )
+              )
+                .then((e) =>
+                  Qi(this, void 0, void 0, function* () {
+                    if (202 === e.status) {
+                      "invalid" === e.headers.get("X-Faro-Session-Status") &&
+                        this.extendFaroSession(this.config, this.logDebug);
+                    }
+                    return (
+                      429 === e.status &&
+                        ((this.disabledUntil = this.getRetryAfterDate(e)),
+                        this.logWarn(
+                          `Too many requests, backing off until ${this.disabledUntil}`
+                        )),
+                      e.text().catch(C),
+                      e
+                    );
+                  })
+                )
+                .catch((e) => {
+                  this.logError(
+                    "Failed sending payload to the receiver\n",
+                    JSON.parse(t),
+                    e
+                  );
+                })
+            );
+          });
+        } catch (e) {
+          this.logError(e);
+        }
+      });
+    }
+    getIgnoreUrls() {
+      var e;
+      return [this.options.url].concat(
+        null !== (e = this.config.ignoreUrls) && void 0 !== e ? e : []
+      );
+    }
+    isBatched() {
+      return !0;
+    }
+    getRetryAfterDate(e) {
+      const t = this.getNow(),
+        n = e.headers.get("Retry-After");
+      if (n) {
+        const e = Number(n);
+        if (!isNaN(e)) return new Date(1e3 * e + t);
+        const i = Date.parse(n);
+        if (!isNaN(i)) return new Date(i);
+      }
+      return new Date(t + this.rateLimitBackoffMs);
+    }
+    extendFaroSession(e, t) {
+      const n = "Session expired",
+        i = e.sessionTracking;
+      if (null == i ? void 0 : i.enabled) {
+        const { fetchUserSession: e, storeUserSession: r } = st(i);
+        tt({ fetchUserSession: e, storeUserSession: r })({
+          forceSessionExtend: !0,
+        }),
+          t(`${n} created new session.`);
+      } else t(`${n}.`);
+    }
+  }
+  function Mr(e) {
+    var t;
+    const n = [],
+      i = K(e.unpatchedConsole, e.internalLoggerLevel);
+    e.transports
+      ? ((e.url || e.apiKey) &&
+          i.error(
+            'if "transports" is defined, "url" and "apiKey" should not be defined'
+          ),
+        n.push(...e.transports))
+      : e.url
+      ? n.push(new Pr({ url: e.url, apiKey: e.apiKey }))
+      : i.error('either "url" or "transports" must be defined');
+    const {
+        dedupe: r = !0,
+        eventDomain: o = Or,
+        globalObjectKey: s = Se,
+        instrumentations: a = kr(),
+        internalLoggerLevel: u = $,
+        isolate: c = !1,
+        logArgsSerializer: l = ce,
+        metas: d = Nr(e),
+        paused: f = !1,
+        preventGlobalExposure: p = !1,
+        unpatchedConsole: g = G,
+        trackUserActionsPreview: m = !1,
+        trackUserActionsDataAttributeName: v = gr,
+      } = e,
+      h = Yi(e, [
+        "dedupe",
+        "eventDomain",
+        "globalObjectKey",
+        "instrumentations",
+        "internalLoggerLevel",
+        "isolate",
+        "logArgsSerializer",
+        "metas",
+        "paused",
+        "preventGlobalExposure",
+        "unpatchedConsole",
+        "trackUserActionsPreview",
+        "trackUserActionsDataAttributeName",
+      ]);
+    return Object.assign(Object.assign({}, h), {
+      batching: Object.assign(Object.assign({}, Te), e.batching),
+      dedupe: r,
+      globalObjectKey: s,
+      instrumentations: jr(a, e),
+      internalLoggerLevel: u,
+      isolate: c,
+      logArgsSerializer: l,
+      metas: d,
+      parseStacktrace: Pt,
+      paused: f,
+      preventGlobalExposure: p,
+      transports: n,
+      unpatchedConsole: g,
+      eventDomain: o,
+      ignoreUrls: (null !== (t = e.ignoreUrls) && void 0 !== t ? t : []).concat(
+        [/\/collect(?:\/[\w]*)?$/]
+      ),
+      sessionTracking: Object.assign(
+        Object.assign(Object.assign({}, Ze), e.sessionTracking),
+        _r({
+          trackGeolocation: e.trackGeolocation,
+          sessionTracking: e.sessionTracking,
+        })
+      ),
+      trackUserActionsPreview: m,
+      trackUserActionsDataAttributeName: v,
+    });
+  }
+  function jr(e, { trackUserActionsPreview: t }) {
+    return e.filter(
+      (e) =>
+        !("@grafana/faro-web-sdk:instrumentation-user-action" === e.name && !t)
+    );
+  }
+  function Nr(e) {
+    var t, n;
+    const { page: i, generatePageId: r } =
+        null !== (t = null == e ? void 0 : e.pageTracking) && void 0 !== t
+          ? t
+          : {},
+      o = [
+        je,
+        Ar({ generatePageId: r, initialPageMeta: i }),
+        ...(null !== (n = e.metas) && void 0 !== n ? n : []),
+      ];
+    return u(window.k6) ? [...o, xr] : o;
+  }
+  function _r({ trackGeolocation: e, sessionTracking: t }) {
+    var n;
+    const i = {};
+    return (
+      a(e) && (i.geoLocationTrackingEnabled = e),
+      S(i)
+        ? {}
+        : {
+            session: Object.assign(
+              Object.assign(
+                {},
+                null !== (n = null == t ? void 0 : t.session) && void 0 !== n
+                  ? n
+                  : {}
+              ),
+              { overrides: i }
+            ),
+          }
+    );
+  }
+  return (
+    (e.BaseExtension = Z),
+    (e.BaseInstrumentation = ge),
+    (e.BaseTransport = Y),
+    (e.ConsoleInstrumentation = _t),
+    (e.ConsoleTransport = class extends Y {
+      constructor(e = {}) {
+        super(),
+          (this.options = e),
+          (this.name = "@grafana/faro-web-sdk:transport-console"),
+          (this.version = me);
+      }
+      send(t) {
+        var n;
+        return this.unpatchedConsole[
+          null !== (n = this.options.level) && void 0 !== n
+            ? n
+            : e.LogLevel.DEBUG
+        ]("New event", ee([t]));
+      }
+    }),
+    (e.Conventions = {
+      EventNames: {
+        CLICK: "click",
+        NAVIGATION: "navigation",
+        SESSION_START: "session_start",
+        VIEW_CHANGED: "view_changed",
+      },
+    }),
+    (e.EVENT_CLICK = "click"),
+    (e.EVENT_NAVIGATION = "navigation"),
+    (e.EVENT_ROUTE_CHANGE = "route_change"),
+    (e.EVENT_SESSION_EXTEND = Oe),
+    (e.EVENT_SESSION_RESUME = ke),
+    (e.EVENT_SESSION_START = Ie),
+    (e.EVENT_VIEW_CHANGED = Ee),
+    (e.ErrorsInstrumentation = Dt),
+    (e.FetchTransport = Pr),
+    (e.MAX_SESSION_PERSISTENCE_TIME = Je),
+    (e.MAX_SESSION_PERSISTENCE_TIME_BUFFER = 6e4),
+    (e.Observable = D),
+    (e.PerformanceInstrumentation = cr),
+    (e.PersistentSessionsManager = rt),
+    (e.SESSION_EXPIRATION_TIME = Ke),
+    (e.SESSION_INACTIVITY_TIME = Xe),
+    (e.STORAGE_KEY = We),
+    (e.SessionInstrumentation = at),
+    (e.USER_ACTION_CANCEL = ie),
+    (e.USER_ACTION_END = ne),
+    (e.USER_ACTION_START = te),
+    (e.UserActionInstrumentation = Ir),
+    (e.VERSION = me),
+    (e.ViewInstrumentation = Rt),
+    (e.VolatileSessionsManager = ot),
+    (e.WebVitalsInstrumentation = Zi),
+    (e.allLogLevels = L),
+    (e.apiMessageBus = fe),
+    (e.browserMeta = je),
+    (e.buildStackFrame = Lt),
+    (e.createInternalLogger = K),
+    (e.createPromiseBuffer = A),
+    (e.createSession = Ne),
+    (e.deepEqual = T),
+    (e.defaultEventDomain = Or),
+    (e.defaultExceptionType = oe),
+    (e.defaultGlobalObjectKey = Se),
+    (e.defaultInternalLoggerLevel = $),
+    (e.defaultLogLevel = x),
+    (e.genShortID = M),
+    (e.getCurrentTimestamp = I),
+    (e.getDataFromSafariExtensions = Ct),
+    (e.getIgnoreUrls = $e),
+    (e.getInternalFaroFromGlobalObject = function () {
+      return j[ve];
+    }),
+    (e.getStackFramesFromError = At),
+    (e.getTransportBody = ee),
+    (e.getUrlFromResource = He),
+    (e.getWebInstrumentations = kr),
+    (e.globalObject = j),
+    (e.initializeFaro = function (e) {
+      const t = Mr(e);
+      if (t) return ye(t);
+    }),
+    (e.internalGlobalObjectKey = ve),
+    (e.isArray = l),
+    (e.isBoolean = a),
+    (e.isDomError = h),
+    (e.isDomException = b),
+    (e.isElement = (e) => w && i(e, Element)),
+    (e.isElementDefined = w),
+    (e.isEmpty = S),
+    (e.isError = m),
+    (e.isErrorDefined = g),
+    (e.isErrorEvent = v),
+    (e.isEvent = p),
+    (e.isEventDefined = f),
+    (e.isFunction = c),
+    (e.isInstanceOf = i),
+    (e.isInt = (e) => s(e) && Number.isInteger(e)),
+    (e.isInternalFaroOnGlobalObject = be),
+    (e.isMap = (e) => y && i(e, Map)),
+    (e.isMapDefined = y),
+    (e.isNull = r),
+    (e.isNumber = s),
+    (e.isObject = u),
+    (e.isPrimitive = d),
+    (e.isRegExp = (e) => n(e, "RegExp")),
+    (e.isString = o),
+    (e.isSymbol = (e) => t(e, "symbol")),
+    (e.isSyntheticEvent = (e) =>
+      u(e) &&
+      "nativeEvent" in e &&
+      "preventDefault" in e &&
+      "stopPropagation" in e),
+    (e.isThenable = (e) => c(null == e ? void 0 : e.then)),
+    (e.isToString = n),
+    (e.isTypeof = t),
+    (e.isUndefined = (e) => t(e, "undefined")),
+    (e.makeCoreConfig = Mr),
+    (e.noop = C),
+    (e.parseStacktrace = Pt),
+    (e.sdkMeta = () => ({
+      sdk: {
+        name: "@grafana/faro-core",
+        version: me,
+        integrations: e.faro.config.instrumentations.map(
+          ({ name: e, version: t }) => ({ name: e, version: t })
+        ),
+      },
+    })),
+    (e.setInternalFaroOnGlobalObject = he),
+    (e.startUserAction = function (e, t) {
+      null == Er ||
+        Er(
+          (function (e, t) {
+            return { name: e, attributes: t, type: "apiEvent" };
+          })(e, t)
+        );
+    }),
+    (e.transportItemTypeToBodyKey = B),
+    (e.unknownString = Le),
+    (e.userActionDataAttribute = gr),
+    e
+  );
+})({});
+
+export default GrafanaFaroWebSdk;

--- a/auth/grafana-faro-web-tracing.js
+++ b/auth/grafana-faro-web-tracing.js
@@ -1,0 +1,4248 @@
+// vendored @grafana/faro-web-tracing v1.18.1 https://unpkg.com/@grafana/faro-web-tracing@1.18.1/dist/bundle/faro-web-tracing.iife.js
+
+var GrafanaFaroWebTracing = function (t, e) {
+  "use strict";
+  var n =
+      "object" == typeof globalThis
+        ? globalThis
+        : "object" == typeof self
+        ? self
+        : "object" == typeof window
+        ? window
+        : "object" == typeof global
+        ? global
+        : {},
+    r = "1.9.0",
+    o = /^(\d+)\.(\d+)\.(\d+)(-(.+))?$/;
+  var i = (function (t) {
+      var e = new Set([t]),
+        n = new Set(),
+        r = t.match(o);
+      if (!r)
+        return function () {
+          return !1;
+        };
+      var i = +r[1],
+        s = +r[2],
+        a = +r[3];
+      if (null != r[4])
+        return function (e) {
+          return e === t;
+        };
+      function u(t) {
+        return n.add(t), !1;
+      }
+      function c(t) {
+        return e.add(t), !0;
+      }
+      return function (t) {
+        if (e.has(t)) return !0;
+        if (n.has(t)) return !1;
+        var r = t.match(o);
+        if (!r) return u(t);
+        var l = +r[1],
+          p = +r[2],
+          d = +r[3];
+        return null != r[4] || i !== l
+          ? u(t)
+          : 0 === i
+          ? s === p && a <= d
+            ? c(t)
+            : u(t)
+          : s <= p
+          ? c(t)
+          : u(t);
+      };
+    })(r),
+    s = r.split(".")[0],
+    a = Symbol.for("opentelemetry.js.api." + s),
+    u = n;
+  function c(t, e, n, o) {
+    var i;
+    void 0 === o && (o = !1);
+    var s = (u[a] = null !== (i = u[a]) && void 0 !== i ? i : { version: r });
+    if (!o && s[t]) {
+      var c = new Error(
+        "@opentelemetry/api: Attempted duplicate registration of API: " + t
+      );
+      return n.error(c.stack || c.message), !1;
+    }
+    if (s.version !== r) {
+      c = new Error(
+        "@opentelemetry/api: Registration of version v" +
+          s.version +
+          " for " +
+          t +
+          " does not match previously registered API v" +
+          r
+      );
+      return n.error(c.stack || c.message), !1;
+    }
+    return (
+      (s[t] = e),
+      n.debug(
+        "@opentelemetry/api: Registered a global for " + t + " v" + r + "."
+      ),
+      !0
+    );
+  }
+  function l(t) {
+    var e,
+      n,
+      r = null === (e = u[a]) || void 0 === e ? void 0 : e.version;
+    if (r && i(r)) return null === (n = u[a]) || void 0 === n ? void 0 : n[t];
+  }
+  function p(t, e) {
+    e.debug(
+      "@opentelemetry/api: Unregistering a global for " + t + " v" + r + "."
+    );
+    var n = u[a];
+    n && delete n[t];
+  }
+  var d,
+    h = function (t, e) {
+      var n = "function" == typeof Symbol && t[Symbol.iterator];
+      if (!n) return t;
+      var r,
+        o,
+        i = n.call(t),
+        s = [];
+      try {
+        for (; (void 0 === e || e-- > 0) && !(r = i.next()).done; )
+          s.push(r.value);
+      } catch (t) {
+        o = { error: t };
+      } finally {
+        try {
+          r && !r.done && (n = i.return) && n.call(i);
+        } finally {
+          if (o) throw o.error;
+        }
+      }
+      return s;
+    },
+    f = function (t, e, n) {
+      if (n || 2 === arguments.length)
+        for (var r, o = 0, i = e.length; o < i; o++)
+          (!r && o in e) ||
+            (r || (r = Array.prototype.slice.call(e, 0, o)), (r[o] = e[o]));
+      return t.concat(r || Array.prototype.slice.call(e));
+    },
+    g = (function () {
+      function t(t) {
+        this._namespace = t.namespace || "DiagComponentLogger";
+      }
+      return (
+        (t.prototype.debug = function () {
+          for (var t = [], e = 0; e < arguments.length; e++)
+            t[e] = arguments[e];
+          return m("debug", this._namespace, t);
+        }),
+        (t.prototype.error = function () {
+          for (var t = [], e = 0; e < arguments.length; e++)
+            t[e] = arguments[e];
+          return m("error", this._namespace, t);
+        }),
+        (t.prototype.info = function () {
+          for (var t = [], e = 0; e < arguments.length; e++)
+            t[e] = arguments[e];
+          return m("info", this._namespace, t);
+        }),
+        (t.prototype.warn = function () {
+          for (var t = [], e = 0; e < arguments.length; e++)
+            t[e] = arguments[e];
+          return m("warn", this._namespace, t);
+        }),
+        (t.prototype.verbose = function () {
+          for (var t = [], e = 0; e < arguments.length; e++)
+            t[e] = arguments[e];
+          return m("verbose", this._namespace, t);
+        }),
+        t
+      );
+    })();
+  function m(t, e, n) {
+    var r = l("diag");
+    if (r) return n.unshift(e), r[t].apply(r, f([], h(n), !1));
+  }
+  !(function (t) {
+    (t[(t.NONE = 0)] = "NONE"),
+      (t[(t.ERROR = 30)] = "ERROR"),
+      (t[(t.WARN = 50)] = "WARN"),
+      (t[(t.INFO = 60)] = "INFO"),
+      (t[(t.DEBUG = 70)] = "DEBUG"),
+      (t[(t.VERBOSE = 80)] = "VERBOSE"),
+      (t[(t.ALL = 9999)] = "ALL");
+  })(d || (d = {}));
+  var _ = function (t, e) {
+      var n = "function" == typeof Symbol && t[Symbol.iterator];
+      if (!n) return t;
+      var r,
+        o,
+        i = n.call(t),
+        s = [];
+      try {
+        for (; (void 0 === e || e-- > 0) && !(r = i.next()).done; )
+          s.push(r.value);
+      } catch (t) {
+        o = { error: t };
+      } finally {
+        try {
+          r && !r.done && (n = i.return) && n.call(i);
+        } finally {
+          if (o) throw o.error;
+        }
+      }
+      return s;
+    },
+    v = function (t, e, n) {
+      if (n || 2 === arguments.length)
+        for (var r, o = 0, i = e.length; o < i; o++)
+          (!r && o in e) ||
+            (r || (r = Array.prototype.slice.call(e, 0, o)), (r[o] = e[o]));
+      return t.concat(r || Array.prototype.slice.call(e));
+    },
+    y = (function () {
+      function t() {
+        function t(t) {
+          return function () {
+            for (var e = [], n = 0; n < arguments.length; n++)
+              e[n] = arguments[n];
+            var r = l("diag");
+            if (r) return r[t].apply(r, v([], _(e), !1));
+          };
+        }
+        var e = this;
+        (e.setLogger = function (t, n) {
+          var r, o, i;
+          if ((void 0 === n && (n = { logLevel: d.INFO }), t === e)) {
+            var s = new Error(
+              "Cannot use diag as the logger for itself. Please use a DiagLogger implementation like ConsoleDiagLogger or a custom implementation"
+            );
+            return (
+              e.error(null !== (r = s.stack) && void 0 !== r ? r : s.message),
+              !1
+            );
+          }
+          "number" == typeof n && (n = { logLevel: n });
+          var a = l("diag"),
+            u = (function (t, e) {
+              function n(n, r) {
+                var o = e[n];
+                return "function" == typeof o && t >= r
+                  ? o.bind(e)
+                  : function () {};
+              }
+              return (
+                t < d.NONE ? (t = d.NONE) : t > d.ALL && (t = d.ALL),
+                (e = e || {}),
+                {
+                  error: n("error", d.ERROR),
+                  warn: n("warn", d.WARN),
+                  info: n("info", d.INFO),
+                  debug: n("debug", d.DEBUG),
+                  verbose: n("verbose", d.VERBOSE),
+                }
+              );
+            })(null !== (o = n.logLevel) && void 0 !== o ? o : d.INFO, t);
+          if (a && !n.suppressOverrideMessage) {
+            var p =
+              null !== (i = new Error().stack) && void 0 !== i
+                ? i
+                : "<failed to generate stacktrace>";
+            a.warn("Current logger will be overwritten from " + p),
+              u.warn(
+                "Current logger will overwrite one already registered from " + p
+              );
+          }
+          return c("diag", u, e, !0);
+        }),
+          (e.disable = function () {
+            p("diag", e);
+          }),
+          (e.createComponentLogger = function (t) {
+            return new g(t);
+          }),
+          (e.verbose = t("verbose")),
+          (e.debug = t("debug")),
+          (e.info = t("info")),
+          (e.warn = t("warn")),
+          (e.error = t("error"));
+      }
+      return (
+        (t.instance = function () {
+          return this._instance || (this._instance = new t()), this._instance;
+        }),
+        t
+      );
+    })(),
+    S = function (t, e) {
+      var n = "function" == typeof Symbol && t[Symbol.iterator];
+      if (!n) return t;
+      var r,
+        o,
+        i = n.call(t),
+        s = [];
+      try {
+        for (; (void 0 === e || e-- > 0) && !(r = i.next()).done; )
+          s.push(r.value);
+      } catch (t) {
+        o = { error: t };
+      } finally {
+        try {
+          r && !r.done && (n = i.return) && n.call(i);
+        } finally {
+          if (o) throw o.error;
+        }
+      }
+      return s;
+    },
+    b = function (t) {
+      var e = "function" == typeof Symbol && Symbol.iterator,
+        n = e && t[e],
+        r = 0;
+      if (n) return n.call(t);
+      if (t && "number" == typeof t.length)
+        return {
+          next: function () {
+            return (
+              t && r >= t.length && (t = void 0),
+              { value: t && t[r++], done: !t }
+            );
+          },
+        };
+      throw new TypeError(
+        e ? "Object is not iterable." : "Symbol.iterator is not defined."
+      );
+    },
+    E = (function () {
+      function t(t) {
+        this._entries = t ? new Map(t) : new Map();
+      }
+      return (
+        (t.prototype.getEntry = function (t) {
+          var e = this._entries.get(t);
+          if (e) return Object.assign({}, e);
+        }),
+        (t.prototype.getAllEntries = function () {
+          return Array.from(this._entries.entries()).map(function (t) {
+            var e = S(t, 2);
+            return [e[0], e[1]];
+          });
+        }),
+        (t.prototype.setEntry = function (e, n) {
+          var r = new t(this._entries);
+          return r._entries.set(e, n), r;
+        }),
+        (t.prototype.removeEntry = function (e) {
+          var n = new t(this._entries);
+          return n._entries.delete(e), n;
+        }),
+        (t.prototype.removeEntries = function () {
+          for (var e, n, r = [], o = 0; o < arguments.length; o++)
+            r[o] = arguments[o];
+          var i = new t(this._entries);
+          try {
+            for (var s = b(r), a = s.next(); !a.done; a = s.next()) {
+              var u = a.value;
+              i._entries.delete(u);
+            }
+          } catch (t) {
+            e = { error: t };
+          } finally {
+            try {
+              a && !a.done && (n = s.return) && n.call(s);
+            } finally {
+              if (e) throw e.error;
+            }
+          }
+          return i;
+        }),
+        (t.prototype.clear = function () {
+          return new t();
+        }),
+        t
+      );
+    })(),
+    T = Symbol("BaggageEntryMetadata"),
+    w = y.instance();
+  function C(t) {
+    return void 0 === t && (t = {}), new E(new Map(Object.entries(t)));
+  }
+  function A(t) {
+    return Symbol.for(t);
+  }
+  var O,
+    R,
+    N = function t(e) {
+      var n = this;
+      (n._currentContext = e ? new Map(e) : new Map()),
+        (n.getValue = function (t) {
+          return n._currentContext.get(t);
+        }),
+        (n.setValue = function (e, r) {
+          var o = new t(n._currentContext);
+          return o._currentContext.set(e, r), o;
+        }),
+        (n.deleteValue = function (e) {
+          var r = new t(n._currentContext);
+          return r._currentContext.delete(e), r;
+        });
+    },
+    x = new N(),
+    P =
+      ((O = function (t, e) {
+        return (
+          (O =
+            Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array &&
+              function (t, e) {
+                t.__proto__ = e;
+              }) ||
+            function (t, e) {
+              for (var n in e)
+                Object.prototype.hasOwnProperty.call(e, n) && (t[n] = e[n]);
+            }),
+          O(t, e)
+        );
+      }),
+      function (t, e) {
+        if ("function" != typeof e && null !== e)
+          throw new TypeError(
+            "Class extends value " + String(e) + " is not a constructor or null"
+          );
+        function n() {
+          this.constructor = t;
+        }
+        O(t, e),
+          (t.prototype =
+            null === e
+              ? Object.create(e)
+              : ((n.prototype = e.prototype), new n()));
+      }),
+    L = (function () {
+      function t() {}
+      return (
+        (t.prototype.createGauge = function (t, e) {
+          return z;
+        }),
+        (t.prototype.createHistogram = function (t, e) {
+          return q;
+        }),
+        (t.prototype.createCounter = function (t, e) {
+          return $;
+        }),
+        (t.prototype.createUpDownCounter = function (t, e) {
+          return G;
+        }),
+        (t.prototype.createObservableGauge = function (t, e) {
+          return W;
+        }),
+        (t.prototype.createObservableCounter = function (t, e) {
+          return K;
+        }),
+        (t.prototype.createObservableUpDownCounter = function (t, e) {
+          return X;
+        }),
+        (t.prototype.addBatchObservableCallback = function (t, e) {}),
+        (t.prototype.removeBatchObservableCallback = function (t) {}),
+        t
+      );
+    })(),
+    D = function () {},
+    I = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), (e.prototype.add = function (t, e) {}), e;
+    })(D),
+    M = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), (e.prototype.add = function (t, e) {}), e;
+    })(D),
+    k = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), (e.prototype.record = function (t, e) {}), e;
+    })(D),
+    j = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), (e.prototype.record = function (t, e) {}), e;
+    })(D),
+    U = (function () {
+      function t() {}
+      return (
+        (t.prototype.addCallback = function (t) {}),
+        (t.prototype.removeCallback = function (t) {}),
+        t
+      );
+    })(),
+    B = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), e;
+    })(U),
+    F = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), e;
+    })(U),
+    H = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), e;
+    })(U),
+    V = new L(),
+    $ = new I(),
+    z = new k(),
+    q = new j(),
+    G = new M(),
+    K = new B(),
+    W = new F(),
+    X = new H(),
+    Q = {
+      get: function (t, e) {
+        if (null != t) return t[e];
+      },
+      keys: function (t) {
+        return null == t ? [] : Object.keys(t);
+      },
+    },
+    Y = {
+      set: function (t, e, n) {
+        null != t && (t[e] = n);
+      },
+    },
+    Z = function (t, e) {
+      var n = "function" == typeof Symbol && t[Symbol.iterator];
+      if (!n) return t;
+      var r,
+        o,
+        i = n.call(t),
+        s = [];
+      try {
+        for (; (void 0 === e || e-- > 0) && !(r = i.next()).done; )
+          s.push(r.value);
+      } catch (t) {
+        o = { error: t };
+      } finally {
+        try {
+          r && !r.done && (n = i.return) && n.call(i);
+        } finally {
+          if (o) throw o.error;
+        }
+      }
+      return s;
+    },
+    J = function (t, e, n) {
+      if (n || 2 === arguments.length)
+        for (var r, o = 0, i = e.length; o < i; o++)
+          (!r && o in e) ||
+            (r || (r = Array.prototype.slice.call(e, 0, o)), (r[o] = e[o]));
+      return t.concat(r || Array.prototype.slice.call(e));
+    },
+    tt = (function () {
+      function t() {}
+      return (
+        (t.prototype.active = function () {
+          return x;
+        }),
+        (t.prototype.with = function (t, e, n) {
+          for (var r = [], o = 3; o < arguments.length; o++)
+            r[o - 3] = arguments[o];
+          return e.call.apply(e, J([n], Z(r), !1));
+        }),
+        (t.prototype.bind = function (t, e) {
+          return e;
+        }),
+        (t.prototype.enable = function () {
+          return this;
+        }),
+        (t.prototype.disable = function () {
+          return this;
+        }),
+        t
+      );
+    })(),
+    et = function (t, e) {
+      var n = "function" == typeof Symbol && t[Symbol.iterator];
+      if (!n) return t;
+      var r,
+        o,
+        i = n.call(t),
+        s = [];
+      try {
+        for (; (void 0 === e || e-- > 0) && !(r = i.next()).done; )
+          s.push(r.value);
+      } catch (t) {
+        o = { error: t };
+      } finally {
+        try {
+          r && !r.done && (n = i.return) && n.call(i);
+        } finally {
+          if (o) throw o.error;
+        }
+      }
+      return s;
+    },
+    nt = function (t, e, n) {
+      if (n || 2 === arguments.length)
+        for (var r, o = 0, i = e.length; o < i; o++)
+          (!r && o in e) ||
+            (r || (r = Array.prototype.slice.call(e, 0, o)), (r[o] = e[o]));
+      return t.concat(r || Array.prototype.slice.call(e));
+    },
+    rt = "context",
+    ot = new tt(),
+    it = (function () {
+      function t() {}
+      return (
+        (t.getInstance = function () {
+          return this._instance || (this._instance = new t()), this._instance;
+        }),
+        (t.prototype.setGlobalContextManager = function (t) {
+          return c(rt, t, y.instance());
+        }),
+        (t.prototype.active = function () {
+          return this._getContextManager().active();
+        }),
+        (t.prototype.with = function (t, e, n) {
+          for (var r, o = [], i = 3; i < arguments.length; i++)
+            o[i - 3] = arguments[i];
+          return (r = this._getContextManager()).with.apply(
+            r,
+            nt([t, e, n], et(o), !1)
+          );
+        }),
+        (t.prototype.bind = function (t, e) {
+          return this._getContextManager().bind(t, e);
+        }),
+        (t.prototype._getContextManager = function () {
+          return l(rt) || ot;
+        }),
+        (t.prototype.disable = function () {
+          this._getContextManager().disable(), p(rt, y.instance());
+        }),
+        t
+      );
+    })();
+  !(function (t) {
+    (t[(t.NONE = 0)] = "NONE"), (t[(t.SAMPLED = 1)] = "SAMPLED");
+  })(R || (R = {}));
+  var st = "0000000000000000",
+    at = "00000000000000000000000000000000",
+    ut = { traceId: at, spanId: st, traceFlags: R.NONE },
+    ct = (function () {
+      function t(t) {
+        void 0 === t && (t = ut), (this._spanContext = t);
+      }
+      return (
+        (t.prototype.spanContext = function () {
+          return this._spanContext;
+        }),
+        (t.prototype.setAttribute = function (t, e) {
+          return this;
+        }),
+        (t.prototype.setAttributes = function (t) {
+          return this;
+        }),
+        (t.prototype.addEvent = function (t, e) {
+          return this;
+        }),
+        (t.prototype.addLink = function (t) {
+          return this;
+        }),
+        (t.prototype.addLinks = function (t) {
+          return this;
+        }),
+        (t.prototype.setStatus = function (t) {
+          return this;
+        }),
+        (t.prototype.updateName = function (t) {
+          return this;
+        }),
+        (t.prototype.end = function (t) {}),
+        (t.prototype.isRecording = function () {
+          return !1;
+        }),
+        (t.prototype.recordException = function (t, e) {}),
+        t
+      );
+    })(),
+    lt = A("OpenTelemetry Context Key SPAN");
+  function pt(t) {
+    return t.getValue(lt) || void 0;
+  }
+  function dt() {
+    return pt(it.getInstance().active());
+  }
+  function ht(t, e) {
+    return t.setValue(lt, e);
+  }
+  function ft(t) {
+    return t.deleteValue(lt);
+  }
+  function gt(t, e) {
+    return ht(t, new ct(e));
+  }
+  function mt(t) {
+    var e;
+    return null === (e = pt(t)) || void 0 === e ? void 0 : e.spanContext();
+  }
+  var _t = /^([0-9a-f]{32})$/i,
+    vt = /^[0-9a-f]{16}$/i;
+  function yt(t) {
+    return _t.test(t) && t !== at;
+  }
+  function St(t) {
+    return yt(t.traceId) && ((e = t.spanId), vt.test(e) && e !== st);
+    var e;
+  }
+  function bt(t) {
+    return new ct(t);
+  }
+  var Et = it.getInstance(),
+    Tt = (function () {
+      function t() {}
+      return (
+        (t.prototype.startSpan = function (t, e, n) {
+          if (
+            (void 0 === n && (n = Et.active()),
+            Boolean(null == e ? void 0 : e.root))
+          )
+            return new ct();
+          var r,
+            o = n && mt(n);
+          return "object" == typeof (r = o) &&
+            "string" == typeof r.spanId &&
+            "string" == typeof r.traceId &&
+            "number" == typeof r.traceFlags &&
+            St(o)
+            ? new ct(o)
+            : new ct();
+        }),
+        (t.prototype.startActiveSpan = function (t, e, n, r) {
+          var o, i, s;
+          if (!(arguments.length < 2)) {
+            2 === arguments.length
+              ? (s = e)
+              : 3 === arguments.length
+              ? ((o = e), (s = n))
+              : ((o = e), (i = n), (s = r));
+            var a = null != i ? i : Et.active(),
+              u = this.startSpan(t, o, a),
+              c = ht(a, u);
+            return Et.with(c, s, void 0, u);
+          }
+        }),
+        t
+      );
+    })();
+  var wt,
+    Ct,
+    At,
+    Ot = new Tt(),
+    Rt = (function () {
+      function t(t, e, n, r) {
+        (this._provider = t),
+          (this.name = e),
+          (this.version = n),
+          (this.options = r);
+      }
+      return (
+        (t.prototype.startSpan = function (t, e, n) {
+          return this._getTracer().startSpan(t, e, n);
+        }),
+        (t.prototype.startActiveSpan = function (t, e, n, r) {
+          var o = this._getTracer();
+          return Reflect.apply(o.startActiveSpan, o, arguments);
+        }),
+        (t.prototype._getTracer = function () {
+          if (this._delegate) return this._delegate;
+          var t = this._provider.getDelegateTracer(
+            this.name,
+            this.version,
+            this.options
+          );
+          return t ? ((this._delegate = t), this._delegate) : Ot;
+        }),
+        t
+      );
+    })(),
+    Nt = new ((function () {
+      function t() {}
+      return (
+        (t.prototype.getTracer = function (t, e, n) {
+          return new Tt();
+        }),
+        t
+      );
+    })())(),
+    xt = (function () {
+      function t() {}
+      return (
+        (t.prototype.getTracer = function (t, e, n) {
+          var r;
+          return null !== (r = this.getDelegateTracer(t, e, n)) && void 0 !== r
+            ? r
+            : new Rt(this, t, e, n);
+        }),
+        (t.prototype.getDelegate = function () {
+          var t;
+          return null !== (t = this._delegate) && void 0 !== t ? t : Nt;
+        }),
+        (t.prototype.setDelegate = function (t) {
+          this._delegate = t;
+        }),
+        (t.prototype.getDelegateTracer = function (t, e, n) {
+          var r;
+          return null === (r = this._delegate) || void 0 === r
+            ? void 0
+            : r.getTracer(t, e, n);
+        }),
+        t
+      );
+    })();
+  !(function (t) {
+    (t[(t.NOT_RECORD = 0)] = "NOT_RECORD"),
+      (t[(t.RECORD = 1)] = "RECORD"),
+      (t[(t.RECORD_AND_SAMPLED = 2)] = "RECORD_AND_SAMPLED");
+  })(wt || (wt = {})),
+    (function (t) {
+      (t[(t.INTERNAL = 0)] = "INTERNAL"),
+        (t[(t.SERVER = 1)] = "SERVER"),
+        (t[(t.CLIENT = 2)] = "CLIENT"),
+        (t[(t.PRODUCER = 3)] = "PRODUCER"),
+        (t[(t.CONSUMER = 4)] = "CONSUMER");
+    })(Ct || (Ct = {})),
+    (function (t) {
+      (t[(t.UNSET = 0)] = "UNSET"),
+        (t[(t.OK = 1)] = "OK"),
+        (t[(t.ERROR = 2)] = "ERROR");
+    })(At || (At = {}));
+  var Pt = it.getInstance(),
+    Lt = y.instance(),
+    Dt = new ((function () {
+      function t() {}
+      return (
+        (t.prototype.getMeter = function (t, e, n) {
+          return V;
+        }),
+        t
+      );
+    })())(),
+    It = "metrics",
+    Mt = (function () {
+      function t() {}
+      return (
+        (t.getInstance = function () {
+          return this._instance || (this._instance = new t()), this._instance;
+        }),
+        (t.prototype.setGlobalMeterProvider = function (t) {
+          return c(It, t, y.instance());
+        }),
+        (t.prototype.getMeterProvider = function () {
+          return l(It) || Dt;
+        }),
+        (t.prototype.getMeter = function (t, e, n) {
+          return this.getMeterProvider().getMeter(t, e, n);
+        }),
+        (t.prototype.disable = function () {
+          p(It, y.instance());
+        }),
+        t
+      );
+    })().getInstance(),
+    kt = (function () {
+      function t() {}
+      return (
+        (t.prototype.inject = function (t, e) {}),
+        (t.prototype.extract = function (t, e) {
+          return t;
+        }),
+        (t.prototype.fields = function () {
+          return [];
+        }),
+        t
+      );
+    })(),
+    jt = A("OpenTelemetry Baggage Key");
+  function Ut(t) {
+    return t.getValue(jt) || void 0;
+  }
+  function Bt() {
+    return Ut(it.getInstance().active());
+  }
+  function Ft(t, e) {
+    return t.setValue(jt, e);
+  }
+  function Ht(t) {
+    return t.deleteValue(jt);
+  }
+  var Vt = "propagation",
+    $t = new kt(),
+    zt = (function () {
+      function t() {
+        (this.createBaggage = C),
+          (this.getBaggage = Ut),
+          (this.getActiveBaggage = Bt),
+          (this.setBaggage = Ft),
+          (this.deleteBaggage = Ht);
+      }
+      return (
+        (t.getInstance = function () {
+          return this._instance || (this._instance = new t()), this._instance;
+        }),
+        (t.prototype.setGlobalPropagator = function (t) {
+          return c(Vt, t, y.instance());
+        }),
+        (t.prototype.inject = function (t, e, n) {
+          return (
+            void 0 === n && (n = Y), this._getGlobalPropagator().inject(t, e, n)
+          );
+        }),
+        (t.prototype.extract = function (t, e, n) {
+          return (
+            void 0 === n && (n = Q),
+            this._getGlobalPropagator().extract(t, e, n)
+          );
+        }),
+        (t.prototype.fields = function () {
+          return this._getGlobalPropagator().fields();
+        }),
+        (t.prototype.disable = function () {
+          p(Vt, y.instance());
+        }),
+        (t.prototype._getGlobalPropagator = function () {
+          return l(Vt) || $t;
+        }),
+        t
+      );
+    })(),
+    qt = zt.getInstance(),
+    Gt = "trace",
+    Kt = (function () {
+      function t() {
+        (this._proxyTracerProvider = new xt()),
+          (this.wrapSpanContext = bt),
+          (this.isSpanContextValid = St),
+          (this.deleteSpan = ft),
+          (this.getSpan = pt),
+          (this.getActiveSpan = dt),
+          (this.getSpanContext = mt),
+          (this.setSpan = ht),
+          (this.setSpanContext = gt);
+      }
+      return (
+        (t.getInstance = function () {
+          return this._instance || (this._instance = new t()), this._instance;
+        }),
+        (t.prototype.setGlobalTracerProvider = function (t) {
+          var e = c(Gt, this._proxyTracerProvider, y.instance());
+          return e && this._proxyTracerProvider.setDelegate(t), e;
+        }),
+        (t.prototype.getTracerProvider = function () {
+          return l(Gt) || this._proxyTracerProvider;
+        }),
+        (t.prototype.getTracer = function (t, e) {
+          return this.getTracerProvider().getTracer(t, e);
+        }),
+        (t.prototype.disable = function () {
+          p(Gt, y.instance()), (this._proxyTracerProvider = new xt());
+        }),
+        t
+      );
+    })().getInstance();
+  const Wt = A("OpenTelemetry SDK Context Key SUPPRESS_TRACING");
+  function Xt(t) {
+    return t.setValue(Wt, !0);
+  }
+  function Qt(t) {
+    return !0 === t.getValue(Wt);
+  }
+  const Yt = "=",
+    Zt = ";",
+    Jt = ",",
+    te = "baggage";
+  function ee(t) {
+    const e = t.split(Zt);
+    if (e.length <= 0) return;
+    const n = e.shift();
+    if (!n) return;
+    const r = n.indexOf(Yt);
+    if (r <= 0) return;
+    const o = decodeURIComponent(n.substring(0, r).trim()),
+      i = decodeURIComponent(n.substring(r + 1).trim());
+    let s;
+    var a;
+    return (
+      e.length > 0 &&
+        ("string" != typeof (a = e.join(Zt)) &&
+          (w.error(
+            "Cannot create baggage metadata from unknown type: " + typeof a
+          ),
+          (a = "")),
+        (s = {
+          __TYPE__: T,
+          toString: function () {
+            return a;
+          },
+        })),
+      { key: o, value: i, metadata: s }
+    );
+  }
+  class ne {
+    inject(t, e, n) {
+      const r = qt.getBaggage(t);
+      if (!r || Qt(t)) return;
+      const o = (function (t) {
+          return t.getAllEntries().map(([t, e]) => {
+            let n = `${encodeURIComponent(t)}=${encodeURIComponent(e.value)}`;
+            return (
+              void 0 !== e.metadata && (n += Zt + e.metadata.toString()), n
+            );
+          });
+        })(r)
+          .filter((t) => t.length <= 4096)
+          .slice(0, 180),
+        i = (function (t) {
+          return t.reduce((t, e) => {
+            const n = `${t}${"" !== t ? Jt : ""}${e}`;
+            return n.length > 8192 ? t : n;
+          }, "");
+        })(o);
+      i.length > 0 && n.set(e, te, i);
+    }
+    extract(t, e, n) {
+      const r = n.get(e, te),
+        o = Array.isArray(r) ? r.join(Jt) : r;
+      if (!o) return t;
+      const i = {};
+      if (0 === o.length) return t;
+      return (
+        o.split(Jt).forEach((t) => {
+          const e = ee(t);
+          if (e) {
+            const t = { value: e.value };
+            e.metadata && (t.metadata = e.metadata), (i[e.key] = t);
+          }
+        }),
+        0 === Object.entries(i).length
+          ? t
+          : qt.setBaggage(t, qt.createBaggage(i))
+      );
+    }
+    fields() {
+      return [te];
+    }
+  }
+  function re(t) {
+    const e = {};
+    if ("object" != typeof t || null == t) return e;
+    for (const [n, r] of Object.entries(t))
+      oe(n)
+        ? ie(r)
+          ? Array.isArray(r)
+            ? (e[n] = r.slice())
+            : (e[n] = r)
+          : Lt.warn(`Invalid attribute value set for key: ${n}`)
+        : Lt.warn(`Invalid attribute key: ${n}`);
+    return e;
+  }
+  function oe(t) {
+    return "string" == typeof t && t.length > 0;
+  }
+  function ie(t) {
+    return (
+      null == t ||
+      (Array.isArray(t)
+        ? (function (t) {
+            let e;
+            for (const n of t)
+              if (null != n) {
+                if (!e) {
+                  if (se(n)) {
+                    e = typeof n;
+                    continue;
+                  }
+                  return !1;
+                }
+                if (typeof n !== e) return !1;
+              }
+            return !0;
+          })(t)
+        : se(t))
+    );
+  }
+  function se(t) {
+    switch (typeof t) {
+      case "number":
+      case "boolean":
+      case "string":
+        return !0;
+    }
+    return !1;
+  }
+  function ae() {
+    return (t) => {
+      Lt.error(
+        (function (t) {
+          return "string" == typeof t
+            ? t
+            : JSON.stringify(
+                (function (t) {
+                  const e = {};
+                  let n = t;
+                  for (; null !== n; )
+                    Object.getOwnPropertyNames(n).forEach((t) => {
+                      if (e[t]) return;
+                      const r = n[t];
+                      r && (e[t] = String(r));
+                    }),
+                      (n = Object.getPrototypeOf(n));
+                  return e;
+                })(t)
+              );
+        })(t)
+      );
+    };
+  }
+  let ue = ae();
+  function ce(t) {
+    try {
+      ue(t);
+    } catch {}
+  }
+  function le(t) {}
+  const pe =
+      "object" == typeof globalThis
+        ? globalThis
+        : "object" == typeof self
+        ? self
+        : "object" == typeof window
+        ? window
+        : "object" == typeof global
+        ? global
+        : {},
+    de = performance,
+    he = "exception.type",
+    fe = "exception.message",
+    ge = "http.method",
+    me = "http.url",
+    _e = "http.host",
+    ve = "http.scheme",
+    ye = "http.status_code",
+    Se = "http.user_agent",
+    be = "http.request_content_length_uncompressed",
+    Ee = "process.runtime.name",
+    Te = "telemetry.sdk.name",
+    we = "telemetry.sdk.language",
+    Ce = "telemetry.sdk.version",
+    Ae = "service.name",
+    Oe = "telemetry.sdk.language",
+    Re = "telemetry.sdk.name",
+    Ne = "telemetry.sdk.version",
+    xe = {
+      [Te]: "opentelemetry",
+      [Ee]: "browser",
+      [we]: "webjs",
+      [Ce]: "2.0.0",
+    };
+  function Pe(t) {}
+  const Le = Math.pow(10, 6),
+    De = Math.pow(10, 9);
+  function Ie(t) {
+    const e = t / 1e3;
+    return [Math.trunc(e), Math.round((t % 1e3) * Le)];
+  }
+  function Me() {
+    let t = de.timeOrigin;
+    if ("number" != typeof t) {
+      const e = de;
+      t = e.timing && e.timing.fetchStart;
+    }
+    return t;
+  }
+  function ke(t) {
+    return Ve(Ie(Me()), Ie("number" == typeof t ? t : de.now()));
+  }
+  function je(t) {
+    if (Fe(t)) return t;
+    if ("number" == typeof t) return t < Me() ? ke(t) : Ie(t);
+    if (t instanceof Date) return Ie(t.getTime());
+    throw TypeError("Invalid input type");
+  }
+  function Ue(t, e) {
+    let n = e[0] - t[0],
+      r = e[1] - t[1];
+    return r < 0 && ((n -= 1), (r += De)), [n, r];
+  }
+  function Be(t) {
+    return t[0] * De + t[1];
+  }
+  function Fe(t) {
+    return (
+      Array.isArray(t) &&
+      2 === t.length &&
+      "number" == typeof t[0] &&
+      "number" == typeof t[1]
+    );
+  }
+  function He(t) {
+    return Fe(t) || "number" == typeof t || t instanceof Date;
+  }
+  function Ve(t, e) {
+    const n = [t[0] + e[0], t[1] + e[1]];
+    return n[1] >= De && ((n[1] -= De), (n[0] += 1)), n;
+  }
+  var $e;
+  !(function (t) {
+    (t[(t.SUCCESS = 0)] = "SUCCESS"), (t[(t.FAILED = 1)] = "FAILED");
+  })($e || ($e = {}));
+  class ze {
+    _propagators;
+    _fields;
+    constructor(t = {}) {
+      (this._propagators = t.propagators ?? []),
+        (this._fields = Array.from(
+          new Set(
+            this._propagators
+              .map((t) => ("function" == typeof t.fields ? t.fields() : []))
+              .reduce((t, e) => t.concat(e), [])
+          )
+        ));
+    }
+    inject(t, e, n) {
+      for (const r of this._propagators)
+        try {
+          r.inject(t, e, n);
+        } catch (t) {
+          Lt.warn(
+            `Failed to inject with ${r.constructor.name}. Err: ${t.message}`
+          );
+        }
+    }
+    extract(t, e, n) {
+      return this._propagators.reduce((t, r) => {
+        try {
+          return r.extract(t, e, n);
+        } catch (t) {
+          Lt.warn(
+            `Failed to extract with ${r.constructor.name}. Err: ${t.message}`
+          );
+        }
+        return t;
+      }, t);
+    }
+    fields() {
+      return this._fields.slice();
+    }
+  }
+  const qe = "[_0-9a-z-*/]",
+    Ge = new RegExp(
+      `^(?:${`[a-z]${qe}{0,255}`}|${`[a-z0-9]${qe}{0,240}@[a-z]${qe}{0,13}`})$`
+    ),
+    Ke = /^[ -~]{0,255}[!-~]$/,
+    We = /,|=/;
+  class Xe {
+    _internalState = new Map();
+    constructor(t) {
+      t && this._parse(t);
+    }
+    set(t, e) {
+      const n = this._clone();
+      return (
+        n._internalState.has(t) && n._internalState.delete(t),
+        n._internalState.set(t, e),
+        n
+      );
+    }
+    unset(t) {
+      const e = this._clone();
+      return e._internalState.delete(t), e;
+    }
+    get(t) {
+      return this._internalState.get(t);
+    }
+    serialize() {
+      return this._keys()
+        .reduce((t, e) => (t.push(e + "=" + this.get(e)), t), [])
+        .join(",");
+    }
+    _parse(t) {
+      t.length > 512 ||
+        ((this._internalState = t
+          .split(",")
+          .reverse()
+          .reduce((t, e) => {
+            const n = e.trim(),
+              r = n.indexOf("=");
+            if (-1 !== r) {
+              const o = n.slice(0, r),
+                i = n.slice(r + 1, e.length);
+              (function (t) {
+                return Ge.test(t);
+              })(o) &&
+                (function (t) {
+                  return Ke.test(t) && !We.test(t);
+                })(i) &&
+                t.set(o, i);
+            }
+            return t;
+          }, new Map())),
+        this._internalState.size > 32 &&
+          (this._internalState = new Map(
+            Array.from(this._internalState.entries()).reverse().slice(0, 32)
+          )));
+    }
+    _keys() {
+      return Array.from(this._internalState.keys()).reverse();
+    }
+    _clone() {
+      const t = new Xe();
+      return (t._internalState = new Map(this._internalState)), t;
+    }
+  }
+  const Qe = "traceparent",
+    Ye = "tracestate",
+    Ze = new RegExp(
+      "^\\s?((?!ff)[\\da-f]{2})-((?![0]{32})[\\da-f]{32})-((?![0]{16})[\\da-f]{16})-([\\da-f]{2})(-.*)?\\s?$"
+    );
+  function Je(t) {
+    const e = Ze.exec(t);
+    return e
+      ? "00" === e[1] && e[5]
+        ? null
+        : { traceId: e[2], spanId: e[3], traceFlags: parseInt(e[4], 16) }
+      : null;
+  }
+  class tn {
+    inject(t, e, n) {
+      const r = Kt.getSpanContext(t);
+      if (!r || Qt(t) || !St(r)) return;
+      const o = `00-${r.traceId}-${r.spanId}-0${Number(
+        r.traceFlags || R.NONE
+      ).toString(16)}`;
+      n.set(e, Qe, o), r.traceState && n.set(e, Ye, r.traceState.serialize());
+    }
+    extract(t, e, n) {
+      const r = n.get(e, Qe);
+      if (!r) return t;
+      const o = Array.isArray(r) ? r[0] : r;
+      if ("string" != typeof o) return t;
+      const i = Je(o);
+      if (!i) return t;
+      i.isRemote = !0;
+      const s = n.get(e, Ye);
+      if (s) {
+        const t = Array.isArray(s) ? s.join(",") : s;
+        i.traceState = new Xe("string" == typeof t ? t : void 0);
+      }
+      return Kt.setSpanContext(t, i);
+    }
+    fields() {
+      return [Qe, Ye];
+    }
+  }
+  const en = A("OpenTelemetry SDK Context Key RPC_METADATA");
+  var nn;
+  !(function (t) {
+    t.HTTP = "http";
+  })(nn || (nn = {}));
+  const rn = "[object Object]",
+    on = "[object Null]",
+    sn = "[object Undefined]",
+    an = Function.prototype.toString,
+    un = an.call(Object),
+    cn = Object.getPrototypeOf,
+    ln = Object.prototype,
+    pn = ln.hasOwnProperty,
+    dn = Symbol ? Symbol.toStringTag : void 0,
+    hn = ln.toString;
+  function fn(t) {
+    if (
+      !(function (t) {
+        return null != t && "object" == typeof t;
+      })(t) ||
+      (function (t) {
+        if (null == t) return void 0 === t ? sn : on;
+        return dn && dn in Object(t)
+          ? (function (t) {
+              const e = pn.call(t, dn),
+                n = t[dn];
+              let r = !1;
+              try {
+                (t[dn] = void 0), (r = !0);
+              } catch (t) {}
+              const o = hn.call(t);
+              r && (e ? (t[dn] = n) : delete t[dn]);
+              return o;
+            })(t)
+          : (function (t) {
+              return hn.call(t);
+            })(t);
+      })(t) !== rn
+    )
+      return !1;
+    const e = cn(t);
+    if (null === e) return !0;
+    const n = pn.call(e, "constructor") && e.constructor;
+    return "function" == typeof n && n instanceof n && an.call(n) === un;
+  }
+  const gn = 20;
+  function mn(...t) {
+    let e = t.shift();
+    const n = new WeakMap();
+    for (; t.length > 0; ) e = vn(e, t.shift(), 0, n);
+    return e;
+  }
+  function _n(t) {
+    return Sn(t) ? t.slice() : t;
+  }
+  function vn(t, e, n = 0, r) {
+    let o;
+    if (!(n > gn)) {
+      if ((n++, Tn(t) || Tn(e) || bn(e))) o = _n(e);
+      else if (Sn(t)) {
+        if (((o = t.slice()), Sn(e)))
+          for (let t = 0, n = e.length; t < n; t++) o.push(_n(e[t]));
+        else if (En(e)) {
+          const t = Object.keys(e);
+          for (let n = 0, r = t.length; n < r; n++) {
+            const r = t[n];
+            o[r] = _n(e[r]);
+          }
+        }
+      } else if (En(t))
+        if (En(e)) {
+          if (
+            !(function (t, e) {
+              if (!fn(t) || !fn(e)) return !1;
+              return !0;
+            })(t, e)
+          )
+            return e;
+          o = Object.assign({}, t);
+          const i = Object.keys(e);
+          for (let s = 0, a = i.length; s < a; s++) {
+            const a = i[s],
+              u = e[a];
+            if (Tn(u)) void 0 === u ? delete o[a] : (o[a] = u);
+            else {
+              const i = o[a],
+                s = u;
+              if (yn(t, a, r) || yn(e, a, r)) delete o[a];
+              else {
+                if (En(i) && En(s)) {
+                  const n = r.get(i) || [],
+                    o = r.get(s) || [];
+                  n.push({ obj: t, key: a }),
+                    o.push({ obj: e, key: a }),
+                    r.set(i, n),
+                    r.set(s, o);
+                }
+                o[a] = vn(o[a], u, n, r);
+              }
+            }
+          }
+        } else o = e;
+      return o;
+    }
+  }
+  function yn(t, e, n) {
+    const r = n.get(t[e]) || [];
+    for (let n = 0, o = r.length; n < o; n++) {
+      const o = r[n];
+      if (o.key === e && o.obj === t) return !0;
+    }
+    return !1;
+  }
+  function Sn(t) {
+    return Array.isArray(t);
+  }
+  function bn(t) {
+    return "function" == typeof t;
+  }
+  function En(t) {
+    return !Tn(t) && !Sn(t) && !bn(t) && "object" == typeof t;
+  }
+  function Tn(t) {
+    return (
+      "string" == typeof t ||
+      "number" == typeof t ||
+      "boolean" == typeof t ||
+      void 0 === t ||
+      t instanceof Date ||
+      t instanceof RegExp ||
+      null === t
+    );
+  }
+  class wn extends Error {
+    constructor(t) {
+      super(t), Object.setPrototypeOf(this, wn.prototype);
+    }
+  }
+  function Cn(t, e) {
+    return "string" == typeof e ? t === e : !!t.match(e);
+  }
+  function An(t, e) {
+    if (!e) return !1;
+    for (const n of e) if (Cn(t, n)) return !0;
+    return !1;
+  }
+  class On {
+    _promise;
+    _resolve;
+    _reject;
+    constructor() {
+      this._promise = new Promise((t, e) => {
+        (this._resolve = t), (this._reject = e);
+      });
+    }
+    get promise() {
+      return this._promise;
+    }
+    resolve(t) {
+      this._resolve(t);
+    }
+    reject(t) {
+      this._reject(t);
+    }
+  }
+  class Rn {
+    _callback;
+    _that;
+    _isCalled = !1;
+    _deferred = new On();
+    constructor(t, e) {
+      (this._callback = t), (this._that = e);
+    }
+    get isCalled() {
+      return this._isCalled;
+    }
+    get promise() {
+      return this._deferred.promise;
+    }
+    call(...t) {
+      if (!this._isCalled) {
+        this._isCalled = !0;
+        try {
+          Promise.resolve(this._callback.call(this._that, ...t)).then(
+            (t) => this._deferred.resolve(t),
+            (t) => this._deferred.reject(t)
+          );
+        } catch (t) {
+          this._deferred.reject(t);
+        }
+      }
+      return this._deferred.promise;
+    }
+  }
+  const Nn = {
+    ALL: d.ALL,
+    VERBOSE: d.VERBOSE,
+    DEBUG: d.DEBUG,
+    INFO: d.INFO,
+    WARN: d.WARN,
+    ERROR: d.ERROR,
+    NONE: d.NONE,
+  };
+  const xn = {
+    _export: function (t, e) {
+      return new Promise((n) => {
+        Pt.with(Xt(Pt.active()), () => {
+          t.export(e, (t) => {
+            n(t);
+          });
+        });
+      });
+    },
+  };
+  var Pn = Object.freeze({
+    __proto__: null,
+    AnchoredClock: class {
+      _monotonicClock;
+      _epochMillis;
+      _performanceMillis;
+      constructor(t, e) {
+        (this._monotonicClock = e),
+          (this._epochMillis = t.now()),
+          (this._performanceMillis = e.now());
+      }
+      now() {
+        const t = this._monotonicClock.now() - this._performanceMillis;
+        return this._epochMillis + t;
+      }
+    },
+    BindOnceFuture: Rn,
+    CompositePropagator: ze,
+    get ExportResultCode() {
+      return $e;
+    },
+    get RPCType() {
+      return nn;
+    },
+    SDK_INFO: xe,
+    TRACE_PARENT_HEADER: Qe,
+    TRACE_STATE_HEADER: Ye,
+    TimeoutError: wn,
+    TraceState: Xe,
+    W3CBaggagePropagator: ne,
+    W3CTraceContextPropagator: tn,
+    _globalThis: pe,
+    addHrTimes: Ve,
+    callWithTimeout: function (t, e) {
+      let n;
+      const r = new Promise(function (t, r) {
+        n = setTimeout(function () {
+          r(new wn("Operation timed out."));
+        }, e);
+      });
+      return Promise.race([t, r]).then(
+        (t) => (clearTimeout(n), t),
+        (t) => {
+          throw (clearTimeout(n), t);
+        }
+      );
+    },
+    deleteRPCMetadata: function (t) {
+      return t.deleteValue(en);
+    },
+    diagLogLevelFromString: function (t) {
+      if (null == t) return;
+      const e = Nn[t.toUpperCase()];
+      return null == e
+        ? (Lt.warn(
+            `Unknown log level "${t}", expected one of ${Object.keys(
+              Nn
+            )}, using default`
+          ),
+          d.INFO)
+        : e;
+    },
+    getBooleanFromEnv: function (t) {},
+    getNumberFromEnv: le,
+    getRPCMetadata: function (t) {
+      return t.getValue(en);
+    },
+    getStringFromEnv: function (t) {},
+    getStringListFromEnv: function (t) {},
+    getTimeOrigin: Me,
+    globalErrorHandler: ce,
+    hrTime: ke,
+    hrTimeDuration: Ue,
+    hrTimeToMicroseconds: function (t) {
+      return 1e6 * t[0] + t[1] / 1e3;
+    },
+    hrTimeToMilliseconds: function (t) {
+      return 1e3 * t[0] + t[1] / 1e6;
+    },
+    hrTimeToNanoseconds: Be,
+    hrTimeToTimeStamp: function (t) {
+      const e = `${"0".repeat(9)}${t[1]}Z`,
+        n = e.substring(e.length - 9 - 1);
+      return new Date(1e3 * t[0]).toISOString().replace("000Z", n);
+    },
+    internal: xn,
+    isAttributeValue: ie,
+    isTimeInput: He,
+    isTimeInputHrTime: Fe,
+    isTracingSuppressed: Qt,
+    isUrlIgnored: An,
+    loggingErrorHandler: ae,
+    merge: mn,
+    millisToHrTime: Ie,
+    otperformance: de,
+    parseKeyPairsIntoRecord: function (t) {
+      return "string" != typeof t || 0 === t.length
+        ? {}
+        : t
+            .split(Jt)
+            .map((t) => ee(t))
+            .filter((t) => void 0 !== t && t.value.length > 0)
+            .reduce((t, e) => ((t[e.key] = e.value), t), {});
+    },
+    parseTraceParent: Je,
+    sanitizeAttributes: re,
+    setGlobalErrorHandler: function (t) {
+      ue = t;
+    },
+    setRPCMetadata: function (t, e) {
+      return t.setValue(en, e);
+    },
+    suppressTracing: Xt,
+    timeInputToHrTime: je,
+    unrefTimer: Pe,
+    unsuppressTracing: function (t) {
+      return t.deleteValue(Wt);
+    },
+    urlMatches: Cn,
+  });
+  function Ln(t) {
+    if (Object.prototype.hasOwnProperty.call(t, "__esModule")) return t;
+    var e = t.default;
+    if ("function" == typeof e) {
+      var n = function t() {
+        return this instanceof t
+          ? Reflect.construct(e, arguments, this.constructor)
+          : e.apply(this, arguments);
+      };
+      n.prototype = e.prototype;
+    } else n = {};
+    return (
+      Object.defineProperty(n, "__esModule", { value: !0 }),
+      Object.keys(t).forEach(function (e) {
+        var r = Object.getOwnPropertyDescriptor(t, e);
+        Object.defineProperty(
+          n,
+          e,
+          r.get
+            ? r
+            : {
+                enumerable: !0,
+                get: function () {
+                  return t[e];
+                },
+              }
+        );
+      }),
+      n
+    );
+  }
+  var Dn,
+    In = {},
+    Mn = {};
+  function kn() {
+    if (Dn) return Mn;
+    function t(t) {
+      return Object.keys(t).map((n) => e(n, t[n]));
+    }
+    function e(t, e) {
+      return { key: t, value: n(e) };
+    }
+    function n(t) {
+      const r = typeof t;
+      return "string" === r
+        ? { stringValue: t }
+        : "number" === r
+        ? Number.isInteger(t)
+          ? { intValue: t }
+          : { doubleValue: t }
+        : "boolean" === r
+        ? { boolValue: t }
+        : t instanceof Uint8Array
+        ? { bytesValue: t }
+        : Array.isArray(t)
+        ? { arrayValue: { values: t.map(n) } }
+        : "object" === r && null != t
+        ? {
+            kvlistValue: { values: Object.entries(t).map(([t, n]) => e(t, n)) },
+          }
+        : {};
+    }
+    return (
+      (Dn = 1),
+      Object.defineProperty(Mn, "__esModule", { value: !0 }),
+      (Mn.toAnyValue =
+        Mn.toKeyValue =
+        Mn.toAttributes =
+        Mn.createInstrumentationScope =
+        Mn.createResource =
+          void 0),
+      (Mn.createResource = function (e) {
+        return { attributes: t(e.attributes), droppedAttributesCount: 0 };
+      }),
+      (Mn.createInstrumentationScope = function (t) {
+        return { name: t.name, version: t.version };
+      }),
+      (Mn.toAttributes = t),
+      (Mn.toKeyValue = e),
+      (Mn.toAnyValue = n),
+      Mn
+    );
+  }
+  var jn,
+    Un,
+    Bn,
+    Fn = {},
+    Hn = Ln(Pn),
+    Vn = {};
+  function $n() {
+    if (jn) return Vn;
+    function t(t) {
+      return t >= 48 && t <= 57
+        ? t - 48
+        : t >= 97 && t <= 102
+        ? t - 87
+        : t - 55;
+    }
+    return (
+      (jn = 1),
+      Object.defineProperty(Vn, "__esModule", { value: !0 }),
+      (Vn.hexToBinary = void 0),
+      (Vn.hexToBinary = function (e) {
+        const n = new Uint8Array(e.length / 2);
+        let r = 0;
+        for (let o = 0; o < e.length; o += 2) {
+          const i = t(e.charCodeAt(o)),
+            s = t(e.charCodeAt(o + 1));
+          n[r++] = (i << 4) | s;
+        }
+        return n;
+      }),
+      Vn
+    );
+  }
+  function zn() {
+    if (Un) return Fn;
+    (Un = 1),
+      Object.defineProperty(Fn, "__esModule", { value: !0 }),
+      (Fn.getOtlpEncoder =
+        Fn.encodeAsString =
+        Fn.encodeAsLongBits =
+        Fn.toLongBits =
+        Fn.hrTimeToNanos =
+          void 0);
+    const t = Hn,
+      e = $n();
+    function n(t) {
+      const e = BigInt(1e9);
+      return BigInt(t[0]) * e + BigInt(t[1]);
+    }
+    function r(t) {
+      return {
+        low: Number(BigInt.asUintN(32, t)),
+        high: Number(BigInt.asUintN(32, t >> BigInt(32))),
+      };
+    }
+    function o(t) {
+      return r(n(t));
+    }
+    function i(t) {
+      return n(t).toString();
+    }
+    (Fn.hrTimeToNanos = n),
+      (Fn.toLongBits = r),
+      (Fn.encodeAsLongBits = o),
+      (Fn.encodeAsString = i);
+    const s = "undefined" != typeof BigInt ? i : t.hrTimeToNanoseconds;
+    function a(t) {
+      return t;
+    }
+    function u(t) {
+      if (void 0 !== t) return (0, e.hexToBinary)(t);
+    }
+    const c = {
+      encodeHrTime: o,
+      encodeSpanContext: e.hexToBinary,
+      encodeOptionalSpanContext: u,
+    };
+    return (
+      (Fn.getOtlpEncoder = function (t) {
+        if (void 0 === t) return c;
+        const n = t.useLongBits ?? !0,
+          r = t.useHex ?? !1;
+        return {
+          encodeHrTime: n ? o : s,
+          encodeSpanContext: r ? a : e.hexToBinary,
+          encodeOptionalSpanContext: r ? a : u,
+        };
+      }),
+      Fn
+    );
+  }
+  function qn() {
+    if (Bn) return In;
+    (Bn = 1),
+      Object.defineProperty(In, "__esModule", { value: !0 }),
+      (In.createExportTraceServiceRequest =
+        In.toOtlpSpanEvent =
+        In.toOtlpLink =
+        In.sdkSpanToOtlpSpan =
+          void 0);
+    const t = kn(),
+      e = zn();
+    function n(e, n) {
+      const i = e.spanContext(),
+        s = e.status,
+        a = e.parentSpanContext?.spanId
+          ? n.encodeSpanContext(e.parentSpanContext?.spanId)
+          : void 0;
+      return {
+        traceId: n.encodeSpanContext(i.traceId),
+        spanId: n.encodeSpanContext(i.spanId),
+        parentSpanId: a,
+        traceState: i.traceState?.serialize(),
+        name: e.name,
+        kind: null == e.kind ? 0 : e.kind + 1,
+        startTimeUnixNano: n.encodeHrTime(e.startTime),
+        endTimeUnixNano: n.encodeHrTime(e.endTime),
+        attributes: (0, t.toAttributes)(e.attributes),
+        droppedAttributesCount: e.droppedAttributesCount,
+        events: e.events.map((t) => o(t, n)),
+        droppedEventsCount: e.droppedEventsCount,
+        status: { code: s.code, message: s.message },
+        links: e.links.map((t) => r(t, n)),
+        droppedLinksCount: e.droppedLinksCount,
+      };
+    }
+    function r(e, n) {
+      return {
+        attributes: e.attributes ? (0, t.toAttributes)(e.attributes) : [],
+        spanId: n.encodeSpanContext(e.context.spanId),
+        traceId: n.encodeSpanContext(e.context.traceId),
+        traceState: e.context.traceState?.serialize(),
+        droppedAttributesCount: e.droppedAttributesCount || 0,
+      };
+    }
+    function o(e, n) {
+      return {
+        attributes: e.attributes ? (0, t.toAttributes)(e.attributes) : [],
+        name: e.name,
+        timeUnixNano: n.encodeHrTime(e.time),
+        droppedAttributesCount: e.droppedAttributesCount || 0,
+      };
+    }
+    function i(e, r) {
+      const o = (function (t) {
+          const e = new Map();
+          for (const n of t) {
+            let t = e.get(n.resource);
+            t || ((t = new Map()), e.set(n.resource, t));
+            const r = `${n.instrumentationScope.name}@${
+              n.instrumentationScope.version || ""
+            }:${n.instrumentationScope.schemaUrl || ""}`;
+            let o = t.get(r);
+            o || ((o = []), t.set(r, o)), o.push(n);
+          }
+          return e;
+        })(e),
+        i = [],
+        s = o.entries();
+      let a = s.next();
+      for (; !a.done; ) {
+        const [e, o] = a.value,
+          u = [],
+          c = o.values();
+        let l = c.next();
+        for (; !l.done; ) {
+          const e = l.value;
+          if (e.length > 0) {
+            const o = e.map((t) => n(t, r));
+            u.push({
+              scope: (0, t.createInstrumentationScope)(
+                e[0].instrumentationScope
+              ),
+              spans: o,
+              schemaUrl: e[0].instrumentationScope.schemaUrl,
+            });
+          }
+          l = c.next();
+        }
+        const p = {
+          resource: (0, t.createResource)(e),
+          scopeSpans: u,
+          schemaUrl: void 0,
+        };
+        i.push(p), (a = s.next());
+      }
+      return i;
+    }
+    return (
+      (In.sdkSpanToOtlpSpan = n),
+      (In.toOtlpLink = r),
+      (In.toOtlpSpanEvent = o),
+      (In.createExportTraceServiceRequest = function (t, n) {
+        return { resourceSpans: i(t, (0, e.getOtlpEncoder)(n)) };
+      }),
+      In
+    );
+  }
+  var Gn,
+    Kn = qn(),
+    Wn = {};
+  function Xn() {
+    return (
+      Gn ||
+        ((Gn = 1),
+        (function (t) {
+          var e;
+          Object.defineProperty(t, "__esModule", { value: !0 }),
+            (t.ESpanKind = void 0),
+            ((e = t.ESpanKind || (t.ESpanKind = {}))[
+              (e.SPAN_KIND_UNSPECIFIED = 0)
+            ] = "SPAN_KIND_UNSPECIFIED"),
+            (e[(e.SPAN_KIND_INTERNAL = 1)] = "SPAN_KIND_INTERNAL"),
+            (e[(e.SPAN_KIND_SERVER = 2)] = "SPAN_KIND_SERVER"),
+            (e[(e.SPAN_KIND_CLIENT = 3)] = "SPAN_KIND_CLIENT"),
+            (e[(e.SPAN_KIND_PRODUCER = 4)] = "SPAN_KIND_PRODUCER"),
+            (e[(e.SPAN_KIND_CONSUMER = 5)] = "SPAN_KIND_CONSUMER");
+        })(Wn)),
+      Wn
+    );
+  }
+  var Qn = Xn();
+  class Yn {
+    constructor(t) {
+      this.config = t;
+    }
+    export(t, n) {
+      const r = Kn.createExportTraceServiceRequest(t, {
+        useHex: !0,
+        useLongBits: !1,
+      });
+      this.config.api.pushTraces(r),
+        (function (t = []) {
+          var n, r;
+          for (const o of t) {
+            const { scopeSpans: t } = o;
+            for (const o of t) {
+              const { scope: t, spans: i = [] } = o;
+              for (const o of i) {
+                if (o.kind !== Qn.ESpanKind.SPAN_KIND_CLIENT) continue;
+                const i = {
+                    traceId: o.traceId.toString(),
+                    spanId: o.spanId.toString(),
+                  },
+                  s = {};
+                for (const t of o.attributes)
+                  s[t.key] = String(Object.values(t.value)[0]);
+                Number.isNaN(o.endTimeUnixNano) ||
+                  Number.isNaN(o.startTimeUnixNano) ||
+                  (s.duration_ns = String(
+                    Number(o.endTimeUnixNano) - Number(o.startTimeUnixNano)
+                  ));
+                const a = (
+                  null !== (n = null == t ? void 0 : t.name) && void 0 !== n
+                    ? n
+                    : ""
+                ).indexOf("-");
+                let u = e.unknownString;
+                (null == t ? void 0 : t.name) &&
+                  (-1 === a &&
+                    (u =
+                      null !== (r = t.name.split("/")[1]) && void 0 !== r
+                        ? r
+                        : t.name),
+                  a > -1 && (u = null == t ? void 0 : t.name.substring(a + 1))),
+                  e.faro.api.pushEvent(`faro.tracing.${u}`, s, void 0, {
+                    spanContext: i,
+                    timestampOverwriteMs: Number(o.endTimeUnixNano) / 1e6,
+                    customPayloadTransformer: (t) => {
+                      var e, n;
+                      return (
+                        null != s["faro.action.user.name"] &&
+                          null != s["faro.action.user.parentId"] &&
+                          ((t.action = {
+                            name: s["faro.action.user.name"],
+                            parentId: s["faro.action.user.parentId"],
+                          }),
+                          null === (e = t.attributes) ||
+                            void 0 === e ||
+                            delete e["faro.action.user.name"],
+                          null === (n = t.attributes) ||
+                            void 0 === n ||
+                            delete n["faro.action.user.parentId"]),
+                        t
+                      );
+                    },
+                  });
+              }
+            }
+          }
+        })(r.resourceSpans),
+        n({ code: $e.SUCCESS });
+    }
+    shutdown() {
+      return Promise.resolve(void 0);
+    }
+  }
+  const Zn = "session.id";
+  "function" == typeof SuppressedError && SuppressedError;
+  class Jn {
+    emit(t) {}
+  }
+  const tr = new Jn();
+  const er = new (class {
+    getLogger(t, e, n) {
+      return new Jn();
+    }
+  })();
+  class nr {
+    constructor(t, e, n, r) {
+      (this._provider = t),
+        (this.name = e),
+        (this.version = n),
+        (this.options = r);
+    }
+    emit(t) {
+      this._getLogger().emit(t);
+    }
+    _getLogger() {
+      if (this._delegate) return this._delegate;
+      const t = this._provider.getDelegateLogger(
+        this.name,
+        this.version,
+        this.options
+      );
+      return t ? ((this._delegate = t), this._delegate) : tr;
+    }
+  }
+  class rr {
+    getLogger(t, e, n) {
+      var r;
+      return null !== (r = this.getDelegateLogger(t, e, n)) && void 0 !== r
+        ? r
+        : new nr(this, t, e, n);
+    }
+    getDelegate() {
+      var t;
+      return null !== (t = this._delegate) && void 0 !== t ? t : er;
+    }
+    setDelegate(t) {
+      this._delegate = t;
+    }
+    getDelegateLogger(t, e, n) {
+      var r;
+      return null === (r = this._delegate) || void 0 === r
+        ? void 0
+        : r.getLogger(t, e, n);
+    }
+  }
+  const or =
+      "object" == typeof globalThis
+        ? globalThis
+        : "object" == typeof self
+        ? self
+        : "object" == typeof window
+        ? window
+        : "object" == typeof global
+        ? global
+        : {},
+    ir = Symbol.for("io.opentelemetry.js.api.logs"),
+    sr = or;
+  class ar {
+    constructor() {
+      this._proxyLoggerProvider = new rr();
+    }
+    static getInstance() {
+      return this._instance || (this._instance = new ar()), this._instance;
+    }
+    setGlobalLoggerProvider(t) {
+      return sr[ir]
+        ? this.getLoggerProvider()
+        : ((sr[ir] = ((e = 1), (n = t), (r = er), (t) => (t === e ? n : r))),
+          this._proxyLoggerProvider.setDelegate(t),
+          t);
+      var e, n, r;
+    }
+    getLoggerProvider() {
+      var t, e;
+      return null !==
+        (e = null === (t = sr[ir]) || void 0 === t ? void 0 : t.call(sr, 1)) &&
+        void 0 !== e
+        ? e
+        : this._proxyLoggerProvider;
+    }
+    getLogger(t, e, n) {
+      return this.getLoggerProvider().getLogger(t, e, n);
+    }
+    disable() {
+      delete sr[ir], (this._proxyLoggerProvider = new rr());
+    }
+  }
+  const ur = ar.getInstance();
+  var cr, lr;
+  var pr = (function () {
+    if (lr) return cr;
+    function t(t) {
+      return "function" == typeof t;
+    }
+    lr = 1;
+    var e = console.error.bind(console);
+    function n(t, e, n) {
+      var r = !!t[e] && t.propertyIsEnumerable(e);
+      Object.defineProperty(t, e, {
+        configurable: !0,
+        enumerable: r,
+        writable: !0,
+        value: n,
+      });
+    }
+    function r(n) {
+      n &&
+        n.logger &&
+        (t(n.logger)
+          ? (e = n.logger)
+          : e("new logger isn't a function, not replacing"));
+    }
+    function o(r, o, i) {
+      if (r && r[o]) {
+        if (!i) return e("no wrapper function"), void e(new Error().stack);
+        if (t(r[o]) && t(i)) {
+          var s = r[o],
+            a = i(s, o);
+          return (
+            n(a, "__original", s),
+            n(a, "__unwrap", function () {
+              r[o] === a && n(r, o, s);
+            }),
+            n(a, "__wrapped", !0),
+            n(r, o, a),
+            a
+          );
+        }
+        e("original object and wrapper must be functions");
+      } else e("no original function " + o + " to wrap");
+    }
+    function i(t, n) {
+      return t && t[n]
+        ? t[n].__unwrap
+          ? t[n].__unwrap()
+          : void e(
+              "no original to unwrap to -- has " +
+                n +
+                " already been unwrapped?"
+            )
+        : (e("no function to unwrap."), void e(new Error().stack));
+    }
+    return (
+      (r.wrap = o),
+      (r.massWrap = function (t, n, r) {
+        if (!t)
+          return (
+            e("must provide one or more modules to patch"),
+            void e(new Error().stack)
+          );
+        Array.isArray(t) || (t = [t]),
+          n && Array.isArray(n)
+            ? t.forEach(function (t) {
+                n.forEach(function (e) {
+                  o(t, e, r);
+                });
+              })
+            : e("must provide one or more functions to wrap on modules");
+      }),
+      (r.unwrap = i),
+      (r.massUnwrap = function (t, n) {
+        if (!t)
+          return (
+            e("must provide one or more modules to patch"),
+            void e(new Error().stack)
+          );
+        Array.isArray(t) || (t = [t]),
+          n && Array.isArray(n)
+            ? t.forEach(function (t) {
+                n.forEach(function (e) {
+                  i(t, e);
+                });
+              })
+            : e("must provide one or more functions to unwrap on modules");
+      }),
+      (cr = r)
+    );
+  })();
+  class dr {
+    instrumentationName;
+    instrumentationVersion;
+    _config = {};
+    _tracer;
+    _meter;
+    _logger;
+    _diag;
+    constructor(t, e, n) {
+      (this.instrumentationName = t),
+        (this.instrumentationVersion = e),
+        this.setConfig(n),
+        (this._diag = Lt.createComponentLogger({ namespace: t })),
+        (this._tracer = Kt.getTracer(t, e)),
+        (this._meter = Mt.getMeter(t, e)),
+        (this._logger = ur.getLogger(t, e)),
+        this._updateMetricInstruments();
+    }
+    _wrap = pr.wrap;
+    _unwrap = pr.unwrap;
+    _massWrap = pr.massWrap;
+    _massUnwrap = pr.massUnwrap;
+    get meter() {
+      return this._meter;
+    }
+    setMeterProvider(t) {
+      (this._meter = t.getMeter(
+        this.instrumentationName,
+        this.instrumentationVersion
+      )),
+        this._updateMetricInstruments();
+    }
+    get logger() {
+      return this._logger;
+    }
+    setLoggerProvider(t) {
+      this._logger = t.getLogger(
+        this.instrumentationName,
+        this.instrumentationVersion
+      );
+    }
+    getModuleDefinitions() {
+      const t = this.init() ?? [];
+      return Array.isArray(t) ? t : [t];
+    }
+    _updateMetricInstruments() {}
+    getConfig() {
+      return this._config;
+    }
+    setConfig(t) {
+      this._config = { enabled: !0, ...t };
+    }
+    setTracerProvider(t) {
+      this._tracer = t.getTracer(
+        this.instrumentationName,
+        this.instrumentationVersion
+      );
+    }
+    get tracer() {
+      return this._tracer;
+    }
+    _runSpanCustomizationHook(t, e, n, r) {
+      if (t)
+        try {
+          t(n, r);
+        } catch (t) {
+          this._diag.error(
+            "Error running span customization hook due to exception in handler",
+            { triggerName: e },
+            t
+          );
+        }
+    }
+  }
+  class hr extends dr {
+    constructor(t, e, n) {
+      super(t, e, n), this._config.enabled && this.enable();
+    }
+  }
+  function fr(t, e, n) {
+    let r, o;
+    try {
+      o = t();
+    } catch (t) {
+      r = t;
+    } finally {
+      return e(r, o), o;
+    }
+  }
+  function gr(t) {
+    return (
+      "function" == typeof t &&
+      "function" == typeof t.__original &&
+      "function" == typeof t.__unwrap &&
+      !0 === t.__wrapped
+    );
+  }
+  const mr = (t) =>
+    null !== t && "object" == typeof t && "function" == typeof t.then;
+  class _r {
+    _rawAttributes;
+    _asyncAttributesPending = !1;
+    _memoizedAttributes;
+    static FromAttributeList(t) {
+      const e = new _r({});
+      return (
+        (e._rawAttributes = t),
+        (e._asyncAttributesPending = t.filter(([t, e]) => mr(e)).length > 0),
+        e
+      );
+    }
+    constructor(t) {
+      const e = t.attributes ?? {};
+      this._rawAttributes = Object.entries(e).map(
+        ([t, e]) => (mr(e) && (this._asyncAttributesPending = !0), [t, e])
+      );
+    }
+    get asyncAttributesPending() {
+      return this._asyncAttributesPending;
+    }
+    async waitForAsyncAttributes() {
+      if (this.asyncAttributesPending) {
+        for (let t = 0; t < this._rawAttributes.length; t++) {
+          const [e, n] = this._rawAttributes[t];
+          try {
+            this._rawAttributes[t] = [e, mr(n) ? await n : n];
+          } catch (n) {
+            Lt.debug("a resource's async attributes promise rejected: %s", n),
+              (this._rawAttributes[t] = [e, void 0]);
+          }
+        }
+        this._asyncAttributesPending = !1;
+      }
+    }
+    get attributes() {
+      if (
+        (this.asyncAttributesPending &&
+          Lt.error(
+            "Accessing resource attributes before async attributes settled"
+          ),
+        this._memoizedAttributes)
+      )
+        return this._memoizedAttributes;
+      const t = {};
+      for (const [e, n] of this._rawAttributes)
+        mr(n)
+          ? Lt.debug(`Unsettled resource attribute ${e} skipped`)
+          : null != n && (t[e] ??= n);
+      return this._asyncAttributesPending || (this._memoizedAttributes = t), t;
+    }
+    getRawAttributes() {
+      return this._rawAttributes;
+    }
+    merge(t) {
+      return null == t
+        ? this
+        : _r.FromAttributeList([
+            ...t.getRawAttributes(),
+            ...this.getRawAttributes(),
+          ]);
+    }
+  }
+  function vr(t) {
+    return _r.FromAttributeList(Object.entries(t));
+  }
+  function yr() {
+    return vr({
+      [Ae]: "unknown_service",
+      [Oe]: xe[Oe],
+      [Re]: xe[Re],
+      [Ne]: xe[Ne],
+    });
+  }
+  class Sr {
+    _spanContext;
+    kind;
+    parentSpanContext;
+    attributes = {};
+    links = [];
+    events = [];
+    startTime;
+    resource;
+    instrumentationScope;
+    _droppedAttributesCount = 0;
+    _droppedEventsCount = 0;
+    _droppedLinksCount = 0;
+    name;
+    status = { code: At.UNSET };
+    endTime = [0, 0];
+    _ended = !1;
+    _duration = [-1, -1];
+    _spanProcessor;
+    _spanLimits;
+    _attributeValueLengthLimit;
+    _performanceStartTime;
+    _performanceOffset;
+    _startTimeProvided;
+    constructor(t) {
+      const e = Date.now();
+      (this._spanContext = t.spanContext),
+        (this._performanceStartTime = de.now()),
+        (this._performanceOffset = e - (this._performanceStartTime + Me())),
+        (this._startTimeProvided = null != t.startTime),
+        (this._spanLimits = t.spanLimits),
+        (this._attributeValueLengthLimit =
+          this._spanLimits.attributeValueLengthLimit || 0),
+        (this._spanProcessor = t.spanProcessor),
+        (this.name = t.name),
+        (this.parentSpanContext = t.parentSpanContext),
+        (this.kind = t.kind),
+        (this.links = t.links || []),
+        (this.startTime = this._getTime(t.startTime ?? e)),
+        (this.resource = t.resource),
+        (this.instrumentationScope = t.scope),
+        null != t.attributes && this.setAttributes(t.attributes),
+        this._spanProcessor.onStart(this, t.context);
+    }
+    spanContext() {
+      return this._spanContext;
+    }
+    setAttribute(t, e) {
+      if (null == e || this._isSpanEnded()) return this;
+      if (0 === t.length) return Lt.warn(`Invalid attribute key: ${t}`), this;
+      if (!ie(e))
+        return Lt.warn(`Invalid attribute value set for key: ${t}`), this;
+      const { attributeCountLimit: n } = this._spanLimits;
+      return void 0 !== n &&
+        Object.keys(this.attributes).length >= n &&
+        !Object.prototype.hasOwnProperty.call(this.attributes, t)
+        ? (this._droppedAttributesCount++, this)
+        : ((this.attributes[t] = this._truncateToSize(e)), this);
+    }
+    setAttributes(t) {
+      for (const [e, n] of Object.entries(t)) this.setAttribute(e, n);
+      return this;
+    }
+    addEvent(t, e, n) {
+      if (this._isSpanEnded()) return this;
+      const { eventCountLimit: r } = this._spanLimits;
+      if (0 === r)
+        return Lt.warn("No events allowed."), this._droppedEventsCount++, this;
+      void 0 !== r &&
+        this.events.length >= r &&
+        (0 === this._droppedEventsCount && Lt.debug("Dropping extra events."),
+        this.events.shift(),
+        this._droppedEventsCount++),
+        He(e) && (He(n) || (n = e), (e = void 0));
+      const o = re(e);
+      return (
+        this.events.push({
+          name: t,
+          attributes: o,
+          time: this._getTime(n),
+          droppedAttributesCount: 0,
+        }),
+        this
+      );
+    }
+    addLink(t) {
+      return this.links.push(t), this;
+    }
+    addLinks(t) {
+      return this.links.push(...t), this;
+    }
+    setStatus(t) {
+      return (
+        this._isSpanEnded() ||
+          ((this.status = { ...t }),
+          null != this.status.message &&
+            "string" != typeof t.message &&
+            (Lt.warn(
+              `Dropping invalid status.message of type '${typeof t.message}', expected 'string'`
+            ),
+            delete this.status.message)),
+        this
+      );
+    }
+    updateName(t) {
+      return this._isSpanEnded() || (this.name = t), this;
+    }
+    end(t) {
+      this._isSpanEnded()
+        ? Lt.error(
+            `${this.name} ${this._spanContext.traceId}-${this._spanContext.spanId} - You can only call end() on a span once.`
+          )
+        : ((this._ended = !0),
+          (this.endTime = this._getTime(t)),
+          (this._duration = Ue(this.startTime, this.endTime)),
+          this._duration[0] < 0 &&
+            (Lt.warn(
+              "Inconsistent start and end time, startTime > endTime. Setting span duration to 0ms.",
+              this.startTime,
+              this.endTime
+            ),
+            (this.endTime = this.startTime.slice()),
+            (this._duration = [0, 0])),
+          this._droppedEventsCount > 0 &&
+            Lt.warn(
+              `Dropped ${this._droppedEventsCount} events because eventCountLimit reached`
+            ),
+          this._spanProcessor.onEnd(this));
+    }
+    _getTime(t) {
+      if ("number" == typeof t && t <= de.now())
+        return ke(t + this._performanceOffset);
+      if ("number" == typeof t) return Ie(t);
+      if (t instanceof Date) return Ie(t.getTime());
+      if (Fe(t)) return t;
+      if (this._startTimeProvided) return Ie(Date.now());
+      const e = de.now() - this._performanceStartTime;
+      return Ve(this.startTime, Ie(e));
+    }
+    isRecording() {
+      return !1 === this._ended;
+    }
+    recordException(t, e) {
+      const n = {};
+      "string" == typeof t
+        ? (n[fe] = t)
+        : t &&
+          (t.code ? (n[he] = t.code.toString()) : t.name && (n[he] = t.name),
+          t.message && (n[fe] = t.message),
+          t.stack && (n["exception.stacktrace"] = t.stack)),
+        n[he] || n[fe]
+          ? this.addEvent("exception", n, e)
+          : Lt.warn(`Failed to record an exception ${t}`);
+    }
+    get duration() {
+      return this._duration;
+    }
+    get ended() {
+      return this._ended;
+    }
+    get droppedAttributesCount() {
+      return this._droppedAttributesCount;
+    }
+    get droppedEventsCount() {
+      return this._droppedEventsCount;
+    }
+    get droppedLinksCount() {
+      return this._droppedLinksCount;
+    }
+    _isSpanEnded() {
+      if (this._ended) {
+        const t = new Error(
+          `Operation attempted on ended Span {traceId: ${this._spanContext.traceId}, spanId: ${this._spanContext.spanId}}`
+        );
+        Lt.warn(
+          `Cannot execute the operation on ended Span {traceId: ${this._spanContext.traceId}, spanId: ${this._spanContext.spanId}}`,
+          t
+        );
+      }
+      return this._ended;
+    }
+    _truncateToLimitUtil(t, e) {
+      return t.length <= e ? t : t.substring(0, e);
+    }
+    _truncateToSize(t) {
+      const e = this._attributeValueLengthLimit;
+      return e <= 0
+        ? (Lt.warn(`Attribute value limit must be positive, got ${e}`), t)
+        : "string" == typeof t
+        ? this._truncateToLimitUtil(t, e)
+        : Array.isArray(t)
+        ? t.map((t) =>
+            "string" == typeof t ? this._truncateToLimitUtil(t, e) : t
+          )
+        : t;
+    }
+  }
+  var br;
+  !(function (t) {
+    (t[(t.NOT_RECORD = 0)] = "NOT_RECORD"),
+      (t[(t.RECORD = 1)] = "RECORD"),
+      (t[(t.RECORD_AND_SAMPLED = 2)] = "RECORD_AND_SAMPLED");
+  })(br || (br = {}));
+  class Er {
+    shouldSample() {
+      return { decision: br.NOT_RECORD };
+    }
+    toString() {
+      return "AlwaysOffSampler";
+    }
+  }
+  class Tr {
+    shouldSample() {
+      return { decision: br.RECORD_AND_SAMPLED };
+    }
+    toString() {
+      return "AlwaysOnSampler";
+    }
+  }
+  class wr {
+    _root;
+    _remoteParentSampled;
+    _remoteParentNotSampled;
+    _localParentSampled;
+    _localParentNotSampled;
+    constructor(t) {
+      (this._root = t.root),
+        this._root ||
+          (ce(
+            new Error("ParentBasedSampler must have a root sampler configured")
+          ),
+          (this._root = new Tr())),
+        (this._remoteParentSampled = t.remoteParentSampled ?? new Tr()),
+        (this._remoteParentNotSampled = t.remoteParentNotSampled ?? new Er()),
+        (this._localParentSampled = t.localParentSampled ?? new Tr()),
+        (this._localParentNotSampled = t.localParentNotSampled ?? new Er());
+    }
+    shouldSample(t, e, n, r, o, i) {
+      const s = Kt.getSpanContext(t);
+      return s && St(s)
+        ? s.isRemote
+          ? s.traceFlags & R.SAMPLED
+            ? this._remoteParentSampled.shouldSample(t, e, n, r, o, i)
+            : this._remoteParentNotSampled.shouldSample(t, e, n, r, o, i)
+          : s.traceFlags & R.SAMPLED
+          ? this._localParentSampled.shouldSample(t, e, n, r, o, i)
+          : this._localParentNotSampled.shouldSample(t, e, n, r, o, i)
+        : this._root.shouldSample(t, e, n, r, o, i);
+    }
+    toString() {
+      return `ParentBased{root=${this._root.toString()}, remoteParentSampled=${this._remoteParentSampled.toString()}, remoteParentNotSampled=${this._remoteParentNotSampled.toString()}, localParentSampled=${this._localParentSampled.toString()}, localParentNotSampled=${this._localParentNotSampled.toString()}}`;
+    }
+  }
+  class Cr {
+    _ratio;
+    _upperBound;
+    constructor(t = 0) {
+      (this._ratio = t),
+        (this._ratio = this._normalize(t)),
+        (this._upperBound = Math.floor(4294967295 * this._ratio));
+    }
+    shouldSample(t, e) {
+      return {
+        decision:
+          yt(e) && this._accumulate(e) < this._upperBound
+            ? br.RECORD_AND_SAMPLED
+            : br.NOT_RECORD,
+      };
+    }
+    toString() {
+      return `TraceIdRatioBased{${this._ratio}}`;
+    }
+    _normalize(t) {
+      return "number" != typeof t || isNaN(t) ? 0 : t >= 1 ? 1 : t <= 0 ? 0 : t;
+    }
+    _accumulate(t) {
+      let e = 0;
+      for (let n = 0; n < t.length / 8; n++) {
+        const r = 8 * n;
+        e = (e ^ parseInt(t.slice(r, r + 8), 16)) >>> 0;
+      }
+      return e;
+    }
+  }
+  const Ar = 1;
+  function Or() {
+    return {
+      sampler: Rr(),
+      forceFlushTimeoutMillis: 3e4,
+      generalLimits: {
+        attributeValueLengthLimit: 1 / 0,
+        attributeCountLimit: 128,
+      },
+      spanLimits: {
+        attributeValueLengthLimit: 1 / 0,
+        attributeCountLimit: 128,
+        linkCountLimit: 128,
+        eventCountLimit: 128,
+        attributePerEventCountLimit: 128,
+        attributePerLinkCountLimit: 128,
+      },
+    };
+  }
+  function Rr() {
+    const t = "parentbased_always_on";
+    switch (t) {
+      case "always_on":
+        return new Tr();
+      case "always_off":
+        return new Er();
+      case "parentbased_always_on":
+        return new wr({ root: new Tr() });
+      case "parentbased_always_off":
+        return new wr({ root: new Er() });
+      case "traceidratio":
+        return new Cr(Nr());
+      case "parentbased_traceidratio":
+        return new wr({ root: new Cr(Nr()) });
+      default:
+        return (
+          Lt.error(
+            `OTEL_TRACES_SAMPLER value "${t}" invalid, defaulting to "parentbased_always_on".`
+          ),
+          new wr({ root: new Tr() })
+        );
+    }
+  }
+  function Nr() {
+    return (
+      Lt.error(`OTEL_TRACES_SAMPLER_ARG is blank, defaulting to ${Ar}.`), Ar
+    );
+  }
+  const xr = 1 / 0;
+  class Pr {
+    _exporter;
+    _maxExportBatchSize;
+    _maxQueueSize;
+    _scheduledDelayMillis;
+    _exportTimeoutMillis;
+    _isExporting = !1;
+    _finishedSpans = [];
+    _timer;
+    _shutdownOnce;
+    _droppedSpansCount = 0;
+    constructor(t, e) {
+      (this._exporter = t),
+        (this._maxExportBatchSize =
+          "number" == typeof e?.maxExportBatchSize
+            ? e.maxExportBatchSize
+            : 512),
+        (this._maxQueueSize =
+          "number" == typeof e?.maxQueueSize ? e.maxQueueSize : 2048),
+        (this._scheduledDelayMillis =
+          "number" == typeof e?.scheduledDelayMillis
+            ? e.scheduledDelayMillis
+            : 5e3),
+        (this._exportTimeoutMillis =
+          "number" == typeof e?.exportTimeoutMillis
+            ? e.exportTimeoutMillis
+            : 3e4),
+        (this._shutdownOnce = new Rn(this._shutdown, this)),
+        this._maxExportBatchSize > this._maxQueueSize &&
+          (Lt.warn(
+            "BatchSpanProcessor: maxExportBatchSize must be smaller or equal to maxQueueSize, setting maxExportBatchSize to match maxQueueSize"
+          ),
+          (this._maxExportBatchSize = this._maxQueueSize));
+    }
+    forceFlush() {
+      return this._shutdownOnce.isCalled
+        ? this._shutdownOnce.promise
+        : this._flushAll();
+    }
+    onStart(t, e) {}
+    onEnd(t) {
+      this._shutdownOnce.isCalled ||
+        (t.spanContext().traceFlags & R.SAMPLED && this._addToBuffer(t));
+    }
+    shutdown() {
+      return this._shutdownOnce.call();
+    }
+    _shutdown() {
+      return Promise.resolve()
+        .then(() => this.onShutdown())
+        .then(() => this._flushAll())
+        .then(() => this._exporter.shutdown());
+    }
+    _addToBuffer(t) {
+      if (this._finishedSpans.length >= this._maxQueueSize)
+        return (
+          0 === this._droppedSpansCount &&
+            Lt.debug("maxQueueSize reached, dropping spans"),
+          void this._droppedSpansCount++
+        );
+      this._droppedSpansCount > 0 &&
+        (Lt.warn(
+          `Dropped ${this._droppedSpansCount} spans because maxQueueSize reached`
+        ),
+        (this._droppedSpansCount = 0)),
+        this._finishedSpans.push(t),
+        this._maybeStartTimer();
+    }
+    _flushAll() {
+      return new Promise((t, e) => {
+        const n = [];
+        for (
+          let t = 0,
+            e = Math.ceil(
+              this._finishedSpans.length / this._maxExportBatchSize
+            );
+          t < e;
+          t++
+        )
+          n.push(this._flushOneBatch());
+        Promise.all(n)
+          .then(() => {
+            t();
+          })
+          .catch(e);
+      });
+    }
+    _flushOneBatch() {
+      return (
+        this._clearTimer(),
+        0 === this._finishedSpans.length
+          ? Promise.resolve()
+          : new Promise((t, e) => {
+              const n = setTimeout(() => {
+                e(new Error("Timeout"));
+              }, this._exportTimeoutMillis);
+              Pt.with(Xt(Pt.active()), () => {
+                let r;
+                this._finishedSpans.length <= this._maxExportBatchSize
+                  ? ((r = this._finishedSpans), (this._finishedSpans = []))
+                  : (r = this._finishedSpans.splice(
+                      0,
+                      this._maxExportBatchSize
+                    ));
+                const o = () =>
+                  this._exporter.export(r, (r) => {
+                    clearTimeout(n),
+                      r.code === $e.SUCCESS
+                        ? t()
+                        : e(
+                            r.error ??
+                              new Error(
+                                "BatchSpanProcessor: span export failed"
+                              )
+                          );
+                  });
+                let i = null;
+                for (let t = 0, e = r.length; t < e; t++) {
+                  const e = r[t];
+                  e.resource.asyncAttributesPending &&
+                    e.resource.waitForAsyncAttributes &&
+                    ((i ??= []), i.push(e.resource.waitForAsyncAttributes()));
+                }
+                null === i
+                  ? o()
+                  : Promise.all(i).then(o, (t) => {
+                      ce(t), e(t);
+                    });
+              });
+            })
+      );
+    }
+    _maybeStartTimer() {
+      if (this._isExporting) return;
+      const t = () => {
+        (this._isExporting = !0),
+          this._flushOneBatch()
+            .finally(() => {
+              (this._isExporting = !1),
+                this._finishedSpans.length > 0 &&
+                  (this._clearTimer(), this._maybeStartTimer());
+            })
+            .catch((t) => {
+              (this._isExporting = !1), ce(t);
+            });
+      };
+      if (this._finishedSpans.length >= this._maxExportBatchSize) return t();
+      void 0 === this._timer &&
+        ((this._timer = setTimeout(() => t(), this._scheduledDelayMillis)),
+        this._timer);
+    }
+    _clearTimer() {
+      void 0 !== this._timer &&
+        (clearTimeout(this._timer), (this._timer = void 0));
+    }
+  }
+  class Lr extends Pr {
+    _visibilityChangeListener;
+    _pageHideListener;
+    constructor(t, e) {
+      super(t, e), this.onInit(e);
+    }
+    onInit(t) {
+      !0 !== t?.disableAutoFlushOnDocumentHide &&
+        "undefined" != typeof document &&
+        ((this._visibilityChangeListener = () => {
+          "hidden" === document.visibilityState &&
+            this.forceFlush().catch((t) => {
+              ce(t);
+            });
+        }),
+        (this._pageHideListener = () => {
+          this.forceFlush().catch((t) => {
+            ce(t);
+          });
+        }),
+        document.addEventListener(
+          "visibilitychange",
+          this._visibilityChangeListener
+        ),
+        document.addEventListener("pagehide", this._pageHideListener));
+    }
+    onShutdown() {
+      "undefined" != typeof document &&
+        (this._visibilityChangeListener &&
+          document.removeEventListener(
+            "visibilitychange",
+            this._visibilityChangeListener
+          ),
+        this._pageHideListener &&
+          document.removeEventListener("pagehide", this._pageHideListener));
+    }
+  }
+  class Dr {
+    generateTraceId = Mr(16);
+    generateSpanId = Mr(8);
+  }
+  const Ir = Array(32);
+  function Mr(t) {
+    return function () {
+      for (let e = 0; e < 2 * t; e++)
+        (Ir[e] = Math.floor(16 * Math.random()) + 48),
+          Ir[e] >= 58 && (Ir[e] += 39);
+      return String.fromCharCode.apply(null, Ir.slice(0, 2 * t));
+    };
+  }
+  class kr {
+    _sampler;
+    _generalLimits;
+    _spanLimits;
+    _idGenerator;
+    instrumentationScope;
+    _resource;
+    _spanProcessor;
+    constructor(t, e, n, r) {
+      const o = (function (t) {
+        const e = { sampler: Rr() },
+          n = Or(),
+          r = Object.assign({}, n, e, t);
+        return (
+          (r.generalLimits = Object.assign(
+            {},
+            n.generalLimits,
+            t.generalLimits || {}
+          )),
+          (r.spanLimits = Object.assign({}, n.spanLimits, t.spanLimits || {})),
+          r
+        );
+      })(e);
+      (this._sampler = o.sampler),
+        (this._generalLimits = o.generalLimits),
+        (this._spanLimits = o.spanLimits),
+        (this._idGenerator = e.idGenerator || new Dr()),
+        (this._resource = n),
+        (this._spanProcessor = r),
+        (this.instrumentationScope = t);
+    }
+    startSpan(t, e = {}, n = Pt.active()) {
+      e.root && (n = Kt.deleteSpan(n));
+      const r = Kt.getSpan(n);
+      if (Qt(n)) {
+        Lt.debug("Instrumentation suppressed, returning Noop Span");
+        return Kt.wrapSpanContext(ut);
+      }
+      const o = r?.spanContext(),
+        i = this._idGenerator.generateSpanId();
+      let s, a, u;
+      o && Kt.isSpanContextValid(o)
+        ? ((a = o.traceId), (u = o.traceState), (s = o))
+        : (a = this._idGenerator.generateTraceId());
+      const c = e.kind ?? Ct.INTERNAL,
+        l = (e.links ?? []).map((t) => ({
+          context: t.context,
+          attributes: re(t.attributes),
+        })),
+        p = re(e.attributes),
+        d = this._sampler.shouldSample(n, a, t, c, p, l);
+      u = d.traceState ?? u;
+      const h = {
+        traceId: a,
+        spanId: i,
+        traceFlags: d.decision === wt.RECORD_AND_SAMPLED ? R.SAMPLED : R.NONE,
+        traceState: u,
+      };
+      if (d.decision === wt.NOT_RECORD) {
+        Lt.debug(
+          "Recording is off, propagating context in a non-recording span"
+        );
+        return Kt.wrapSpanContext(h);
+      }
+      const f = re(Object.assign(p, d.attributes));
+      return new Sr({
+        resource: this._resource,
+        scope: this.instrumentationScope,
+        context: n,
+        spanContext: h,
+        name: t,
+        kind: c,
+        links: l,
+        parentSpanContext: s,
+        attributes: f,
+        startTime: e.startTime,
+        spanProcessor: this._spanProcessor,
+        spanLimits: this._spanLimits,
+      });
+    }
+    startActiveSpan(t, e, n, r) {
+      let o, i, s;
+      if (arguments.length < 2) return;
+      2 === arguments.length
+        ? (s = e)
+        : 3 === arguments.length
+        ? ((o = e), (s = n))
+        : ((o = e), (i = n), (s = r));
+      const a = i ?? Pt.active(),
+        u = this.startSpan(t, o, a),
+        c = Kt.setSpan(a, u);
+      return Pt.with(c, s, void 0, u);
+    }
+    getGeneralLimits() {
+      return this._generalLimits;
+    }
+    getSpanLimits() {
+      return this._spanLimits;
+    }
+  }
+  class jr {
+    _spanProcessors;
+    constructor(t) {
+      this._spanProcessors = t;
+    }
+    forceFlush() {
+      const t = [];
+      for (const e of this._spanProcessors) t.push(e.forceFlush());
+      return new Promise((e) => {
+        Promise.all(t)
+          .then(() => {
+            e();
+          })
+          .catch((t) => {
+            ce(t || new Error("MultiSpanProcessor: forceFlush failed")), e();
+          });
+      });
+    }
+    onStart(t, e) {
+      for (const n of this._spanProcessors) n.onStart(t, e);
+    }
+    onEnd(t) {
+      for (const e of this._spanProcessors) e.onEnd(t);
+    }
+    shutdown() {
+      const t = [];
+      for (const e of this._spanProcessors) t.push(e.shutdown());
+      return new Promise((e, n) => {
+        Promise.all(t).then(() => {
+          e();
+        }, n);
+      });
+    }
+  }
+  var Ur, Br;
+  !(function (t) {
+    (t[(t.resolved = 0)] = "resolved"),
+      (t[(t.timeout = 1)] = "timeout"),
+      (t[(t.error = 2)] = "error"),
+      (t[(t.unresolved = 3)] = "unresolved");
+  })(Ur || (Ur = {}));
+  class Fr {
+    _config;
+    _tracers = new Map();
+    _resource;
+    _activeSpanProcessor;
+    constructor(t = {}) {
+      const e = mn(
+        {},
+        Or(),
+        (function (t) {
+          const e = Object.assign({}, t.spanLimits);
+          return (
+            (e.attributeCountLimit =
+              t.spanLimits?.attributeCountLimit ??
+              t.generalLimits?.attributeCountLimit ??
+              void 0 ??
+              void 0 ??
+              128),
+            (e.attributeValueLengthLimit =
+              t.spanLimits?.attributeValueLengthLimit ??
+              t.generalLimits?.attributeValueLengthLimit ??
+              void 0 ??
+              void 0 ??
+              xr),
+            Object.assign({}, t, { spanLimits: e })
+          );
+        })(t)
+      );
+      (this._resource = e.resource ?? yr()),
+        (this._config = Object.assign({}, e, { resource: this._resource }));
+      const n = [];
+      t.spanProcessors?.length && n.push(...t.spanProcessors),
+        (this._activeSpanProcessor = new jr(n));
+    }
+    getTracer(t, e, n) {
+      const r = `${t}@${e || ""}:${n?.schemaUrl || ""}`;
+      return (
+        this._tracers.has(r) ||
+          this._tracers.set(
+            r,
+            new kr(
+              { name: t, version: e, schemaUrl: n?.schemaUrl },
+              this._config,
+              this._resource,
+              this._activeSpanProcessor
+            )
+          ),
+        this._tracers.get(r)
+      );
+    }
+    forceFlush() {
+      const t = this._config.forceFlushTimeoutMillis,
+        e = this._activeSpanProcessor._spanProcessors.map(
+          (e) =>
+            new Promise((n) => {
+              let r;
+              const o = setTimeout(() => {
+                n(
+                  new Error(
+                    `Span processor did not completed within timeout period of ${t} ms`
+                  )
+                ),
+                  (r = Ur.timeout);
+              }, t);
+              e.forceFlush()
+                .then(() => {
+                  clearTimeout(o),
+                    r !== Ur.timeout && ((r = Ur.resolved), n(r));
+                })
+                .catch((t) => {
+                  clearTimeout(o), (r = Ur.error), n(t);
+                });
+            })
+        );
+      return new Promise((t, n) => {
+        Promise.all(e)
+          .then((e) => {
+            const r = e.filter((t) => t !== Ur.resolved);
+            r.length > 0 ? n(r) : t();
+          })
+          .catch((t) => n([t]));
+      });
+    }
+    shutdown() {
+      return this._activeSpanProcessor.shutdown();
+    }
+  }
+  class Hr {
+    _enabled = !1;
+    _currentContext = x;
+    _bindFunction(t = x, e) {
+      const n = this,
+        r = function (...r) {
+          return n.with(t, () => e.apply(this, r));
+        };
+      return (
+        Object.defineProperty(r, "length", {
+          enumerable: !1,
+          configurable: !0,
+          writable: !1,
+          value: e.length,
+        }),
+        r
+      );
+    }
+    active() {
+      return this._currentContext;
+    }
+    bind(t, e) {
+      return (
+        void 0 === t && (t = this.active()),
+        "function" == typeof e ? this._bindFunction(t, e) : e
+      );
+    }
+    disable() {
+      return (this._currentContext = x), (this._enabled = !1), this;
+    }
+    enable() {
+      return (
+        this._enabled || ((this._enabled = !0), (this._currentContext = x)),
+        this
+      );
+    }
+    with(t, e, n, ...r) {
+      const o = this._currentContext;
+      this._currentContext = t || x;
+      try {
+        return e.call(n, ...r);
+      } finally {
+        this._currentContext = o;
+      }
+    }
+  }
+  class Vr extends Fr {
+    constructor(t = {}) {
+      super(t);
+    }
+    register(t = {}) {
+      var e;
+      Kt.setGlobalTracerProvider(this),
+        null !== (e = t.propagator) &&
+          (void 0 !== e
+            ? qt.setGlobalPropagator(e)
+            : qt.setGlobalPropagator(
+                new ze({ propagators: [new tn(), new ne()] })
+              )),
+        (function (t) {
+          if (null !== t) {
+            if (void 0 === t) {
+              const t = new Hr();
+              return t.enable(), void Pt.setGlobalContextManager(t);
+            }
+            t.enable(), Pt.setGlobalContextManager(t);
+          }
+        })(t.contextManager);
+    }
+  }
+  let $r;
+  function zr(t, e, n, r = !0) {
+    if (
+      !((o = n),
+      (i = e),
+      !(i in o) || "number" != typeof n[e] || (r && 0 === n[e]))
+    )
+      return t.addEvent(e, n[e]);
+    var o, i;
+  }
+  function qr(t, e, n = !1, r) {
+    void 0 === r && (r = 0 !== e[Br.START_TIME]),
+      n ||
+        (zr(t, Br.FETCH_START, e, r),
+        zr(t, Br.DOMAIN_LOOKUP_START, e, r),
+        zr(t, Br.DOMAIN_LOOKUP_END, e, r),
+        zr(t, Br.CONNECT_START, e, r),
+        zr(t, Br.SECURE_CONNECTION_START, e, r),
+        zr(t, Br.CONNECT_END, e, r),
+        zr(t, Br.REQUEST_START, e, r),
+        zr(t, Br.RESPONSE_START, e, r),
+        zr(t, Br.RESPONSE_END, e, r));
+    const o = e[Br.ENCODED_BODY_SIZE];
+    void 0 !== o && t.setAttribute("http.response_content_length", o);
+    const i = e[Br.DECODED_BODY_SIZE];
+    void 0 !== i &&
+      o !== i &&
+      t.setAttribute("http.response_content_length_uncompressed", i);
+  }
+  function Gr() {
+    return "undefined" != typeof location ? location.origin : void 0;
+  }
+  function Kr(t, e, n, r, o = new WeakSet(), i) {
+    const s = Wr(t),
+      a = (function (t, e, n, r, o, i) {
+        const s = Be(e),
+          a = Be(n);
+        let u = r.filter((e) => {
+          const n = Be(je(e[Br.FETCH_START])),
+            r = Be(je(e[Br.RESPONSE_END]));
+          return (
+            e.initiatorType.toLowerCase() === (i || "xmlhttprequest") &&
+            e.name === t &&
+            n >= s &&
+            r <= a
+          );
+        });
+        u.length > 0 && (u = u.filter((t) => !o.has(t)));
+        return u;
+      })((t = s.toString()), e, n, r, o, i);
+    if (0 === a.length) return { mainRequest: void 0 };
+    if (1 === a.length) return { mainRequest: a[0] };
+    const u = (function (t) {
+      return t.slice().sort((t, e) => {
+        const n = t[Br.FETCH_START],
+          r = e[Br.FETCH_START];
+        return n > r ? 1 : n < r ? -1 : 0;
+      });
+    })(a);
+    if (s.origin !== Gr() && u.length > 1) {
+      let t = u[0],
+        e = (function (t, e, n) {
+          const r = Be(n),
+            o = Be(je(e));
+          let i,
+            s = t[1];
+          const a = t.length;
+          for (let e = 1; e < a; e++) {
+            const n = t[e],
+              a = Be(je(n[Br.FETCH_START])),
+              u = r - Be(je(n[Br.RESPONSE_END]));
+            a >= o && (!i || u < i) && ((i = u), (s = n));
+          }
+          return s;
+        })(u, t[Br.RESPONSE_END], n);
+      const r = t[Br.RESPONSE_END];
+      return (
+        e[Br.FETCH_START] < r && ((e = t), (t = void 0)),
+        { corsPreFlightRequest: t, mainRequest: e }
+      );
+    }
+    return { mainRequest: a[0] };
+  }
+  function Wr(t) {
+    if ("function" == typeof URL)
+      return new URL(
+        t,
+        "undefined" != typeof document
+          ? document.baseURI
+          : "undefined" != typeof location
+          ? location.href
+          : void 0
+      );
+    const e = ($r || ($r = document.createElement("a")), $r);
+    return (e.href = t), e;
+  }
+  function Xr(t, e) {
+    let n = e || [];
+    ("string" == typeof n || n instanceof RegExp) && (n = [n]);
+    return Wr(t).origin === Gr() || n.some((e) => Cn(t, e));
+  }
+  var Qr;
+  !(function (t) {
+    (t.CONNECT_END = "connectEnd"),
+      (t.CONNECT_START = "connectStart"),
+      (t.DECODED_BODY_SIZE = "decodedBodySize"),
+      (t.DOM_COMPLETE = "domComplete"),
+      (t.DOM_CONTENT_LOADED_EVENT_END = "domContentLoadedEventEnd"),
+      (t.DOM_CONTENT_LOADED_EVENT_START = "domContentLoadedEventStart"),
+      (t.DOM_INTERACTIVE = "domInteractive"),
+      (t.DOMAIN_LOOKUP_END = "domainLookupEnd"),
+      (t.DOMAIN_LOOKUP_START = "domainLookupStart"),
+      (t.ENCODED_BODY_SIZE = "encodedBodySize"),
+      (t.FETCH_START = "fetchStart"),
+      (t.LOAD_EVENT_END = "loadEventEnd"),
+      (t.LOAD_EVENT_START = "loadEventStart"),
+      (t.NAVIGATION_START = "navigationStart"),
+      (t.REDIRECT_END = "redirectEnd"),
+      (t.REDIRECT_START = "redirectStart"),
+      (t.REQUEST_START = "requestStart"),
+      (t.RESPONSE_END = "responseEnd"),
+      (t.RESPONSE_START = "responseStart"),
+      (t.SECURE_CONNECTION_START = "secureConnectionStart"),
+      (t.START_TIME = "startTime"),
+      (t.UNLOAD_EVENT_END = "unloadEventEnd"),
+      (t.UNLOAD_EVENT_START = "unloadEventStart");
+  })(Br || (Br = {})),
+    (function (t) {
+      (t.COMPONENT = "component"),
+        (t.HTTP_ERROR_NAME = "http.error_name"),
+        (t.HTTP_STATUS_TEXT = "http.status_text");
+    })(Qr || (Qr = {}));
+  const Yr = Lt.createComponentLogger({
+    namespace: "@opentelemetry/opentelemetry-instrumentation-fetch/utils",
+  });
+  function Zr(...t) {
+    if (t[0] instanceof URL || "string" == typeof t[0]) {
+      const e = t[1];
+      if (!e?.body) return Promise.resolve();
+      if (e.body instanceof ReadableStream) {
+        const { body: t, length: n } = (function (t) {
+          if (!t.pipeThrough)
+            return (
+              Yr.warn("Platform has ReadableStream but not pipeThrough!"),
+              { body: t, length: Promise.resolve(void 0) }
+            );
+          let e,
+            n = 0;
+          const r = new Promise((t) => {
+              e = t;
+            }),
+            o = new TransformStream({
+              start() {},
+              async transform(t, e) {
+                const r = await t;
+                (n += r.byteLength), e.enqueue(t);
+              },
+              flush() {
+                e(n);
+              },
+            });
+          return { body: t.pipeThrough(o), length: r };
+        })(e.body);
+        return (e.body = t), n;
+      }
+      return Promise.resolve(
+        (function (t) {
+          if (
+            ((e = t), "undefined" != typeof Document && e instanceof Document)
+          )
+            return new XMLSerializer().serializeToString(document).length;
+          var e;
+          if ("string" == typeof t) return to(t);
+          if (t instanceof Blob) return t.size;
+          if (t instanceof FormData)
+            return (function (t) {
+              let e = 0;
+              for (const [n, r] of t.entries())
+                (e += n.length),
+                  r instanceof Blob ? (e += r.size) : (e += r.length);
+              return e;
+            })(t);
+          if (t instanceof URLSearchParams) return to(t.toString());
+          if (void 0 !== t.byteLength) return t.byteLength;
+          return void Yr.warn("unknown body type");
+        })(e.body)
+      );
+    }
+    {
+      const e = t[0];
+      return e?.body
+        ? e
+            .clone()
+            .text()
+            .then((t) => to(t))
+        : Promise.resolve();
+    }
+  }
+  const Jr = new TextEncoder();
+  function to(t) {
+    return Jr.encode(t).byteLength;
+  }
+  const eo = "0.200.0",
+    no = "object" == typeof process && "node" === process.release?.name;
+  class ro extends hr {
+    component = "fetch";
+    version = eo;
+    moduleName = this.component;
+    _usedResources = new WeakSet();
+    _tasksCount = 0;
+    constructor(t = {}) {
+      super("@opentelemetry/instrumentation-fetch", eo, t);
+    }
+    init() {}
+    _addChildSpan(t, e) {
+      const n = this.tracer.startSpan(
+        "CORS Preflight",
+        { startTime: e[Br.FETCH_START] },
+        Kt.setSpan(Pt.active(), t)
+      );
+      qr(n, e, this.getConfig().ignoreNetworkEvents), n.end(e[Br.RESPONSE_END]);
+    }
+    _addFinalSpanAttributes(t, e) {
+      const n = Wr(e.url);
+      t.setAttribute(ye, e.status),
+        null != e.statusText &&
+          t.setAttribute(Qr.HTTP_STATUS_TEXT, e.statusText),
+        t.setAttribute(_e, n.host),
+        t.setAttribute(ve, n.protocol.replace(":", "")),
+        "undefined" != typeof navigator &&
+          t.setAttribute(Se, navigator.userAgent);
+    }
+    _addHeaders(t, e) {
+      if (!Xr(e, this.getConfig().propagateTraceHeaderCorsUrls)) {
+        const t = {};
+        return (
+          qt.inject(Pt.active(), t),
+          void (
+            Object.keys(t).length > 0 &&
+            this._diag.debug("headers inject skipped due to CORS policy")
+          )
+        );
+      }
+      if (t instanceof Request)
+        qt.inject(Pt.active(), t.headers, {
+          set: (t, e, n) => t.set(e, "string" == typeof n ? n : String(n)),
+        });
+      else if (t.headers instanceof Headers)
+        qt.inject(Pt.active(), t.headers, {
+          set: (t, e, n) => t.set(e, "string" == typeof n ? n : String(n)),
+        });
+      else if (t.headers instanceof Map)
+        qt.inject(Pt.active(), t.headers, {
+          set: (t, e, n) => t.set(e, "string" == typeof n ? n : String(n)),
+        });
+      else {
+        const e = {};
+        qt.inject(Pt.active(), e),
+          (t.headers = Object.assign({}, e, t.headers || {}));
+      }
+    }
+    _clearResources() {
+      0 === this._tasksCount &&
+        this.getConfig().clearTimingResources &&
+        (performance.clearResourceTimings(),
+        (this._usedResources = new WeakSet()));
+    }
+    _createSpan(t, e = {}) {
+      if (An(t, this.getConfig().ignoreUrls))
+        return void this._diag.debug(
+          "ignoring span as url matches ignored url"
+        );
+      const n = (e.method || "GET").toUpperCase(),
+        r = `HTTP ${n}`;
+      return this.tracer.startSpan(r, {
+        kind: Ct.CLIENT,
+        attributes: { [Qr.COMPONENT]: this.moduleName, [ge]: n, [me]: t },
+      });
+    }
+    _findResourceAndAddNetworkEvents(t, e, n) {
+      let r = e.entries;
+      if (!r.length) {
+        if (!performance.getEntriesByType) return;
+        r = performance.getEntriesByType("resource");
+      }
+      const o = Kr(e.spanUrl, e.startTime, n, r, this._usedResources, "fetch");
+      if (o.mainRequest) {
+        const e = o.mainRequest;
+        this._markResourceAsUsed(e);
+        const n = o.corsPreFlightRequest;
+        n && (this._addChildSpan(t, n), this._markResourceAsUsed(n)),
+          qr(t, e, this.getConfig().ignoreNetworkEvents);
+      }
+    }
+    _markResourceAsUsed(t) {
+      this._usedResources.add(t);
+    }
+    _endSpan(t, e, n) {
+      const r = Ie(Date.now()),
+        o = ke();
+      this._addFinalSpanAttributes(t, n),
+        setTimeout(() => {
+          e.observer?.disconnect(),
+            this._findResourceAndAddNetworkEvents(t, e, o),
+            this._tasksCount--,
+            this._clearResources(),
+            t.end(r);
+        }, 300);
+    }
+    _patchConstructor() {
+      return (t) => {
+        const e = this;
+        return function (...n) {
+          const r = this,
+            o = Wr(n[0] instanceof Request ? n[0].url : String(n[0])).href,
+            i = n[0] instanceof Request ? n[0] : n[1] || {},
+            s = e._createSpan(o, i);
+          if (!s) return t.apply(this, n);
+          const a = e._prepareSpanData(o);
+          function u(t, n) {
+            e._applyAttributesAfterFetch(t, i, n),
+              e._endSpan(t, a, {
+                status: n.status || 0,
+                statusText: n.message,
+                url: o,
+              });
+          }
+          function c(t, n) {
+            e._applyAttributesAfterFetch(t, i, n),
+              n.status >= 200 && n.status < 400
+                ? e._endSpan(t, a, n)
+                : e._endSpan(t, a, {
+                    status: n.status,
+                    statusText: n.statusText,
+                    url: o,
+                  });
+          }
+          function l(t, e, n) {
+            try {
+              const e = n.clone().body;
+              if (e) {
+                const r = e.getReader(),
+                  o = () => {
+                    r.read().then(
+                      ({ done: e }) => {
+                        e ? c(t, n) : o();
+                      },
+                      (e) => {
+                        u(t, e);
+                      }
+                    );
+                  };
+                o();
+              } else c(t, n);
+            } finally {
+              e(n);
+            }
+          }
+          function p(t, e, n) {
+            try {
+              u(t, n);
+            } finally {
+              e(n);
+            }
+          }
+          return (
+            e.getConfig().measureRequestSize &&
+              Zr(...n)
+                .then((t) => {
+                  t && s.setAttribute(be, t);
+                })
+                .catch((t) => {
+                  e._diag.warn("getFetchBodyLength", t);
+                }),
+            new Promise((n, a) =>
+              Pt.with(
+                Kt.setSpan(Pt.active(), s),
+                () => (
+                  e._addHeaders(i, o),
+                  e._callRequestHook(s, i),
+                  e._tasksCount++,
+                  t
+                    .apply(r, i instanceof Request ? [i] : [o, i])
+                    .then(l.bind(r, s, n), p.bind(r, s, a))
+                )
+              )
+            )
+          );
+        };
+      };
+    }
+    _applyAttributesAfterFetch(t, e, n) {
+      const r = this.getConfig().applyCustomAttributesOnSpan;
+      r &&
+        fr(
+          () => r(t, e, n),
+          (t) => {
+            t && this._diag.error("applyCustomAttributesOnSpan", t);
+          }
+        );
+    }
+    _callRequestHook(t, e) {
+      const n = this.getConfig().requestHook;
+      n &&
+        fr(
+          () => n(t, e),
+          (t) => {
+            t && this._diag.error("requestHook", t);
+          }
+        );
+    }
+    _prepareSpanData(t) {
+      const e = ke(),
+        n = [];
+      if ("function" != typeof PerformanceObserver)
+        return { entries: n, startTime: e, spanUrl: t };
+      const r = new PerformanceObserver((e) => {
+        e.getEntries().forEach((e) => {
+          "fetch" === e.initiatorType && e.name === t && n.push(e);
+        });
+      });
+      return (
+        r.observe({ entryTypes: ["resource"] }),
+        { entries: n, observer: r, startTime: e, spanUrl: t }
+      );
+    }
+    enable() {
+      no
+        ? this._diag.warn(
+            "this instrumentation is intended for web usage only, it does not instrument Node.js's fetch()"
+          )
+        : (gr(fetch) &&
+            (this._unwrap(pe, "fetch"),
+            this._diag.debug("removing previous patch for constructor")),
+          this._wrap(pe, "fetch", this._patchConstructor()));
+    }
+    disable() {
+      no || (this._unwrap(pe, "fetch"), (this._usedResources = new WeakSet()));
+    }
+  }
+  var oo;
+  !(function (t) {
+    (t.METHOD_OPEN = "open"),
+      (t.METHOD_SEND = "send"),
+      (t.EVENT_ABORT = "abort"),
+      (t.EVENT_ERROR = "error"),
+      (t.EVENT_LOAD = "loaded"),
+      (t.EVENT_TIMEOUT = "timeout");
+  })(oo || (oo = {}));
+  const io = Lt.createComponentLogger({
+    namespace:
+      "@opentelemetry/opentelemetry-instrumentation-xml-http-request/utils",
+  });
+  function so(t) {
+    return (
+      (e = t),
+      "undefined" != typeof Document && e instanceof Document
+        ? new XMLSerializer().serializeToString(document).length
+        : "string" == typeof t
+        ? uo(t)
+        : t instanceof Blob
+        ? t.size
+        : t instanceof FormData
+        ? (function (t) {
+            let e = 0;
+            for (const [n, r] of t.entries())
+              (e += n.length),
+                r instanceof Blob ? (e += r.size) : (e += r.length);
+            return e;
+          })(t)
+        : t instanceof URLSearchParams
+        ? uo(t.toString())
+        : void 0 !== t.byteLength
+        ? t.byteLength
+        : void io.warn("unknown body type")
+    );
+    var e;
+  }
+  const ao = new TextEncoder();
+  function uo(t) {
+    return ao.encode(t).byteLength;
+  }
+  const co = "0.200.0";
+  var lo;
+  !(function (t) {
+    t.HTTP_STATUS_TEXT = "http.status_text";
+  })(lo || (lo = {}));
+  class po extends hr {
+    component = "xml-http-request";
+    version = co;
+    moduleName = this.component;
+    _tasksCount = 0;
+    _xhrMem = new WeakMap();
+    _usedResources = new WeakSet();
+    constructor(t = {}) {
+      super("@opentelemetry/instrumentation-xml-http-request", co, t);
+    }
+    init() {}
+    _addHeaders(t, e) {
+      if (!Xr(Wr(e).href, this.getConfig().propagateTraceHeaderCorsUrls)) {
+        const t = {};
+        return (
+          qt.inject(Pt.active(), t),
+          void (
+            Object.keys(t).length > 0 &&
+            this._diag.debug("headers inject skipped due to CORS policy")
+          )
+        );
+      }
+      const n = {};
+      qt.inject(Pt.active(), n),
+        Object.keys(n).forEach((e) => {
+          t.setRequestHeader(e, String(n[e]));
+        });
+    }
+    _addChildSpan(t, e) {
+      Pt.with(Kt.setSpan(Pt.active(), t), () => {
+        const t = this.tracer.startSpan("CORS Preflight", {
+          startTime: e[Br.FETCH_START],
+        });
+        qr(t, e, this.getConfig().ignoreNetworkEvents),
+          t.end(e[Br.RESPONSE_END]);
+      });
+    }
+    _addFinalSpanAttributes(t, e, n) {
+      if ("string" == typeof n) {
+        const r = Wr(n);
+        void 0 !== e.status && t.setAttribute(ye, e.status),
+          void 0 !== e.statusText &&
+            t.setAttribute(lo.HTTP_STATUS_TEXT, e.statusText),
+          t.setAttribute(_e, r.host),
+          t.setAttribute(ve, r.protocol.replace(":", "")),
+          t.setAttribute(Se, navigator.userAgent);
+      }
+    }
+    _applyAttributesAfterXHR(t, e) {
+      const n = this.getConfig().applyCustomAttributesOnSpan;
+      "function" == typeof n &&
+        fr(
+          () => n(t, e),
+          (t) => {
+            t && this._diag.error("applyCustomAttributesOnSpan", t);
+          }
+        );
+    }
+    _addResourceObserver(t, e) {
+      const n = this._xhrMem.get(t);
+      n &&
+        "function" == typeof PerformanceObserver &&
+        "function" == typeof PerformanceResourceTiming &&
+        ((n.createdResources = {
+          observer: new PerformanceObserver((t) => {
+            const r = t.getEntries(),
+              o = Wr(e);
+            r.forEach((t) => {
+              "xmlhttprequest" === t.initiatorType &&
+                t.name === o.href &&
+                n.createdResources &&
+                n.createdResources.entries.push(t);
+            });
+          }),
+          entries: [],
+        }),
+        n.createdResources.observer.observe({ entryTypes: ["resource"] }));
+    }
+    _clearResources() {
+      0 === this._tasksCount &&
+        this.getConfig().clearTimingResources &&
+        (de.clearResourceTimings(),
+        (this._xhrMem = new WeakMap()),
+        (this._usedResources = new WeakSet()));
+    }
+    _findResourceAndAddNetworkEvents(t, e, n, r, o) {
+      if (!(n && r && o && t.createdResources)) return;
+      let i = t.createdResources.entries;
+      (i && i.length) || (i = de.getEntriesByType("resource"));
+      const s = Kr(Wr(n).href, r, o, i, this._usedResources);
+      if (s.mainRequest) {
+        const t = s.mainRequest;
+        this._markResourceAsUsed(t);
+        const n = s.corsPreFlightRequest;
+        n && (this._addChildSpan(e, n), this._markResourceAsUsed(n)),
+          qr(e, t, this.getConfig().ignoreNetworkEvents);
+      }
+    }
+    _cleanPreviousSpanInformation(t) {
+      const e = this._xhrMem.get(t);
+      if (e) {
+        const n = e.callbackToRemoveEvents;
+        n && n(), this._xhrMem.delete(t);
+      }
+    }
+    _createSpan(t, e, n) {
+      if (An(e, this.getConfig().ignoreUrls))
+        return void this._diag.debug(
+          "ignoring span as url matches ignored url"
+        );
+      const r = n.toUpperCase(),
+        o = this.tracer.startSpan(r, {
+          kind: Ct.CLIENT,
+          attributes: { [ge]: n, [me]: Wr(e).toString() },
+        });
+      return (
+        o.addEvent(oo.METHOD_OPEN),
+        this._cleanPreviousSpanInformation(t),
+        this._xhrMem.set(t, { span: o, spanUrl: e }),
+        o
+      );
+    }
+    _markResourceAsUsed(t) {
+      this._usedResources.add(t);
+    }
+    _patchOpen() {
+      return (t) => {
+        const e = this;
+        return function (...n) {
+          const r = n[0],
+            o = n[1];
+          return e._createSpan(this, o, r), t.apply(this, n);
+        };
+      };
+    }
+    _patchSend() {
+      const t = this;
+      function e(e, n) {
+        const r = t._xhrMem.get(n);
+        if (!r) return;
+        (r.status = n.status),
+          (r.statusText = n.statusText),
+          t._xhrMem.delete(n),
+          r.span && t._applyAttributesAfterXHR(r.span, n);
+        const o = ke(),
+          i = Date.now();
+        setTimeout(() => {
+          !(function (e, n, r, o) {
+            const i = n.callbackToRemoveEvents;
+            "function" == typeof i && i();
+            const { span: s, spanUrl: a, sendStartTime: u } = n;
+            s &&
+              (t._findResourceAndAddNetworkEvents(n, s, a, u, r),
+              s.addEvent(e, o),
+              t._addFinalSpanAttributes(s, n, a),
+              s.end(o),
+              t._tasksCount--),
+              t._clearResources();
+          })(e, r, o, i);
+        }, 300);
+      }
+      function n() {
+        e(oo.EVENT_ERROR, this);
+      }
+      function r() {
+        e(oo.EVENT_ABORT, this);
+      }
+      function o() {
+        e(oo.EVENT_TIMEOUT, this);
+      }
+      function i() {
+        this.status < 299 ? e(oo.EVENT_LOAD, this) : e(oo.EVENT_ERROR, this);
+      }
+      return (e) =>
+        function (...s) {
+          const a = t._xhrMem.get(this);
+          if (!a) return e.apply(this, s);
+          const u = a.span,
+            c = a.spanUrl;
+          if (u && c) {
+            if (t.getConfig().measureRequestSize && s?.[0]) {
+              const t = so(s[0]);
+              void 0 !== t && u.setAttribute(be, t);
+            }
+            Pt.with(Kt.setSpan(Pt.active(), u), () => {
+              t._tasksCount++,
+                (a.sendStartTime = ke()),
+                u.addEvent(oo.METHOD_SEND),
+                this.addEventListener("abort", r),
+                this.addEventListener("error", n),
+                this.addEventListener("load", i),
+                this.addEventListener("timeout", o),
+                (a.callbackToRemoveEvents = () => {
+                  !(function (e) {
+                    e.removeEventListener("abort", r),
+                      e.removeEventListener("error", n),
+                      e.removeEventListener("load", i),
+                      e.removeEventListener("timeout", o);
+                    const s = t._xhrMem.get(e);
+                    s && (s.callbackToRemoveEvents = void 0);
+                  })(this),
+                    a.createdResources &&
+                      a.createdResources.observer.disconnect();
+                }),
+                t._addHeaders(this, c),
+                t._addResourceObserver(this, c);
+            });
+          }
+          return e.apply(this, s);
+        };
+    }
+    enable() {
+      this._diag.debug("applying patch to", this.moduleName, this.version),
+        gr(XMLHttpRequest.prototype.open) &&
+          (this._unwrap(XMLHttpRequest.prototype, "open"),
+          this._diag.debug("removing previous patch from method open")),
+        gr(XMLHttpRequest.prototype.send) &&
+          (this._unwrap(XMLHttpRequest.prototype, "send"),
+          this._diag.debug("removing previous patch from method send")),
+        this._wrap(XMLHttpRequest.prototype, "open", this._patchOpen()),
+        this._wrap(XMLHttpRequest.prototype, "send", this._patchSend());
+    }
+    disable() {
+      this._diag.debug("removing patch from", this.moduleName, this.version),
+        this._unwrap(XMLHttpRequest.prototype, "open"),
+        this._unwrap(XMLHttpRequest.prototype, "send"),
+        (this._tasksCount = 0),
+        (this._xhrMem = new WeakMap()),
+        (this._usedResources = new WeakSet());
+    }
+  }
+  class ho extends po {
+    constructor(t = {}) {
+      super(t);
+      this.parentCreateSpan = this._createSpan.bind(this);
+    }
+    _patchOpen() {
+      return (t) => {
+        const n = this;
+        return function (...r) {
+          try {
+            const t = r[0];
+            let o = e.getUrlFromResource(r[1]);
+            n.parentCreateSpan(this, o, t);
+          } catch (t) {
+            e.faro.internalLogger.error(t);
+          }
+          return t.apply(this, r);
+        };
+      };
+    }
+  }
+  function fo(t, e, n) {
+    go(t, n instanceof Error ? 0 : n.status);
+  }
+  function go(t, e) {
+    if (null == e) return;
+    (0 === e || (e >= 400 && e < 600)) && t.setStatus({ code: At.ERROR });
+  }
+  function mo(t) {
+    return (e, n, r) => {
+      fo(e, 0, r), null == t || t(e, n, r);
+    };
+  }
+  function _o(t) {
+    return (e, n) => {
+      !(function (t, e) {
+        go(t, e.status);
+      })(e, n),
+        null == t || t(e, n);
+    };
+  }
+  function vo(t = {}) {
+    const { fetchInstrumentationOptions: e, xhrInstrumentationOptions: n } = t,
+      r = (function (t, e) {
+        var n = {};
+        for (var r in t)
+          Object.prototype.hasOwnProperty.call(t, r) &&
+            e.indexOf(r) < 0 &&
+            (n[r] = t[r]);
+        if (null != t && "function" == typeof Object.getOwnPropertySymbols) {
+          var o = 0;
+          for (r = Object.getOwnPropertySymbols(t); o < r.length; o++)
+            e.indexOf(r[o]) < 0 &&
+              Object.prototype.propertyIsEnumerable.call(t, r[o]) &&
+              (n[r[o]] = t[r[o]]);
+        }
+        return n;
+      })(t, ["fetchInstrumentationOptions", "xhrInstrumentationOptions"]),
+      o = (function (t, e) {
+        return Object.assign(
+          Object.assign(
+            Object.assign(Object.assign({}, e), { ignoreNetworkEvents: !0 }),
+            t
+          ),
+          {
+            applyCustomAttributesOnSpan: mo(
+              null == t ? void 0 : t.applyCustomAttributesOnSpan
+            ),
+          }
+        );
+      })(e, r),
+      i = (function (t, e) {
+        return Object.assign(
+          Object.assign(
+            Object.assign(Object.assign({}, e), { ignoreNetworkEvents: !0 }),
+            t
+          ),
+          {
+            applyCustomAttributesOnSpan: _o(
+              null == t ? void 0 : t.applyCustomAttributesOnSpan
+            ),
+          }
+        );
+      })(n, r);
+    return [new ro(o), new ho(i)];
+  }
+  class yo {
+    constructor(t, e) {
+      (this.processor = t), (this.metas = e);
+    }
+    forceFlush() {
+      return this.processor.forceFlush();
+    }
+    onStart(t, e) {
+      var n;
+      const r = this.metas.value.session;
+      (null == r ? void 0 : r.id) &&
+        ((t.attributes[Zn] = r.id), (t.attributes.session_id = r.id));
+      const o = null !== (n = this.metas.value.user) && void 0 !== n ? n : {};
+      o.email && (t.attributes["user.email"] = o.email),
+        o.id && (t.attributes["user.id"] = o.id),
+        o.username && (t.attributes["user.name"] = o.username),
+        o.fullName && (t.attributes["user.full_name"] = o.fullName),
+        o.roles &&
+          (t.attributes["user.roles"] = o.roles
+            .split(",")
+            .map((t) => t.trim())),
+        o.hash && (t.attributes["user.hash"] = o.hash),
+        this.processor.onStart(t, e);
+    }
+    onEnd(t) {
+      this.processor.onEnd(t);
+    }
+    shutdown() {
+      return this.processor.shutdown();
+    }
+  }
+  class So {
+    constructor(t) {
+      (this.processor = t),
+        e.apiMessageBus.subscribe((t) => {
+          t.type !== e.USER_ACTION_START
+            ? [e.USER_ACTION_END, e.USER_ACTION_CANCEL].includes(t.type) &&
+              (this.message = void 0)
+            : (this.message = t);
+        });
+    }
+    forceFlush() {
+      return this.processor.forceFlush();
+    }
+    onStart(t, e) {
+      var n, r;
+      t.kind === Ct.CLIENT &&
+        this.message &&
+        ((t.attributes["faro.action.user.name"] =
+          null === (n = this.message) || void 0 === n ? void 0 : n.name),
+        (t.attributes["faro.action.user.parentId"] =
+          null === (r = this.message) || void 0 === r ? void 0 : r.parentId)),
+        this.processor.onStart(t, e);
+    }
+    onEnd(t) {
+      this.processor.onEnd(t);
+    }
+    shutdown() {
+      return this.processor.shutdown();
+    }
+  }
+  function bo(t = {}) {
+    var e;
+    return "true" ===
+      (null === (e = t.attributes) || void 0 === e ? void 0 : e.isSampled)
+      ? br.RECORD_AND_SAMPLED
+      : br.NOT_RECORD;
+  }
+  class Eo extends e.BaseInstrumentation {
+    constructor(t = {}) {
+      super(),
+        (this.options = t),
+        (this.name = "@grafana/faro-web-tracing"),
+        (this.version = e.VERSION);
+    }
+    initialize() {
+      var t, e, n, r;
+      const o = this.options,
+        i = {};
+      this.config.app.name && (i[Ae] = this.config.app.name),
+        this.config.app.namespace &&
+          (i["service.namespace"] = this.config.app.namespace),
+        this.config.app.version &&
+          (i["service.version"] = this.config.app.version),
+        this.config.app.environment &&
+          ((i["deployment.environment.name"] = this.config.app.environment),
+          (i["deployment.environment"] = this.config.app.environment)),
+        Object.assign(i, o.resourceAttributes);
+      const s = yr().merge(vr(i));
+      new Vr({
+        resource: s,
+        sampler: {
+          shouldSample: () => ({ decision: bo(this.api.getSession()) }),
+        },
+        spanProcessors: [
+          null !== (t = o.spanProcessor) && void 0 !== t
+            ? t
+            : new So(
+                new yo(
+                  new Lr(new Yn({ api: this.api }), {
+                    scheduledDelayMillis: Eo.SCHEDULED_BATCH_DELAY_MS,
+                    maxExportBatchSize: 30,
+                  }),
+                  this.metas
+                )
+              ),
+        ],
+      }).register({
+        propagator: null !== (e = o.propagator) && void 0 !== e ? e : new tn(),
+        contextManager: o.contextManager,
+      });
+      const {
+        propagateTraceHeaderCorsUrls: a,
+        fetchInstrumentationOptions: u,
+        xhrInstrumentationOptions: c,
+      } = null !== (n = this.options.instrumentationOptions) && void 0 !== n
+        ? n
+        : {};
+      !(function (t) {
+        const e = t.tracerProvider || Kt.getTracerProvider(),
+          n = t.meterProvider || Mt.getMeterProvider(),
+          r = t.loggerProvider || ur.getLoggerProvider(),
+          o = t.instrumentations?.flat() ?? [];
+        (function (t, e, n, r) {
+          for (let o = 0, i = t.length; o < i; o++) {
+            const i = t[o];
+            e && i.setTracerProvider(e),
+              n && i.setMeterProvider(n),
+              r && i.setLoggerProvider && i.setLoggerProvider(r),
+              i.getConfig().enabled || i.enable();
+          }
+        })(o, e, n, r);
+      })({
+        instrumentations:
+          null !== (r = o.instrumentations) && void 0 !== r
+            ? r
+            : vo({
+                ignoreUrls: this.getIgnoreUrls(),
+                propagateTraceHeaderCorsUrls: a,
+                fetchInstrumentationOptions: u,
+                xhrInstrumentationOptions: c,
+              }),
+      }),
+        this.api.initOTEL(Kt, Pt);
+    }
+    getIgnoreUrls() {
+      return this.transports.transports.flatMap((t) => t.getIgnoreUrls());
+    }
+  }
+  return (
+    (Eo.SCHEDULED_BATCH_DELAY_MS = 1e3),
+    (t.FaroSessionSpanProcessor = class {
+      constructor(t, e) {
+        (this.processor = t), (this.metas = e);
+      }
+      forceFlush() {
+        return this.processor.forceFlush();
+      }
+      onStart(t, e) {
+        const n = this.metas.value.session;
+        (null == n ? void 0 : n.id) &&
+          ((t.attributes[Zn] = n.id), (t.attributes.session_id = n.id)),
+          this.processor.onStart(t, e);
+      }
+      onEnd(t) {
+        this.processor.onEnd(t);
+      }
+      shutdown() {
+        return this.processor.shutdown();
+      }
+    }),
+    (t.FaroTraceExporter = Yn),
+    (t.TracingInstrumentation = Eo),
+    (t.fetchCustomAttributeFunctionWithDefaults = mo),
+    (t.getDefaultOTELInstrumentations = vo),
+    (t.getSamplingDecision = bo),
+    (t.setSpanStatusOnFetchError = fo),
+    t
+  );
+};
+
+export default GrafanaFaroWebTracing;

--- a/auth/index.html
+++ b/auth/index.html
@@ -77,6 +77,33 @@
         display: none;
       }
     </style>
+    <script type="module">
+      import GrafanaFaroWebSdk from "./grafana-faro-web-sdk.js";
+      import GrafanaFaroWebTracing from "./grafana-faro-web-tracing.js";
+
+      // set environment based on the host
+      let environment = "development";
+      const host = window.location.host;
+      if (host === "auth.turnkey.com") {
+        environment = "production";
+      } else if (host === "auth.preprod.turnkey.engineering") {
+        environment = "preprod";
+      }
+
+      const faro = GrafanaFaroWebSdk.initializeFaro({
+        url: "https://faro-collector-prod-us-central-0.grafana.net/collect/208ef3024d71da6062bd867dbd1f8b34",
+        app: {
+          name: "email-auth",
+          version: "1.0.0",
+          environment: environment,
+        },
+        trackGeolocation: false,
+      });
+
+      const grafanaTracing = GrafanaFaroWebTracing({}, GrafanaFaroWebSdk);
+
+      faro.instrumentations.add(new grafanaTracing.TracingInstrumentation());
+    </script>
   </head>
 
   <body>
@@ -292,7 +319,9 @@
             hexString.length % 2 != 0 ||
             !hexRegex.test(hexString)
           ) {
-            throw new Error("cannot create uint8array from invalid hex string");
+            const errorMessage = `cannot create uint8array from invalid hex string: ${hexString}`;
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
           var buffer = new Uint8Array(
             hexString.match(/../g).map((h) => parseInt(h, 16))
@@ -365,9 +394,9 @@
          */
         async function base58checkDecode(s) {
           if (s.length < 5) {
-            throw new Error(
-              `cannot base58-decode a string of length < 5 (found length ${s.length})`
-            );
+            const errorMessage = `cannot base58-decode a string of length < 5 (found length ${s.length})`;
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
 
           // See https://en.bitcoin.it/wiki/Base58Check_encoding
@@ -378,9 +407,9 @@
           var leadingZeros = [];
           for (var i = 0; i < s.length; i++) {
             if (alphabet.indexOf(s[i]) === -1) {
-              throw new Error(
-                `cannot base58-decode: ${s[i]} isn't a valid character`
-              );
+              const errorMessage = `cannot base58-decode: ${s[i]} isn't a valid character`;
+              reportError(errorMessage);
+              throw new Error(errorMessage);
             }
             var carry = alphabet.indexOf(s[i]);
 
@@ -430,9 +459,9 @@
           );
 
           if (computedChecksum.toString() != foundChecksum.toString()) {
-            throw new Error(
-              `unable to decode credential bundle. checksums do not match: computed ${computedChecksum} but found ${foundChecksum}`
-            );
+            const errorMessage = `unable to decode credential bundle. checksums do not match: computed ${computedChecksum} but found ${foundChecksum}`;
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
 
           return new Uint8Array(msg);
@@ -454,9 +483,9 @@
          */
         function convertEcdsaIeee1363ToDer(ieee) {
           if (ieee.length % 2 != 0 || ieee.length == 0 || ieee.length > 132) {
-            throw new Error(
-              "Invalid IEEE P1363 signature encoding. Length: " + ieee.length
-            );
+            const errorMessage = `Invalid IEEE P1363 signature encoding. Length: ${ieee.length}`;
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
           const r = toUnsignedBigNum(ieee.subarray(0, ieee.length / 2));
           const s = toUnsignedBigNum(
@@ -542,6 +571,15 @@
          * @param requestId serves as an idempotency key to match incoming requests. Backwards compatible: if not provided, it isn't passed in.
          */
         var sendMessageUp = function (type, value, requestId) {
+          if (type === "ERROR") {
+            window.faro?.api?.pushError([value], {
+              context: {
+                requestId: requestId,
+              },
+              level: "error",
+            });
+          }
+
           const message = {
             type: type,
             value: value,
@@ -574,6 +612,15 @@
           var message = document.createElement("p");
           message.innerText = content;
           messageLog.appendChild(message);
+        };
+
+        /**
+         * Function to report errors to Grafana Faro.
+         */
+        var reportError = function (errorMessage) {
+          window.faro?.api?.pushError([errorMessage], {
+            level: "error",
+          });
         };
 
         /**
@@ -658,9 +705,9 @@
         var bigIntToHex = function (num, length) {
           var hexString = num.toString(16);
           if (hexString.length > length) {
-            throw new Error(
-              "number cannot fit in a hex string of " + length + " characters"
-            );
+            const errorMessage = `number cannot fit in a hex string of ${length} characters`;
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
           // Add an extra 0 to the start of the string to get to `length`
           return hexString.padStart(length, 0);
@@ -717,11 +764,15 @@
           }
 
           if (x < BigInt(0) || x >= p) {
-            throw new Error("x is out of range");
+            const errorMessage = "x is out of range";
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
 
           if (y < BigInt(0) || y >= p) {
-            throw new Error("y is out of range");
+            const errorMessage = "y is out of range";
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
 
           var uncompressedHexString =
@@ -734,7 +785,9 @@
          */
         function modSqrt(x, p) {
           if (p <= BigInt(0)) {
-            throw new Error("p must be positive");
+            const errorMessage = "p must be positive";
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
           const base = x % p;
           // The currently supported NIST curves P-256, P-384, and P-521 all satisfy
@@ -746,12 +799,16 @@
             const q = (p + BigInt(1)) >> BigInt(2);
             const squareRoot = modPow(base, q, p);
             if ((squareRoot * squareRoot) % p !== base) {
-              throw new Error("could not find a modular square root");
+              const errorMessage = "could not find a modular square root";
+              reportError(errorMessage);
+              throw new Error(errorMessage);
             }
             return squareRoot;
           }
           // Skipping other elliptic curve types that require Cipolla's algorithm.
-          throw new Error("unsupported modulus value");
+          const errorMessage = `unsupported modulus value: ${p}`;
+          reportError(errorMessage);
+          throw new Error(errorMessage);
         }
 
         /**
@@ -823,10 +880,9 @@
           } else if (other instanceof P256FieldElement) {
             coefficient = other.num;
           } else {
-            throw new Error(
-              "Cannot multiply element. Expected a BigInt, a Number or a P256FieldElement. Got: " +
-                other
-            );
+            const errorMessage = `Cannot multiply element. Expected a BigInt, a Number or a P256FieldElement. Got: ${other}`;
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
           num = (this.num * coefficient) % this.prime;
           return new P256FieldElement(num);
@@ -864,12 +920,16 @@
          */
         P256Point = function (x, y) {
           if (!x instanceof P256FieldElement) {
-            throw new Error("expected a P256FieldElement for x. Got: " + x);
+            const errorMessage = `expected a P256FieldElement for x. Got: ${x}`;
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
           this.x = x;
 
           if (!y instanceof P256FieldElement) {
-            throw new Error("expected a P256FieldElement for y. Got: " + y);
+            const errorMessage = `expected a P256FieldElement for y. Got: ${y}`;
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
           this.y = y;
           this.a = new P256FieldElement(
@@ -893,13 +953,9 @@
 
           if (left != right) {
             // y**2 = x**3 + 7 is the elliptic curve equation
-            throw new Error(
-              "Not on the P256 curve! y**2 (" +
-                left +
-                ") != x3 + ax + b (" +
-                right +
-                ")"
-            );
+            const errorMessage = `Not on the P256 curve! y**2 (${left}) != x3 + ax + b (${right})`;
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
         };
 
@@ -963,18 +1019,9 @@
             y = s.mul(this.x.sub(x)).sub(this.y);
             return new P256Point(x, y);
           }
-
-          throw new Error(
-            "cannot handle addition of (" +
-              this.x +
-              ", " +
-              this.y +
-              ") with (" +
-              other.x +
-              ", " +
-              other.y +
-              ")"
-          );
+          const errorMessage = `cannot handle addition of (${this.x}, ${this.y}) with (${other.x}, ${other.y})`;
+          reportError(errorMessage);
+          throw new Error(errorMessage);
         };
         /**
          * Multiplication uses addition. Nothing crazy here.
@@ -1035,6 +1082,7 @@
           sendMessageUp,
           setParentFrameMessageChannelPort,
           logMessage,
+          reportError,
           base64urlEncode,
           base64urlDecode,
           base58checkDecode,
@@ -1264,11 +1312,9 @@
         }
 
         if (bundleBytes.byteLength <= 33) {
-          throw new Error(
-            "bundle size " +
-              bundleBytes.byteLength +
-              " is too low. Expecting a compressed public key (33 bytes) and an encrypted credential"
-          );
+          const errorMessage = `bundle size ${bundleBytes.byteLength} is too low. Expecting a compressed public key (33 bytes) and an encrypted credential`;
+          TKHQ.reportError(errorMessage);
+          throw new Error(errorMessage);
         }
 
         var compressedEncappedKeyBuf = bundleBytes.subarray(0, 33);
@@ -1339,9 +1385,10 @@
        */
       var onStampRequest = async function (payload, requestId) {
         if (CREDENTIAL_BYTES === null) {
-          throw new Error(
-            "cannot sign payload without credential. Credential bytes are null. Has a credential bundle been injected into the iframe?"
-          );
+          const errorMessage =
+            "cannot sign payload without credential. Credential bytes are null. Has a credential bundle been injected into the iframe?";
+          TKHQ.reportError(errorMessage);
+          throw new Error(errorMessage);
         }
         var key = await TKHQ.importCredential(CREDENTIAL_BYTES);
         var signatureIeee1363 = await window.crypto.subtle.sign(
@@ -1413,10 +1460,9 @@
         try {
           res = await recipientCtx.open(ciphertextBuf, aad);
         } catch (e) {
-          throw new Error(
-            "unable to decrypt bundle using embedded key. the bundle may be incorrect. failed with error: " +
-              e.toString()
-          );
+          const errorMessage = `unable to decrypt bundle using embedded key. the bundle may be incorrect. failed with error: ${e.toString()}`;
+          TKHQ.reportError(errorMessage);
+          throw new Error(errorMessage);
         }
         return res;
       };

--- a/export/grafana-faro-web-sdk.js
+++ b/export/grafana-faro-web-sdk.js
@@ -1,0 +1,5329 @@
+// vendored @grafana/faro-web-sdk v1.18.1 https://unpkg.com/@grafana/faro-web-sdk@1.18.1/dist/bundle/faro-web-sdk.iife.js
+
+var GrafanaFaroWebSdk = (function (e) {
+  "use strict";
+  function t(e, t) {
+    return typeof e === t;
+  }
+  function n(e, t) {
+    return Object.prototype.toString.call(e) === `[object ${t}]`;
+  }
+  function i(e, t) {
+    try {
+      return e instanceof t;
+    } catch (e) {
+      return !1;
+    }
+  }
+  const r = (e) => t(e, "null"),
+    o = (e) => t(e, "string"),
+    s = (e) => (t(e, "number") && !isNaN(e)) || t(e, "bigint"),
+    a = (e) => t(e, "boolean"),
+    u = (e) => !r(e) && t(e, "object"),
+    c = (e) => t(e, "function"),
+    l = (e) => n(e, "Array"),
+    d = (e) => !u(e) && !c(e),
+    f = "undefined" != typeof Event,
+    p = (e) => f && i(e, Event),
+    g = "undefined" != typeof Error,
+    m = (e) => g && i(e, Error),
+    v = (e) => n(e, "ErrorEvent"),
+    h = (e) => n(e, "DOMError"),
+    b = (e) => n(e, "DOMException"),
+    w = "undefined" != typeof Element,
+    y = "undefined" != typeof Map;
+  function S(e) {
+    return (
+      null == e ||
+      (l(e) || o(e) ? 0 === e.length : !!u(e) && 0 === Object.keys(e).length)
+    );
+  }
+  function T(e, n) {
+    if (e === n) return !0;
+    if (t(e, "number") && isNaN(e)) return t(n, "number") && isNaN(n);
+    const i = l(e),
+      r = l(n);
+    if (i !== r) return !1;
+    if (i && r) {
+      const t = e.length;
+      if (t !== n.length) return !1;
+      for (let i = t; 0 != i--; ) if (!T(e[i], n[i])) return !1;
+      return !0;
+    }
+    const o = u(e),
+      s = u(n);
+    if (o !== s) return !1;
+    if (e && n && o && s) {
+      const t = Object.keys(e),
+        i = Object.keys(n);
+      if (t.length !== i.length) return !1;
+      for (let e of t) if (!i.includes(e)) return !1;
+      for (let i of t) if (!T(e[i], n[i])) return !1;
+      return !0;
+    }
+    return !1;
+  }
+  function E() {
+    return Date.now();
+  }
+  function I() {
+    return new Date().toISOString();
+  }
+  function k(e) {
+    return new Date(e).toISOString();
+  }
+  var O;
+  (e.LogLevel = void 0),
+    ((O = e.LogLevel || (e.LogLevel = {})).TRACE = "trace"),
+    (O.DEBUG = "debug"),
+    (O.INFO = "info"),
+    (O.LOG = "log"),
+    (O.WARN = "warn"),
+    (O.ERROR = "error");
+  const x = e.LogLevel.LOG,
+    L = [
+      e.LogLevel.TRACE,
+      e.LogLevel.DEBUG,
+      e.LogLevel.INFO,
+      e.LogLevel.LOG,
+      e.LogLevel.WARN,
+      e.LogLevel.ERROR,
+    ];
+  function C() {}
+  function A(e) {
+    const { size: t, concurrency: n } = e,
+      i = [];
+    let r = 0;
+    const o = () => {
+      if (r < n && i.length) {
+        const { producer: e, resolve: t, reject: n } = i.shift();
+        r++,
+          e().then(
+            (e) => {
+              r--, o(), t(e);
+            },
+            (e) => {
+              r--, o(), n(e);
+            }
+          );
+      }
+    };
+    return {
+      add: (e) => {
+        if (i.length + r >= t) throw new Error("Task buffer full");
+        return new Promise((t, n) => {
+          i.push({ producer: e, resolve: t, reject: n }), o();
+        });
+      },
+    };
+  }
+  const P = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ0123456789";
+  function M(e = 10) {
+    return Array.from(Array(e))
+      .map(() => P[Math.floor(Math.random() * P.length)])
+      .join("");
+  }
+  const j =
+    "undefined" != typeof globalThis
+      ? globalThis
+      : "undefined" != typeof global
+      ? global
+      : "undefined" != typeof self
+      ? self
+      : void 0;
+  function N(e = {}) {
+    return JSON.stringify(
+      null != e ? e : {},
+      (function () {
+        const e = new WeakSet();
+        return function (t, n) {
+          if (u(n) && null !== n) {
+            if (e.has(n)) return null;
+            e.add(n);
+          }
+          return n;
+        };
+      })()
+    );
+  }
+  function _(e = {}) {
+    const t = {};
+    for (const [n, i] of Object.entries(e))
+      t[n] = u(i) && null !== i ? N(i) : String(i);
+    return t;
+  }
+  class D {
+    constructor() {
+      this.subscribers = [];
+    }
+    subscribe(e) {
+      return (
+        this.subscribers.push(e), { unsubscribe: () => this.unsubscribe(e) }
+      );
+    }
+    unsubscribe(e) {
+      this.subscribers = this.subscribers.filter((t) => t !== e);
+    }
+    notify(e) {
+      this.subscribers.forEach((t) => t(e));
+    }
+    first() {
+      const e = new D(),
+        t = (t) => {
+          e.notify(t), n.unsubscribe();
+        },
+        n = this.subscribe(t),
+        i = e.unsubscribe.bind(e);
+      return this.withUnsubscribeOverride(e, i, t);
+    }
+    takeWhile(e) {
+      const t = new D(),
+        n = (i) => {
+          e(i) ? t.notify(i) : t.unsubscribe(n);
+        };
+      this.subscribe(n);
+      const i = t.unsubscribe.bind(t);
+      return this.withUnsubscribeOverride(t, i, n);
+    }
+    filter(e) {
+      const t = new D(),
+        n = (n) => {
+          e(n) && t.notify(n);
+        };
+      this.subscribe(n);
+      const i = t.unsubscribe.bind(t);
+      return this.withUnsubscribeOverride(t, i, n);
+    }
+    merge(...e) {
+      const t = new D(),
+        n = [];
+      e.forEach((e) => {
+        const i = e.subscribe((e) => {
+          t.notify(e);
+        });
+        n.push(i);
+      });
+      const i = t.unsubscribeAll.bind(t);
+      return (
+        (t.unsubscribe = () => {
+          n.forEach((e) => e.unsubscribe()), i();
+        }),
+        t
+      );
+    }
+    withUnsubscribeOverride(e, t, n) {
+      return (
+        (e.unsubscribe = (e) => {
+          t(e), this.unsubscribe(n);
+        }),
+        e
+      );
+    }
+    unsubscribeAll() {
+      this.subscribers = [];
+    }
+  }
+  class R {
+    constructor(e, t) {
+      var n, i;
+      (this.signalBuffer = []),
+        (this.itemLimit =
+          null !== (n = null == t ? void 0 : t.itemLimit) && void 0 !== n
+            ? n
+            : 50),
+        (this.sendTimeout =
+          null !== (i = null == t ? void 0 : t.sendTimeout) && void 0 !== i
+            ? i
+            : 250),
+        (this.paused = (null == t ? void 0 : t.paused) || !1),
+        (this.sendFn = e),
+        (this.flushInterval = -1),
+        this.paused || this.start(),
+        document.addEventListener("visibilitychange", () => {
+          "hidden" === document.visibilityState && this.flush();
+        });
+    }
+    addItem(e) {
+      this.paused ||
+        (this.signalBuffer.push(e),
+        this.signalBuffer.length >= this.itemLimit && this.flush());
+    }
+    start() {
+      (this.paused = !1),
+        this.sendTimeout > 0 &&
+          (this.flushInterval = window.setInterval(
+            () => this.flush(),
+            this.sendTimeout
+          ));
+    }
+    pause() {
+      (this.paused = !0), clearInterval(this.flushInterval);
+    }
+    groupItems(e) {
+      const t = new Map();
+      return (
+        e.forEach((e) => {
+          const n = JSON.stringify(e.meta);
+          let i = t.get(n);
+          (i = void 0 === i ? [e] : [...i, e]), t.set(n, i);
+        }),
+        Array.from(t.values())
+      );
+    }
+    flush() {
+      if (this.paused || 0 === this.signalBuffer.length) return;
+      this.groupItems(this.signalBuffer).forEach(this.sendFn),
+        (this.signalBuffer = []);
+    }
+  }
+  var U;
+  (e.TransportItemType = void 0),
+    ((U = e.TransportItemType || (e.TransportItemType = {})).EXCEPTION =
+      "exception"),
+    (U.LOG = "log"),
+    (U.MEASUREMENT = "measurement"),
+    (U.TRACE = "trace"),
+    (U.EVENT = "event");
+  const B = {
+    [e.TransportItemType.EXCEPTION]: "exceptions",
+    [e.TransportItemType.LOG]: "logs",
+    [e.TransportItemType.MEASUREMENT]: "measurements",
+    [e.TransportItemType.TRACE]: "traces",
+    [e.TransportItemType.EVENT]: "events",
+  };
+  function F(e, t, n, i) {
+    var r;
+    t.debug("Initializing transports");
+    const o = [];
+    let s = n.paused,
+      a = [];
+    const u = (e) => {
+        let t = e;
+        for (const e of a) {
+          const i = t.map(e).filter(Boolean);
+          if (0 === i.length) return [];
+          t = z(i, n);
+        }
+        return t;
+      },
+      c = (e) => {
+        const n = u(e);
+        if (0 !== n.length)
+          for (const e of o)
+            t.debug(`Transporting item using ${e.name}\n`, n),
+              e.isBatched() && e.send(n);
+      };
+    let l;
+    (null === (r = n.batching) || void 0 === r ? void 0 : r.enabled) &&
+      (l = new R(c, {
+        sendTimeout: n.batching.sendTimeout,
+        itemLimit: n.batching.itemLimit,
+        paused: s,
+      }));
+    return {
+      add: (...r) => {
+        t.debug("Adding transports"),
+          r.forEach((r) => {
+            t.debug(`Adding "${r.name}" transport`);
+            o.some((e) => e === r)
+              ? t.warn(`Transport ${r.name} is already added`)
+              : ((r.unpatchedConsole = e),
+                (r.internalLogger = t),
+                (r.config = n),
+                (r.metas = i),
+                o.push(r));
+          });
+      },
+      addBeforeSendHooks: (...e) => {
+        t.debug("Adding beforeSendHooks\n", a),
+          e.forEach((e) => {
+            e && a.push(e);
+          });
+      },
+      getBeforeSendHooks: () => [...a],
+      execute: (e) => {
+        var i;
+        s ||
+          ((null === (i = n.batching) || void 0 === i ? void 0 : i.enabled) &&
+            (null == l || l.addItem(e)),
+          ((e) => {
+            var i, r;
+            if (
+              (null === (i = n.batching) || void 0 === i
+                ? void 0
+                : i.enabled) &&
+              o.every((e) => e.isBatched())
+            )
+              return;
+            const [s] = u([e]);
+            if (void 0 !== s)
+              for (const e of o)
+                t.debug(`Transporting item using ${e.name}\n`, s),
+                  e.isBatched()
+                    ? (null === (r = n.batching) || void 0 === r
+                        ? void 0
+                        : r.enabled) || e.send([s])
+                    : e.send(s);
+          })(e));
+      },
+      isPaused: () => s,
+      pause: () => {
+        t.debug("Pausing transports"), null == l || l.pause(), (s = !0);
+      },
+      remove: (...e) => {
+        t.debug("Removing transports"),
+          e.forEach((e) => {
+            t.debug(`Removing "${e.name}" transport`);
+            const n = o.indexOf(e);
+            -1 !== n
+              ? o.splice(n, 1)
+              : t.warn(`Transport "${e.name}" is not added`);
+          });
+      },
+      removeBeforeSendHooks: (...e) => {
+        a.filter((t) => !e.includes(t));
+      },
+      get transports() {
+        return [...o];
+      },
+      unpause: () => {
+        t.debug("Unpausing transports"), null == l || l.start(), (s = !1);
+      },
+    };
+  }
+  function z(t, n) {
+    if (n.preserveOriginalError)
+      for (const n of t)
+        n.type === e.TransportItemType.EXCEPTION &&
+          delete n.payload.originalError;
+    return t;
+  }
+  var q;
+  (e.InternalLoggerLevel = void 0),
+    ((q = e.InternalLoggerLevel || (e.InternalLoggerLevel = {}))[(q.OFF = 0)] =
+      "OFF"),
+    (q[(q.ERROR = 1)] = "ERROR"),
+    (q[(q.WARN = 2)] = "WARN"),
+    (q[(q.INFO = 3)] = "INFO"),
+    (q[(q.VERBOSE = 4)] = "VERBOSE");
+  const V = { debug: C, error: C, info: C, prefix: "Faro", warn: C },
+    $ = e.InternalLoggerLevel.ERROR,
+    G = Object.assign({}, console);
+  let H = G;
+  function W(e) {
+    var t;
+    return (H = null !== (t = e.unpatchedConsole) && void 0 !== t ? t : H), H;
+  }
+  function K(t = G, n = $) {
+    const i = V;
+    return (
+      n > e.InternalLoggerLevel.OFF &&
+        ((i.error =
+          n >= e.InternalLoggerLevel.ERROR
+            ? function (...e) {
+                t.error(`${i.prefix}\n`, ...e);
+              }
+            : C),
+        (i.warn =
+          n >= e.InternalLoggerLevel.WARN
+            ? function (...e) {
+                t.warn(`${i.prefix}\n`, ...e);
+              }
+            : C),
+        (i.info =
+          n >= e.InternalLoggerLevel.INFO
+            ? function (...e) {
+                t.info(`${i.prefix}\n`, ...e);
+              }
+            : C),
+        (i.debug =
+          n >= e.InternalLoggerLevel.VERBOSE
+            ? function (...e) {
+                t.debug(`${i.prefix}\n`, ...e);
+              }
+            : C)),
+      i
+    );
+  }
+  let X = V;
+  function J(e, t) {
+    return (X = K(e, t.internalLoggerLevel)), X;
+  }
+  class Z {
+    constructor() {
+      (this.unpatchedConsole = G),
+        (this.internalLogger = V),
+        (this.config = {}),
+        (this.metas = {});
+    }
+    logDebug(...e) {
+      this.internalLogger.debug(`${this.name}\n`, ...e);
+    }
+    logInfo(...e) {
+      this.internalLogger.info(`${this.name}\n`, ...e);
+    }
+    logWarn(...e) {
+      this.internalLogger.warn(`${this.name}\n`, ...e);
+    }
+    logError(...e) {
+      this.internalLogger.error(`${this.name}\n`, ...e);
+    }
+  }
+  class Y extends Z {
+    isBatched() {
+      return !1;
+    }
+    getIgnoreUrls() {
+      return [];
+    }
+  }
+  function Q(e, t) {
+    var n, i;
+    if (void 0 === t) return e;
+    if (void 0 === e) return { resourceSpans: t };
+    const r = null === (n = e.resourceSpans) || void 0 === n ? void 0 : n[0];
+    if (void 0 === r) return e;
+    const o = (null == r ? void 0 : r.scopeSpans) || [],
+      s =
+        (null === (i = null == t ? void 0 : t[0]) || void 0 === i
+          ? void 0
+          : i.scopeSpans) || [];
+    return Object.assign(Object.assign({}, e), {
+      resourceSpans: [
+        Object.assign(Object.assign({}, r), { scopeSpans: [...o, ...s] }),
+      ],
+    });
+  }
+  function ee(t) {
+    let n = { meta: {} };
+    return (
+      void 0 !== t[0] && (n.meta = t[0].meta),
+      t.forEach((t) => {
+        switch (t.type) {
+          case e.TransportItemType.LOG:
+          case e.TransportItemType.EVENT:
+          case e.TransportItemType.EXCEPTION:
+          case e.TransportItemType.MEASUREMENT:
+            const i = B[t.type],
+              r = n[i];
+            n = Object.assign(Object.assign({}, n), {
+              [i]: void 0 === r ? [t.payload] : [...r, t.payload],
+            });
+            break;
+          case e.TransportItemType.TRACE:
+            n = Object.assign(Object.assign({}, n), {
+              traces: Q(n.traces, t.payload.resourceSpans),
+            });
+        }
+      }),
+      n
+    );
+  }
+  const te = "user-action-start",
+    ne = "user-action-end",
+    ie = "user-action-cancel",
+    re = "user-action-halt";
+  const oe = "Error",
+    se = (e) => e.map((e) => (u(e) ? N(e) : String(e))).join(" ");
+  let ae;
+  function ue({
+    internalLogger: t,
+    config: n,
+    metas: i,
+    transports: s,
+    tracesApi: a,
+    actionBuffer: c,
+    getMessage: d,
+  }) {
+    var f;
+    t.debug("Initializing exceptions API");
+    let p = null;
+    ae = null !== (f = n.parseStacktrace) && void 0 !== f ? f : ae;
+    const g = (e) => {
+        t.debug("Changing stacktrace parser"), (ae = null != e ? e : ae);
+      },
+      { ignoreErrors: v = [], preserveOriginalError: h } = n;
+    return (
+      g(n.parseStacktrace),
+      {
+        changeStacktraceParser: g,
+        getStacktraceParser: () => ae,
+        pushError: (
+          f,
+          {
+            skipDedupe: g,
+            stackFrames: b,
+            type: w,
+            context: y,
+            spanContext: E,
+            timestampOverwriteMs: O,
+            originalError: x,
+          } = {}
+        ) => {
+          if (
+            !(function (e, t) {
+              const { message: n, name: i, stack: r } = t;
+              return (
+                (s = e),
+                (a = n + " " + i + " " + r),
+                s.some((e) => (o(e) ? a.includes(e) : !!a.match(e)))
+              );
+              var s, a;
+            })(v, null != x ? x : f)
+          )
+            try {
+              const o = _(
+                  Object.assign(
+                    Object.assign(
+                      {},
+                      (function (e) {
+                        let t = e.cause;
+                        m(t)
+                          ? (t = e.cause.toString())
+                          : null !== t && (u(e.cause) || l(e.cause))
+                          ? (t = N(e.cause))
+                          : null != t && (t = e.cause.toString());
+                        return null == t ? {} : { cause: t };
+                      })(null != x ? x : f)
+                    ),
+                    null != y ? y : {}
+                  )
+                ),
+                v = {
+                  meta: i.value,
+                  payload: Object.assign(
+                    Object.assign(
+                      {
+                        type: w || f.name || oe,
+                        value: f.message,
+                        timestamp: O ? k(O) : I(),
+                        trace: E
+                          ? { trace_id: E.traceId, span_id: E.spanId }
+                          : a.getTraceContext(),
+                      },
+                      S(o) ? {} : { context: o }
+                    ),
+                    h ? { originalError: x } : {}
+                  ),
+                  type: e.TransportItemType.EXCEPTION,
+                };
+              (null ==
+              (b =
+                null != b
+                  ? b
+                  : f.stack
+                  ? null == ae
+                    ? void 0
+                    : ae(f).frames
+                  : void 0)
+                ? void 0
+                : b.length) && (v.payload.stacktrace = { frames: b });
+              const L = {
+                type: v.payload.type,
+                value: v.payload.value,
+                stackTrace: v.payload.stacktrace,
+                context: v.payload.context,
+              };
+              if (!g && n.dedupe && !r(p) && T(L, p))
+                return void t.debug(
+                  "Skipping error push because it is the same as the last one\n",
+                  v.payload
+                );
+              (p = L), t.debug("Pushing exception\n", v);
+              const C = d();
+              C && C.type === te ? c.addItem(v) : s.execute(v);
+            } catch (e) {
+              t.error("Error pushing event", e);
+            }
+        },
+      }
+    );
+  }
+  const ce = (e) =>
+    e
+      .map((e) => {
+        try {
+          return String(e);
+        } catch (e) {
+          return "";
+        }
+      })
+      .join(" ");
+  class le {
+    constructor() {
+      this.buffer = [];
+    }
+    addItem(e) {
+      this.buffer.push(e);
+    }
+    flushBuffer(e) {
+      if (c(e)) for (const t of this.buffer) e(t);
+      this.buffer.length = 0;
+    }
+    size() {
+      return this.buffer.length;
+    }
+  }
+  function de({ apiMessageBus: t, transports: n, config: i }) {
+    const r = new le(),
+      o = i.trackUserActionsExcludeItem;
+    let s;
+    t.subscribe((t) => {
+      if (te !== t.type && re !== t.type) {
+        if (t.type === ne) {
+          const { id: i, name: a } = t;
+          return (
+            r.flushBuffer((t) => {
+              if (
+                (function (t, n) {
+                  return (
+                    (null == n ? void 0 : n(t)) ||
+                    (t.type === e.TransportItemType.MEASUREMENT &&
+                      "web-vitals" === t.payload.type)
+                  );
+                })(t, o)
+              )
+                return void n.execute(t);
+              const r = Object.assign(Object.assign({}, t), {
+                payload: Object.assign(Object.assign({}, t.payload), {
+                  action: { parentId: i, name: a },
+                }),
+              });
+              n.execute(r);
+            }),
+            void (s = void 0)
+          );
+        }
+        t.type === ie &&
+          ((s = void 0),
+          r.flushBuffer((e) => {
+            n.execute(e);
+          }));
+      } else s = t;
+    });
+    return { actionBuffer: r, getMessage: () => s };
+  }
+  const fe = new D();
+  function pe(t, n, i, s, a) {
+    n.debug("Initializing API");
+    const { actionBuffer: u, getMessage: c } = de({
+        apiMessageBus: fe,
+        transports: a,
+        config: i,
+      }),
+      l = (function (t, n, i, r, o) {
+        let s;
+        return (
+          n.debug("Initializing traces API"),
+          {
+            getOTEL: () => s,
+            getTraceContext: () => {
+              const e =
+                null == s ? void 0 : s.trace.getSpanContext(s.context.active());
+              return e ? { trace_id: e.traceId, span_id: e.spanId } : void 0;
+            },
+            initOTEL: (e, t) => {
+              n.debug("Initializing OpenTelemetry"),
+                (s = { trace: e, context: t });
+            },
+            isOTELInitialized: () => !!s,
+            pushTraces: (t) => {
+              try {
+                const i = {
+                  type: e.TransportItemType.TRACE,
+                  payload: t,
+                  meta: r.value,
+                };
+                n.debug("Pushing trace\n", i), o.execute(i);
+              } catch (e) {
+                n.error("Error pushing trace\n", e);
+              }
+            },
+          }
+        );
+      })(0, n, 0, s, a),
+      d = {
+        unpatchedConsole: t,
+        internalLogger: n,
+        config: i,
+        metas: s,
+        transports: a,
+        tracesApi: l,
+        actionBuffer: u,
+        getMessage: c,
+      };
+    return Object.assign(
+      Object.assign(
+        Object.assign(
+          Object.assign(
+            Object.assign(Object.assign({}, l), ue(d)),
+            (function ({ internalLogger: e, metas: t }) {
+              let n, i, r, s;
+              e.debug("Initializing meta API");
+              const a = (e) => {
+                  i && t.remove(i), (i = { user: e }), t.add(i);
+                },
+                u = (e, i) => {
+                  var r;
+                  const o = null == i ? void 0 : i.overrides,
+                    s = o
+                      ? {
+                          overrides: Object.assign(
+                            Object.assign(
+                              {},
+                              null === (r = null == n ? void 0 : n.session) ||
+                                void 0 === r
+                                ? void 0
+                                : r.overrides
+                            ),
+                            o
+                          ),
+                        }
+                      : {};
+                  n && t.remove(n),
+                    (n = {
+                      session: Object.assign(
+                        Object.assign({}, S(e) ? void 0 : e),
+                        s
+                      ),
+                    }),
+                    t.add(n);
+                },
+                c = () => t.value.session,
+                l = () => t.value.page;
+              return {
+                setUser: a,
+                resetUser: a,
+                setSession: u,
+                resetSession: u,
+                getSession: c,
+                setView: (e, n) => {
+                  var i;
+                  if (
+                    ((null == n ? void 0 : n.overrides) &&
+                      u(c(), { overrides: n.overrides }),
+                    (null === (i = null == r ? void 0 : r.view) || void 0 === i
+                      ? void 0
+                      : i.name) === (null == e ? void 0 : e.name))
+                  )
+                    return;
+                  const o = r;
+                  (r = { view: e }), t.add(r), o && t.remove(o);
+                },
+                getView: () => t.value.view,
+                setPage: (e) => {
+                  var n;
+                  const i = o(e)
+                    ? Object.assign(
+                        Object.assign(
+                          {},
+                          null !== (n = null == s ? void 0 : s.page) &&
+                            void 0 !== n
+                            ? n
+                            : l()
+                        ),
+                        { id: e }
+                      )
+                    : e;
+                  s && t.remove(s), (s = { page: i }), t.add(s);
+                },
+                getPage: l,
+              };
+            })(d)
+          ),
+          (function ({
+            internalLogger: t,
+            config: n,
+            metas: i,
+            transports: o,
+            tracesApi: s,
+            actionBuffer: a,
+            getMessage: u,
+          }) {
+            var c;
+            t.debug("Initializing logs API");
+            let l = null;
+            const d =
+              null !== (c = n.logArgsSerializer) && void 0 !== c ? c : ce;
+            return {
+              pushLog: (
+                c,
+                {
+                  context: f,
+                  level: p,
+                  skipDedupe: g,
+                  spanContext: m,
+                  timestampOverwriteMs: v,
+                } = {}
+              ) => {
+                try {
+                  const h = _(f),
+                    b = {
+                      type: e.TransportItemType.LOG,
+                      payload: {
+                        message: d(c),
+                        level: null != p ? p : x,
+                        context: S(h) ? void 0 : h,
+                        timestamp: v ? k(v) : I(),
+                        trace: m
+                          ? { trace_id: m.traceId, span_id: m.spanId }
+                          : s.getTraceContext(),
+                      },
+                      meta: i.value,
+                    },
+                    w = {
+                      message: b.payload.message,
+                      level: b.payload.level,
+                      context: b.payload.context,
+                    };
+                  if (!g && n.dedupe && !r(l) && T(w, l))
+                    return void t.debug(
+                      "Skipping log push because it is the same as the last one\n",
+                      b.payload
+                    );
+                  (l = w), t.debug("Pushing log\n", b);
+                  const y = u();
+                  y && y.type === te ? a.addItem(b) : o.execute(b);
+                } catch (e) {
+                  t.error("Error pushing log\n", e);
+                }
+              },
+            };
+          })(d)
+        ),
+        (function ({
+          internalLogger: t,
+          config: n,
+          metas: i,
+          transports: o,
+          tracesApi: s,
+          actionBuffer: a,
+          getMessage: u,
+        }) {
+          t.debug("Initializing measurements API");
+          let c = null;
+          return {
+            pushMeasurement: (
+              l,
+              {
+                skipDedupe: d,
+                context: f,
+                spanContext: p,
+                timestampOverwriteMs: g,
+              } = {}
+            ) => {
+              try {
+                const m = _(f),
+                  v = {
+                    type: e.TransportItemType.MEASUREMENT,
+                    payload: Object.assign(Object.assign({}, l), {
+                      trace: p
+                        ? { trace_id: p.traceId, span_id: p.spanId }
+                        : s.getTraceContext(),
+                      timestamp: g ? k(g) : I(),
+                      context: S(m) ? void 0 : m,
+                    }),
+                    meta: i.value,
+                  },
+                  h = {
+                    type: v.payload.type,
+                    values: v.payload.values,
+                    context: v.payload.context,
+                  };
+                if (!d && n.dedupe && !r(c) && T(h, c))
+                  return void t.debug(
+                    "Skipping measurement push because it is the same as the last one\n",
+                    v.payload
+                  );
+                (c = h), t.debug("Pushing measurement\n", v);
+                const b = u();
+                b && b.type === te ? a.addItem(v) : o.execute(v);
+              } catch (e) {
+                t.error("Error pushing measurement\n", e);
+              }
+            },
+          };
+        })(d)
+      ),
+      (function ({
+        internalLogger: t,
+        config: n,
+        metas: i,
+        transports: o,
+        tracesApi: s,
+        actionBuffer: a,
+        getMessage: u,
+      }) {
+        let c = null;
+        return {
+          pushEvent: (
+            l,
+            d,
+            f,
+            {
+              skipDedupe: p,
+              spanContext: g,
+              timestampOverwriteMs: m,
+              customPayloadTransformer: v = (e) => e,
+            } = {}
+          ) => {
+            try {
+              const h = _(d),
+                b = {
+                  meta: i.value,
+                  payload: v({
+                    name: l,
+                    domain: null != f ? f : n.eventDomain,
+                    attributes: S(h) ? void 0 : h,
+                    timestamp: m ? k(m) : I(),
+                    trace: g
+                      ? { trace_id: g.traceId, span_id: g.spanId }
+                      : s.getTraceContext(),
+                  }),
+                  type: e.TransportItemType.EVENT,
+                },
+                w = {
+                  name: b.payload.name,
+                  attributes: b.payload.attributes,
+                  domain: b.payload.domain,
+                };
+              if (!p && n.dedupe && !r(c) && T(w, c))
+                return void t.debug(
+                  "Skipping event push because it is the same as the last one\n",
+                  b.payload
+                );
+              (c = w), t.debug("Pushing event\n", b);
+              const y = u();
+              y && y.type === te ? a.addItem(b) : o.execute(b);
+            } catch (e) {
+              t.error("Error pushing event", e);
+            }
+          },
+        };
+      })(d)
+    );
+  }
+  class ge extends Z {
+    constructor() {
+      super(...arguments), (this.api = {}), (this.transports = {});
+    }
+  }
+  const me = "1.18.1";
+  const ve = "_faroInternal";
+  function he(e) {
+    e.config.isolate
+      ? e.internalLogger.debug(
+          "Skipping registering internal Faro instance on global object"
+        )
+      : (e.internalLogger.debug(
+          "Registering internal Faro instance on global object"
+        ),
+        Object.defineProperty(j, ve, {
+          configurable: !1,
+          enumerable: !1,
+          writable: !1,
+          value: e,
+        }));
+  }
+  function be() {
+    return ve in j;
+  }
+  function we(t, n, i, r, o, s, a) {
+    return (
+      n.debug("Initializing Faro"),
+      (e.faro = {
+        api: s,
+        config: i,
+        instrumentations: a,
+        internalLogger: n,
+        metas: r,
+        pause: o.pause,
+        transports: o,
+        unpatchedConsole: t,
+        unpause: o.unpause,
+      }),
+      he(e.faro),
+      (function (e) {
+        if (e.config.preventGlobalExposure)
+          e.internalLogger.debug(
+            "Skipping registering public Faro instance in the global scope"
+          );
+        else {
+          if (
+            (e.internalLogger.debug(
+              `Registering public faro reference in the global scope using "${e.config.globalObjectKey}" key`
+            ),
+            e.config.globalObjectKey in j)
+          )
+            return void e.internalLogger.warn(
+              `Skipping global registration due to key "${e.config.globalObjectKey}" being used already. Please set "globalObjectKey" to something else or set "preventGlobalExposure" to "true"`
+            );
+          Object.defineProperty(j, e.config.globalObjectKey, {
+            configurable: !1,
+            writable: !1,
+            value: e,
+          });
+        }
+      })(e.faro),
+      e.faro
+    );
+  }
+  function ye(e) {
+    const t = W(e),
+      n = J(t, e);
+    if (be() && !e.isolate)
+      return void n.error(
+        'Faro is already registered. Either add instrumentations, transports etc. to the global faro instance or use the "isolate" property'
+      );
+    n.debug("Initializing");
+    const i = (function (e, t) {
+        let n = [],
+          i = [];
+        const r = () =>
+            n.reduce((e, t) => Object.assign(e, c(t) ? t() : t), {}),
+          o = () => {
+            if (i.length) {
+              const e = r();
+              i.forEach((t) => t(e));
+            }
+          };
+        return {
+          add: (...e) => {
+            t.debug("Adding metas\n", e), n.push(...e), o();
+          },
+          remove: (...e) => {
+            t.debug("Removing metas\n", e),
+              (n = n.filter((t) => !e.includes(t))),
+              o();
+          },
+          addListener: (e) => {
+            t.debug("Adding metas listener\n", e), i.push(e);
+          },
+          removeListener: (e) => {
+            t.debug("Removing metas listener\n", e),
+              (i = i.filter((t) => t !== e));
+          },
+          get value() {
+            return r();
+          },
+        };
+      })(0, n),
+      r = F(t, n, e, i),
+      o = pe(t, n, e, i, r),
+      s = (function (e, t, n, i, r, o) {
+        t.debug("Initializing instrumentations");
+        const s = [];
+        return {
+          add: (...a) => {
+            t.debug("Adding instrumentations"),
+              a.forEach((a) => {
+                t.debug(`Adding "${a.name}" instrumentation`),
+                  s.some((e) => e.name === a.name)
+                    ? t.warn(`Instrumentation ${a.name} is already added`)
+                    : ((a.unpatchedConsole = e),
+                      (a.internalLogger = t),
+                      (a.config = n),
+                      (a.metas = i),
+                      (a.transports = r),
+                      (a.api = o),
+                      s.push(a),
+                      a.initialize());
+              });
+          },
+          get instrumentations() {
+            return [...s];
+          },
+          remove: (...e) => {
+            t.debug("Removing instrumentations"),
+              e.forEach((e) => {
+                var n, i;
+                t.debug(`Removing "${e.name}" instrumentation`);
+                const r = s.reduce(
+                  (t, n, i) => (null === t && n.name === e.name ? i : null),
+                  null
+                );
+                r
+                  ? (null === (i = (n = s[r]).destroy) ||
+                      void 0 === i ||
+                      i.call(n),
+                    s.splice(r, 1))
+                  : t.warn(`Instrumentation "${e.name}" is not added`);
+              });
+          },
+        };
+      })(t, n, e, i, r, o),
+      a = we(t, n, e, i, r, o, s);
+    return (
+      (function (e) {
+        var t, n;
+        const i = {
+          sdk: { version: me },
+          app: {
+            bundleId:
+              e.config.app.name &&
+              ((r = e.config.app.name),
+              null == j ? void 0 : j[`__faroBundleId_${r}`]),
+          },
+        };
+        var r;
+        const o =
+          null === (t = e.config.sessionTracking) || void 0 === t
+            ? void 0
+            : t.session;
+        o && e.api.setSession(o),
+          e.config.app &&
+            (i.app = Object.assign(Object.assign({}, e.config.app), i.app)),
+          e.config.user && (i.user = e.config.user),
+          e.config.view && (i.view = e.config.view),
+          e.metas.add(
+            i,
+            ...(null !== (n = e.config.metas) && void 0 !== n ? n : [])
+          );
+      })(a),
+      (function (e) {
+        e.transports.add(...e.config.transports),
+          e.transports.addBeforeSendHooks(e.config.beforeSend);
+      })(a),
+      (function (e) {
+        e.instrumentations.add(...e.config.instrumentations);
+      })(a),
+      a
+    );
+  }
+  e.faro = {};
+  const Se = "faro",
+    Te = { enabled: !0, sendTimeout: 250, itemLimit: 50 },
+    Ee = "view_changed",
+    Ie = "session_start",
+    ke = "session_resume",
+    Oe = "session_extend",
+    xe = "service_name_override",
+    Le = "unknown";
+  var Ce,
+    Ae = { exports: {} },
+    Pe = Ae.exports;
+  var Me =
+    (Ce ||
+      ((Ce = 1),
+      (function (e, t) {
+        !(function (n, i) {
+          var r = "function",
+            o = "undefined",
+            s = "object",
+            a = "string",
+            u = "major",
+            c = "model",
+            l = "name",
+            d = "type",
+            f = "vendor",
+            p = "version",
+            g = "architecture",
+            m = "console",
+            v = "mobile",
+            h = "tablet",
+            b = "smarttv",
+            w = "wearable",
+            y = "embedded",
+            S = "Amazon",
+            T = "Apple",
+            E = "ASUS",
+            I = "BlackBerry",
+            k = "Browser",
+            O = "Chrome",
+            x = "Firefox",
+            L = "Google",
+            C = "Huawei",
+            A = "LG",
+            P = "Microsoft",
+            M = "Motorola",
+            j = "Opera",
+            N = "Samsung",
+            _ = "Sharp",
+            D = "Sony",
+            R = "Xiaomi",
+            U = "Zebra",
+            B = "Facebook",
+            F = "Chromium OS",
+            z = "Mac OS",
+            q = " Browser",
+            V = function (e) {
+              for (var t = {}, n = 0; n < e.length; n++)
+                t[e[n].toUpperCase()] = e[n];
+              return t;
+            },
+            $ = function (e, t) {
+              return typeof e === a && -1 !== G(t).indexOf(G(e));
+            },
+            G = function (e) {
+              return e.toLowerCase();
+            },
+            H = function (e, t) {
+              if (typeof e === a)
+                return (
+                  (e = e.replace(/^\s\s*/, "")),
+                  typeof t === o ? e : e.substring(0, 500)
+                );
+            },
+            W = function (e, t) {
+              for (var n, o, a, u, c, l, d = 0; d < t.length && !c; ) {
+                var f = t[d],
+                  p = t[d + 1];
+                for (n = o = 0; n < f.length && !c && f[n]; )
+                  if ((c = f[n++].exec(e)))
+                    for (a = 0; a < p.length; a++)
+                      (l = c[++o]),
+                        typeof (u = p[a]) === s && u.length > 0
+                          ? 2 === u.length
+                            ? typeof u[1] == r
+                              ? (this[u[0]] = u[1].call(this, l))
+                              : (this[u[0]] = u[1])
+                            : 3 === u.length
+                            ? typeof u[1] !== r || (u[1].exec && u[1].test)
+                              ? (this[u[0]] = l ? l.replace(u[1], u[2]) : i)
+                              : (this[u[0]] = l ? u[1].call(this, l, u[2]) : i)
+                            : 4 === u.length &&
+                              (this[u[0]] = l
+                                ? u[3].call(this, l.replace(u[1], u[2]))
+                                : i)
+                          : (this[u] = l || i);
+                d += 2;
+              }
+            },
+            K = function (e, t) {
+              for (var n in t)
+                if (typeof t[n] === s && t[n].length > 0) {
+                  for (var r = 0; r < t[n].length; r++)
+                    if ($(t[n][r], e)) return "?" === n ? i : n;
+                } else if ($(t[n], e)) return "?" === n ? i : n;
+              return t.hasOwnProperty("*") ? t["*"] : e;
+            },
+            X = {
+              ME: "4.90",
+              "NT 3.11": "NT3.51",
+              "NT 4.0": "NT4.0",
+              2e3: "NT 5.0",
+              XP: ["NT 5.1", "NT 5.2"],
+              Vista: "NT 6.0",
+              7: "NT 6.1",
+              8: "NT 6.2",
+              8.1: "NT 6.3",
+              10: ["NT 6.4", "NT 10.0"],
+              RT: "ARM",
+            },
+            J = {
+              browser: [
+                [/\b(?:crmo|crios)\/([\w\.]+)/i],
+                [p, [l, "Chrome"]],
+                [/edg(?:e|ios|a)?\/([\w\.]+)/i],
+                [p, [l, "Edge"]],
+                [
+                  /(opera mini)\/([-\w\.]+)/i,
+                  /(opera [mobiletab]{3,6})\b.+version\/([-\w\.]+)/i,
+                  /(opera)(?:.+version\/|[\/ ]+)([\w\.]+)/i,
+                ],
+                [l, p],
+                [/opios[\/ ]+([\w\.]+)/i],
+                [p, [l, j + " Mini"]],
+                [/\bop(?:rg)?x\/([\w\.]+)/i],
+                [p, [l, j + " GX"]],
+                [/\bopr\/([\w\.]+)/i],
+                [p, [l, j]],
+                [/\bb[ai]*d(?:uhd|[ub]*[aekoprswx]{5,6})[\/ ]?([\w\.]+)/i],
+                [p, [l, "Baidu"]],
+                [/\b(?:mxbrowser|mxios|myie2)\/?([-\w\.]*)\b/i],
+                [p, [l, "Maxthon"]],
+                [
+                  /(kindle)\/([\w\.]+)/i,
+                  /(lunascape|maxthon|netfront|jasmine|blazer|sleipnir)[\/ ]?([\w\.]*)/i,
+                  /(avant|iemobile|slim(?:browser|boat|jet))[\/ ]?([\d\.]*)/i,
+                  /(?:ms|\()(ie) ([\w\.]+)/i,
+                  /(flock|rockmelt|midori|epiphany|silk|skyfire|ovibrowser|bolt|iron|vivaldi|iridium|phantomjs|bowser|qupzilla|falkon|rekonq|puffin|brave|whale(?!.+naver)|qqbrowserlite|duckduckgo|klar|helio|(?=comodo_)?dragon)\/([-\w\.]+)/i,
+                  /(heytap|ovi|115)browser\/([\d\.]+)/i,
+                  /(weibo)__([\d\.]+)/i,
+                ],
+                [l, p],
+                [/quark(?:pc)?\/([-\w\.]+)/i],
+                [p, [l, "Quark"]],
+                [/\bddg\/([\w\.]+)/i],
+                [p, [l, "DuckDuckGo"]],
+                [/(?:\buc? ?browser|(?:juc.+)ucweb)[\/ ]?([\w\.]+)/i],
+                [p, [l, "UC" + k]],
+                [
+                  /microm.+\bqbcore\/([\w\.]+)/i,
+                  /\bqbcore\/([\w\.]+).+microm/i,
+                  /micromessenger\/([\w\.]+)/i,
+                ],
+                [p, [l, "WeChat"]],
+                [/konqueror\/([\w\.]+)/i],
+                [p, [l, "Konqueror"]],
+                [/trident.+rv[: ]([\w\.]{1,9})\b.+like gecko/i],
+                [p, [l, "IE"]],
+                [/ya(?:search)?browser\/([\w\.]+)/i],
+                [p, [l, "Yandex"]],
+                [/slbrowser\/([\w\.]+)/i],
+                [p, [l, "Smart Lenovo " + k]],
+                [/(avast|avg)\/([\w\.]+)/i],
+                [[l, /(.+)/, "$1 Secure " + k], p],
+                [/\bfocus\/([\w\.]+)/i],
+                [p, [l, x + " Focus"]],
+                [/\bopt\/([\w\.]+)/i],
+                [p, [l, j + " Touch"]],
+                [/coc_coc\w+\/([\w\.]+)/i],
+                [p, [l, "Coc Coc"]],
+                [/dolfin\/([\w\.]+)/i],
+                [p, [l, "Dolphin"]],
+                [/coast\/([\w\.]+)/i],
+                [p, [l, j + " Coast"]],
+                [/miuibrowser\/([\w\.]+)/i],
+                [p, [l, "MIUI" + q]],
+                [/fxios\/([\w\.-]+)/i],
+                [p, [l, x]],
+                [/\bqihoobrowser\/?([\w\.]*)/i],
+                [p, [l, "360"]],
+                [/\b(qq)\/([\w\.]+)/i],
+                [[l, /(.+)/, "$1Browser"], p],
+                [/(oculus|sailfish|huawei|vivo|pico)browser\/([\w\.]+)/i],
+                [[l, /(.+)/, "$1" + q], p],
+                [/samsungbrowser\/([\w\.]+)/i],
+                [p, [l, N + " Internet"]],
+                [/metasr[\/ ]?([\d\.]+)/i],
+                [p, [l, "Sogou Explorer"]],
+                [/(sogou)mo\w+\/([\d\.]+)/i],
+                [[l, "Sogou Mobile"], p],
+                [
+                  /(electron)\/([\w\.]+) safari/i,
+                  /(tesla)(?: qtcarbrowser|\/(20\d\d\.[-\w\.]+))/i,
+                  /m?(qqbrowser|2345(?=browser|chrome|explorer))\w*[\/ ]?v?([\w\.]+)/i,
+                ],
+                [l, p],
+                [/(lbbrowser|rekonq)/i, /\[(linkedin)app\]/i],
+                [l],
+                [
+                  /ome\/([\w\.]+) \w* ?(iron) saf/i,
+                  /ome\/([\w\.]+).+qihu (360)[es]e/i,
+                ],
+                [p, l],
+                [/((?:fban\/fbios|fb_iab\/fb4a)(?!.+fbav)|;fbav\/([\w\.]+);)/i],
+                [[l, B], p],
+                [
+                  /(Klarna)\/([\w\.]+)/i,
+                  /(kakao(?:talk|story))[\/ ]([\w\.]+)/i,
+                  /(naver)\(.*?(\d+\.[\w\.]+).*\)/i,
+                  /safari (line)\/([\w\.]+)/i,
+                  /\b(line)\/([\w\.]+)\/iab/i,
+                  /(alipay)client\/([\w\.]+)/i,
+                  /(twitter)(?:and| f.+e\/([\w\.]+))/i,
+                  /(chromium|instagram|snapchat)[\/ ]([-\w\.]+)/i,
+                ],
+                [l, p],
+                [/\bgsa\/([\w\.]+) .*safari\//i],
+                [p, [l, "GSA"]],
+                [/musical_ly(?:.+app_?version\/|_)([\w\.]+)/i],
+                [p, [l, "TikTok"]],
+                [/headlesschrome(?:\/([\w\.]+)| )/i],
+                [p, [l, O + " Headless"]],
+                [/ wv\).+(chrome)\/([\w\.]+)/i],
+                [[l, O + " WebView"], p],
+                [/droid.+ version\/([\w\.]+)\b.+(?:mobile safari|safari)/i],
+                [p, [l, "Android " + k]],
+                [/(chrome|omniweb|arora|[tizenoka]{5} ?browser)\/v?([\w\.]+)/i],
+                [l, p],
+                [/version\/([\w\.\,]+) .*mobile\/\w+ (safari)/i],
+                [p, [l, "Mobile Safari"]],
+                [/version\/([\w(\.|\,)]+) .*(mobile ?safari|safari)/i],
+                [p, l],
+                [/webkit.+?(mobile ?safari|safari)(\/[\w\.]+)/i],
+                [
+                  l,
+                  [
+                    p,
+                    K,
+                    {
+                      "1.0": "/8",
+                      1.2: "/1",
+                      1.3: "/3",
+                      "2.0": "/412",
+                      "2.0.2": "/416",
+                      "2.0.3": "/417",
+                      "2.0.4": "/419",
+                      "?": "/",
+                    },
+                  ],
+                ],
+                [/(webkit|khtml)\/([\w\.]+)/i],
+                [l, p],
+                [/(navigator|netscape\d?)\/([-\w\.]+)/i],
+                [[l, "Netscape"], p],
+                [/(wolvic|librewolf)\/([\w\.]+)/i],
+                [l, p],
+                [/mobile vr; rv:([\w\.]+)\).+firefox/i],
+                [p, [l, x + " Reality"]],
+                [
+                  /ekiohf.+(flow)\/([\w\.]+)/i,
+                  /(swiftfox)/i,
+                  /(icedragon|iceweasel|camino|chimera|fennec|maemo browser|minimo|conkeror)[\/ ]?([\w\.\+]+)/i,
+                  /(seamonkey|k-meleon|icecat|iceape|firebird|phoenix|palemoon|basilisk|waterfox)\/([-\w\.]+)$/i,
+                  /(firefox)\/([\w\.]+)/i,
+                  /(mozilla)\/([\w\.]+) .+rv\:.+gecko\/\d+/i,
+                  /(polaris|lynx|dillo|icab|doris|amaya|w3m|netsurf|obigo|mosaic|(?:go|ice|up)[\. ]?browser)[-\/ ]?v?([\w\.]+)/i,
+                  /(links) \(([\w\.]+)/i,
+                ],
+                [l, [p, /_/g, "."]],
+                [/(cobalt)\/([\w\.]+)/i],
+                [l, [p, /master.|lts./, ""]],
+              ],
+              cpu: [
+                [/(?:(amd|x(?:(?:86|64)[-_])?|wow|win)64)[;\)]/i],
+                [[g, "amd64"]],
+                [/(ia32(?=;))/i],
+                [[g, G]],
+                [/((?:i[346]|x)86)[;\)]/i],
+                [[g, "ia32"]],
+                [/\b(aarch64|arm(v?8e?l?|_?64))\b/i],
+                [[g, "arm64"]],
+                [/\b(arm(?:v[67])?ht?n?[fl]p?)\b/i],
+                [[g, "armhf"]],
+                [/windows (ce|mobile); ppc;/i],
+                [[g, "arm"]],
+                [/((?:ppc|powerpc)(?:64)?)(?: mac|;|\))/i],
+                [[g, /ower/, "", G]],
+                [/(sun4\w)[;\)]/i],
+                [[g, "sparc"]],
+                [
+                  /((?:avr32|ia64(?=;))|68k(?=\))|\barm(?=v(?:[1-7]|[5-7]1)l?|;|eabi)|(?=atmel )avr|(?:irix|mips|sparc)(?:64)?\b|pa-risc)/i,
+                ],
+                [[g, G]],
+              ],
+              device: [
+                [
+                  /\b(sch-i[89]0\d|shw-m380s|sm-[ptx]\w{2,4}|gt-[pn]\d{2,4}|sgh-t8[56]9|nexus 10)/i,
+                ],
+                [c, [f, N], [d, h]],
+                [
+                  /\b((?:s[cgp]h|gt|sm)-(?![lr])\w+|sc[g-]?[\d]+a?|galaxy nexus)/i,
+                  /samsung[- ]((?!sm-[lr])[-\w]+)/i,
+                  /sec-(sgh\w+)/i,
+                ],
+                [c, [f, N], [d, v]],
+                [/(?:\/|\()(ip(?:hone|od)[\w, ]*)(?:\/|;)/i],
+                [c, [f, T], [d, v]],
+                [
+                  /\((ipad);[-\w\),; ]+apple/i,
+                  /applecoremedia\/[\w\.]+ \((ipad)/i,
+                  /\b(ipad)\d\d?,\d\d?[;\]].+ios/i,
+                ],
+                [c, [f, T], [d, h]],
+                [/(macintosh);/i],
+                [c, [f, T]],
+                [/\b(sh-?[altvz]?\d\d[a-ekm]?)/i],
+                [c, [f, _], [d, v]],
+                [/(?:honor)([-\w ]+)[;\)]/i],
+                [c, [f, "Honor"], [d, v]],
+                [/\b((?:ag[rs][23]?|bah2?|sht?|btv)-a?[lw]\d{2})\b(?!.+d\/s)/i],
+                [c, [f, C], [d, h]],
+                [
+                  /(?:huawei)([-\w ]+)[;\)]/i,
+                  /\b(nexus 6p|\w{2,4}e?-[atu]?[ln][\dx][012359c][adn]?)\b(?!.+d\/s)/i,
+                ],
+                [c, [f, C], [d, v]],
+                [
+                  /\b(poco[\w ]+|m2\d{3}j\d\d[a-z]{2})(?: bui|\))/i,
+                  /\b; (\w+) build\/hm\1/i,
+                  /\b(hm[-_ ]?note?[_ ]?(?:\d\w)?) bui/i,
+                  /\b(redmi[\-_ ]?(?:note|k)?[\w_ ]+)(?: bui|\))/i,
+                  /oid[^\)]+; (m?[12][0-389][01]\w{3,6}[c-y])( bui|; wv|\))/i,
+                  /\b(mi[-_ ]?(?:a\d|one|one[_ ]plus|note lte|max|cc)?[_ ]?(?:\d?\w?)[_ ]?(?:plus|se|lite|pro)?)(?: bui|\))/i,
+                ],
+                [
+                  [c, /_/g, " "],
+                  [f, R],
+                  [d, v],
+                ],
+                [
+                  /oid[^\)]+; (2\d{4}(283|rpbf)[cgl])( bui|\))/i,
+                  /\b(mi[-_ ]?(?:pad)(?:[\w_ ]+))(?: bui|\))/i,
+                ],
+                [
+                  [c, /_/g, " "],
+                  [f, R],
+                  [d, h],
+                ],
+                [
+                  /; (\w+) bui.+ oppo/i,
+                  /\b(cph[12]\d{3}|p(?:af|c[al]|d\w|e[ar])[mt]\d0|x9007|a101op)\b/i,
+                ],
+                [c, [f, "OPPO"], [d, v]],
+                [/\b(opd2\d{3}a?) bui/i],
+                [c, [f, "OPPO"], [d, h]],
+                [/vivo (\w+)(?: bui|\))/i, /\b(v[12]\d{3}\w?[at])(?: bui|;)/i],
+                [c, [f, "Vivo"], [d, v]],
+                [/\b(rmx[1-3]\d{3})(?: bui|;|\))/i],
+                [c, [f, "Realme"], [d, v]],
+                [
+                  /\b(milestone|droid(?:[2-4x]| (?:bionic|x2|pro|razr))?:?( 4g)?)\b[\w ]+build\//i,
+                  /\bmot(?:orola)?[- ](\w*)/i,
+                  /((?:moto[\w\(\) ]+|xt\d{3,4}|nexus 6)(?= bui|\)))/i,
+                ],
+                [c, [f, M], [d, v]],
+                [/\b(mz60\d|xoom[2 ]{0,2}) build\//i],
+                [c, [f, M], [d, h]],
+                [
+                  /((?=lg)?[vl]k\-?\d{3}) bui| 3\.[-\w; ]{10}lg?-([06cv9]{3,4})/i,
+                ],
+                [c, [f, A], [d, h]],
+                [
+                  /(lm(?:-?f100[nv]?|-[\w\.]+)(?= bui|\))|nexus [45])/i,
+                  /\blg[-e;\/ ]+((?!browser|netcast|android tv)\w+)/i,
+                  /\blg-?([\d\w]+) bui/i,
+                ],
+                [c, [f, A], [d, v]],
+                [
+                  /(ideatab[-\w ]+)/i,
+                  /lenovo ?(s[56]000[-\w]+|tab(?:[\w ]+)|yt[-\d\w]{6}|tb[-\d\w]{6})/i,
+                ],
+                [c, [f, "Lenovo"], [d, h]],
+                [
+                  /(?:maemo|nokia).*(n900|lumia \d+)/i,
+                  /nokia[-_ ]?([-\w\.]*)/i,
+                ],
+                [
+                  [c, /_/g, " "],
+                  [f, "Nokia"],
+                  [d, v],
+                ],
+                [/(pixel c)\b/i],
+                [c, [f, L], [d, h]],
+                [/droid.+; (pixel[\daxl ]{0,6})(?: bui|\))/i],
+                [c, [f, L], [d, v]],
+                [
+                  /droid.+; (a?\d[0-2]{2}so|[c-g]\d{4}|so[-gl]\w+|xq-a\w[4-7][12])(?= bui|\).+chrome\/(?![1-6]{0,1}\d\.))/i,
+                ],
+                [c, [f, D], [d, v]],
+                [/sony tablet [ps]/i, /\b(?:sony)?sgp\w+(?: bui|\))/i],
+                [
+                  [c, "Xperia Tablet"],
+                  [f, D],
+                  [d, h],
+                ],
+                [
+                  / (kb2005|in20[12]5|be20[12][59])\b/i,
+                  /(?:one)?(?:plus)? (a\d0\d\d)(?: b|\))/i,
+                ],
+                [c, [f, "OnePlus"], [d, v]],
+                [
+                  /(alexa)webm/i,
+                  /(kf[a-z]{2}wi|aeo(?!bc)\w\w)( bui|\))/i,
+                  /(kf[a-z]+)( bui|\)).+silk\//i,
+                ],
+                [c, [f, S], [d, h]],
+                [/((?:sd|kf)[0349hijorstuw]+)( bui|\)).+silk\//i],
+                [
+                  [c, /(.+)/g, "Fire Phone $1"],
+                  [f, S],
+                  [d, v],
+                ],
+                [/(playbook);[-\w\),; ]+(rim)/i],
+                [c, f, [d, h]],
+                [/\b((?:bb[a-f]|st[hv])100-\d)/i, /\(bb10; (\w+)/i],
+                [c, [f, I], [d, v]],
+                [
+                  /(?:\b|asus_)(transfo[prime ]{4,10} \w+|eeepc|slider \w+|nexus 7|padfone|p00[cj])/i,
+                ],
+                [c, [f, E], [d, h]],
+                [/ (z[bes]6[027][012][km][ls]|zenfone \d\w?)\b/i],
+                [c, [f, E], [d, v]],
+                [/(nexus 9)/i],
+                [c, [f, "HTC"], [d, h]],
+                [
+                  /(htc)[-;_ ]{1,2}([\w ]+(?=\)| bui)|\w+)/i,
+                  /(zte)[- ]([\w ]+?)(?: bui|\/|\))/i,
+                  /(alcatel|geeksphone|nexian|panasonic(?!(?:;|\.))|sony(?!-bra))[-_ ]?([-\w]*)/i,
+                ],
+                [f, [c, /_/g, " "], [d, v]],
+                [
+                  /droid [\w\.]+; ((?:8[14]9[16]|9(?:0(?:48|60|8[01])|1(?:3[27]|66)|2(?:6[69]|9[56])|466))[gqswx])\w*(\)| bui)/i,
+                ],
+                [c, [f, "TCL"], [d, h]],
+                [/(itel) ((\w+))/i],
+                [
+                  [f, G],
+                  c,
+                  [d, K, { tablet: ["p10001l", "w7001"], "*": "mobile" }],
+                ],
+                [/droid.+; ([ab][1-7]-?[0178a]\d\d?)/i],
+                [c, [f, "Acer"], [d, h]],
+                [/droid.+; (m[1-5] note) bui/i, /\bmz-([-\w]{2,})/i],
+                [c, [f, "Meizu"], [d, v]],
+                [/; ((?:power )?armor(?:[\w ]{0,8}))(?: bui|\))/i],
+                [c, [f, "Ulefone"], [d, v]],
+                [
+                  /; (energy ?\w+)(?: bui|\))/i,
+                  /; energizer ([\w ]+)(?: bui|\))/i,
+                ],
+                [c, [f, "Energizer"], [d, v]],
+                [
+                  /; cat (b35);/i,
+                  /; (b15q?|s22 flip|s48c|s62 pro)(?: bui|\))/i,
+                ],
+                [c, [f, "Cat"], [d, v]],
+                [/((?:new )?andromax[\w- ]+)(?: bui|\))/i],
+                [c, [f, "Smartfren"], [d, v]],
+                [/droid.+; (a(?:015|06[35]|142p?))/i],
+                [c, [f, "Nothing"], [d, v]],
+                [
+                  /(blackberry|benq|palm(?=\-)|sonyericsson|acer|asus|dell|meizu|motorola|polytron|infinix|tecno|micromax|advan)[-_ ]?([-\w]*)/i,
+                  /; (imo) ((?!tab)[\w ]+?)(?: bui|\))/i,
+                  /(hp) ([\w ]+\w)/i,
+                  /(asus)-?(\w+)/i,
+                  /(microsoft); (lumia[\w ]+)/i,
+                  /(lenovo)[-_ ]?([-\w]+)/i,
+                  /(jolla)/i,
+                  /(oppo) ?([\w ]+) bui/i,
+                ],
+                [f, c, [d, v]],
+                [
+                  /(imo) (tab \w+)/i,
+                  /(kobo)\s(ereader|touch)/i,
+                  /(archos) (gamepad2?)/i,
+                  /(hp).+(touchpad(?!.+tablet)|tablet)/i,
+                  /(kindle)\/([\w\.]+)/i,
+                  /(nook)[\w ]+build\/(\w+)/i,
+                  /(dell) (strea[kpr\d ]*[\dko])/i,
+                  /(le[- ]+pan)[- ]+(\w{1,9}) bui/i,
+                  /(trinity)[- ]*(t\d{3}) bui/i,
+                  /(gigaset)[- ]+(q\w{1,9}) bui/i,
+                  /(vodafone) ([\w ]+)(?:\)| bui)/i,
+                ],
+                [f, c, [d, h]],
+                [/(surface duo)/i],
+                [c, [f, P], [d, h]],
+                [/droid [\d\.]+; (fp\du?)(?: b|\))/i],
+                [c, [f, "Fairphone"], [d, v]],
+                [/(u304aa)/i],
+                [c, [f, "AT&T"], [d, v]],
+                [/\bsie-(\w*)/i],
+                [c, [f, "Siemens"], [d, v]],
+                [/\b(rct\w+) b/i],
+                [c, [f, "RCA"], [d, h]],
+                [/\b(venue[\d ]{2,7}) b/i],
+                [c, [f, "Dell"], [d, h]],
+                [/\b(q(?:mv|ta)\w+) b/i],
+                [c, [f, "Verizon"], [d, h]],
+                [/\b(?:barnes[& ]+noble |bn[rt])([\w\+ ]*) b/i],
+                [c, [f, "Barnes & Noble"], [d, h]],
+                [/\b(tm\d{3}\w+) b/i],
+                [c, [f, "NuVision"], [d, h]],
+                [/\b(k88) b/i],
+                [c, [f, "ZTE"], [d, h]],
+                [/\b(nx\d{3}j) b/i],
+                [c, [f, "ZTE"], [d, v]],
+                [/\b(gen\d{3}) b.+49h/i],
+                [c, [f, "Swiss"], [d, v]],
+                [/\b(zur\d{3}) b/i],
+                [c, [f, "Swiss"], [d, h]],
+                [/\b((zeki)?tb.*\b) b/i],
+                [c, [f, "Zeki"], [d, h]],
+                [/\b([yr]\d{2}) b/i, /\b(dragon[- ]+touch |dt)(\w{5}) b/i],
+                [[f, "Dragon Touch"], c, [d, h]],
+                [/\b(ns-?\w{0,9}) b/i],
+                [c, [f, "Insignia"], [d, h]],
+                [/\b((nxa|next)-?\w{0,9}) b/i],
+                [c, [f, "NextBook"], [d, h]],
+                [/\b(xtreme\_)?(v(1[045]|2[015]|[3469]0|7[05])) b/i],
+                [[f, "Voice"], c, [d, v]],
+                [/\b(lvtel\-)?(v1[12]) b/i],
+                [[f, "LvTel"], c, [d, v]],
+                [/\b(ph-1) /i],
+                [c, [f, "Essential"], [d, v]],
+                [/\b(v(100md|700na|7011|917g).*\b) b/i],
+                [c, [f, "Envizen"], [d, h]],
+                [/\b(trio[-\w\. ]+) b/i],
+                [c, [f, "MachSpeed"], [d, h]],
+                [/\btu_(1491) b/i],
+                [c, [f, "Rotor"], [d, h]],
+                [/(shield[\w ]+) b/i],
+                [c, [f, "Nvidia"], [d, h]],
+                [/(sprint) (\w+)/i],
+                [f, c, [d, v]],
+                [/(kin\.[onetw]{3})/i],
+                [
+                  [c, /\./g, " "],
+                  [f, P],
+                  [d, v],
+                ],
+                [/droid.+; (cc6666?|et5[16]|mc[239][23]x?|vc8[03]x?)\)/i],
+                [c, [f, U], [d, h]],
+                [/droid.+; (ec30|ps20|tc[2-8]\d[kx])\)/i],
+                [c, [f, U], [d, v]],
+                [/smart-tv.+(samsung)/i],
+                [f, [d, b]],
+                [/hbbtv.+maple;(\d+)/i],
+                [
+                  [c, /^/, "SmartTV"],
+                  [f, N],
+                  [d, b],
+                ],
+                [/(nux; netcast.+smarttv|lg (netcast\.tv-201\d|android tv))/i],
+                [
+                  [f, A],
+                  [d, b],
+                ],
+                [/(apple) ?tv/i],
+                [f, [c, T + " TV"], [d, b]],
+                [/crkey/i],
+                [
+                  [c, O + "cast"],
+                  [f, L],
+                  [d, b],
+                ],
+                [/droid.+aft(\w+)( bui|\))/i],
+                [c, [f, S], [d, b]],
+                [/\(dtv[\);].+(aquos)/i, /(aquos-tv[\w ]+)\)/i],
+                [c, [f, _], [d, b]],
+                [/(bravia[\w ]+)( bui|\))/i],
+                [c, [f, D], [d, b]],
+                [/(mitv-\w{5}) bui/i],
+                [c, [f, R], [d, b]],
+                [/Hbbtv.*(technisat) (.*);/i],
+                [f, c, [d, b]],
+                [
+                  /\b(roku)[\dx]*[\)\/]((?:dvp-)?[\d\.]*)/i,
+                  /hbbtv\/\d+\.\d+\.\d+ +\([\w\+ ]*; *([\w\d][^;]*);([^;]*)/i,
+                ],
+                [
+                  [f, H],
+                  [c, H],
+                  [d, b],
+                ],
+                [/\b(android tv|smart[- ]?tv|opera tv|tv; rv:)\b/i],
+                [[d, b]],
+                [/(ouya)/i, /(nintendo) ([wids3utch]+)/i],
+                [f, c, [d, m]],
+                [/droid.+; (shield) bui/i],
+                [c, [f, "Nvidia"], [d, m]],
+                [/(playstation [345portablevi]+)/i],
+                [c, [f, D], [d, m]],
+                [/\b(xbox(?: one)?(?!; xbox))[\); ]/i],
+                [c, [f, P], [d, m]],
+                [/\b(sm-[lr]\d\d[05][fnuw]?s?)\b/i],
+                [c, [f, N], [d, w]],
+                [/((pebble))app/i],
+                [f, c, [d, w]],
+                [/(watch)(?: ?os[,\/]|\d,\d\/)[\d\.]+/i],
+                [c, [f, T], [d, w]],
+                [/droid.+; (glass) \d/i],
+                [c, [f, L], [d, w]],
+                [/droid.+; (wt63?0{2,3})\)/i],
+                [c, [f, U], [d, w]],
+                [/droid.+; (glass) \d/i],
+                [c, [f, L], [d, w]],
+                [/(pico) (4|neo3(?: link|pro)?)/i],
+                [f, c, [d, w]],
+                [/; (quest( \d| pro)?)/i],
+                [c, [f, B], [d, w]],
+                [/(tesla)(?: qtcarbrowser|\/[-\w\.]+)/i],
+                [f, [d, y]],
+                [/(aeobc)\b/i],
+                [c, [f, S], [d, y]],
+                [
+                  /droid .+?; ([^;]+?)(?: bui|; wv\)|\) applew).+? mobile safari/i,
+                ],
+                [c, [d, v]],
+                [/droid .+?; ([^;]+?)(?: bui|\) applew).+?(?! mobile) safari/i],
+                [c, [d, h]],
+                [/\b((tablet|tab)[;\/]|focus\/\d(?!.+mobile))/i],
+                [[d, h]],
+                [
+                  /(phone|mobile(?:[;\/]| [ \w\/\.]*safari)|pda(?=.+windows ce))/i,
+                ],
+                [[d, v]],
+                [/(android[-\w\. ]{0,9});.+buil/i],
+                [c, [f, "Generic"]],
+              ],
+              engine: [
+                [/windows.+ edge\/([\w\.]+)/i],
+                [p, [l, "EdgeHTML"]],
+                [/(arkweb)\/([\w\.]+)/i],
+                [l, p],
+                [/webkit\/537\.36.+chrome\/(?!27)([\w\.]+)/i],
+                [p, [l, "Blink"]],
+                [
+                  /(presto)\/([\w\.]+)/i,
+                  /(webkit|trident|netfront|netsurf|amaya|lynx|w3m|goanna|servo)\/([\w\.]+)/i,
+                  /ekioh(flow)\/([\w\.]+)/i,
+                  /(khtml|tasman|links)[\/ ]\(?([\w\.]+)/i,
+                  /(icab)[\/ ]([23]\.[\d\.]+)/i,
+                  /\b(libweb)/i,
+                ],
+                [l, p],
+                [/rv\:([\w\.]{1,9})\b.+(gecko)/i],
+                [p, l],
+              ],
+              os: [
+                [/microsoft (windows) (vista|xp)/i],
+                [l, p],
+                [/(windows (?:phone(?: os)?|mobile))[\/ ]?([\d\.\w ]*)/i],
+                [l, [p, K, X]],
+                [
+                  /windows nt 6\.2; (arm)/i,
+                  /windows[\/ ]?([ntce\d\. ]+\w)(?!.+xbox)/i,
+                  /(?:win(?=3|9|n)|win 9x )([nt\d\.]+)/i,
+                ],
+                [
+                  [p, K, X],
+                  [l, "Windows"],
+                ],
+                [
+                  /ip[honead]{2,4}\b(?:.*os ([\w]+) like mac|; opera)/i,
+                  /(?:ios;fbsv\/|iphone.+ios[\/ ])([\d\.]+)/i,
+                  /cfnetwork\/.+darwin/i,
+                ],
+                [
+                  [p, /_/g, "."],
+                  [l, "iOS"],
+                ],
+                [
+                  /(mac os x) ?([\w\. ]*)/i,
+                  /(macintosh|mac_powerpc\b)(?!.+haiku)/i,
+                ],
+                [
+                  [l, z],
+                  [p, /_/g, "."],
+                ],
+                [/droid ([\w\.]+)\b.+(android[- ]x86|harmonyos)/i],
+                [p, l],
+                [
+                  /(android|webos|qnx|bada|rim tablet os|maemo|meego|sailfish|openharmony)[-\/ ]?([\w\.]*)/i,
+                  /(blackberry)\w*\/([\w\.]*)/i,
+                  /(tizen|kaios)[\/ ]([\w\.]+)/i,
+                  /\((series40);/i,
+                ],
+                [l, p],
+                [/\(bb(10);/i],
+                [p, [l, I]],
+                [/(?:symbian ?os|symbos|s60(?=;)|series60)[-\/ ]?([\w\.]*)/i],
+                [p, [l, "Symbian"]],
+                [
+                  /mozilla\/[\d\.]+ \((?:mobile|tablet|tv|mobile; [\w ]+); rv:.+ gecko\/([\w\.]+)/i,
+                ],
+                [p, [l, x + " OS"]],
+                [/web0s;.+rt(tv)/i, /\b(?:hp)?wos(?:browser)?\/([\w\.]+)/i],
+                [p, [l, "webOS"]],
+                [/watch(?: ?os[,\/]|\d,\d\/)([\d\.]+)/i],
+                [p, [l, "watchOS"]],
+                [/crkey\/([\d\.]+)/i],
+                [p, [l, O + "cast"]],
+                [/(cros) [\w]+(?:\)| ([\w\.]+)\b)/i],
+                [[l, F], p],
+                [
+                  /panasonic;(viera)/i,
+                  /(netrange)mmh/i,
+                  /(nettv)\/(\d+\.[\w\.]+)/i,
+                  /(nintendo|playstation) ([wids345portablevuch]+)/i,
+                  /(xbox); +xbox ([^\);]+)/i,
+                  /\b(joli|palm)\b ?(?:os)?\/?([\w\.]*)/i,
+                  /(mint)[\/\(\) ]?(\w*)/i,
+                  /(mageia|vectorlinux)[; ]/i,
+                  /([kxln]?ubuntu|debian|suse|opensuse|gentoo|arch(?= linux)|slackware|fedora|mandriva|centos|pclinuxos|red ?hat|zenwalk|linpus|raspbian|plan 9|minix|risc os|contiki|deepin|manjaro|elementary os|sabayon|linspire)(?: gnu\/linux)?(?: enterprise)?(?:[- ]linux)?(?:-gnu)?[-\/ ]?(?!chrom|package)([-\w\.]*)/i,
+                  /(hurd|linux) ?([\w\.]*)/i,
+                  /(gnu) ?([\w\.]*)/i,
+                  /\b([-frentopcghs]{0,5}bsd|dragonfly)[\/ ]?(?!amd|[ix346]{1,2}86)([\w\.]*)/i,
+                  /(haiku) (\w+)/i,
+                ],
+                [l, p],
+                [/(sunos) ?([\w\.\d]*)/i],
+                [[l, "Solaris"], p],
+                [
+                  /((?:open)?solaris)[-\/ ]?([\w\.]*)/i,
+                  /(aix) ((\d)(?=\.|\)| )[\w\.])*/i,
+                  /\b(beos|os\/2|amigaos|morphos|openvms|fuchsia|hp-ux|serenityos)/i,
+                  /(unix) ?([\w\.]*)/i,
+                ],
+                [l, p],
+              ],
+            },
+            Z = function (e, t) {
+              if ((typeof e === s && ((t = e), (e = i)), !(this instanceof Z)))
+                return new Z(e, t).getResult();
+              var m = typeof n !== o && n.navigator ? n.navigator : i,
+                b = e || (m && m.userAgent ? m.userAgent : ""),
+                w = m && m.userAgentData ? m.userAgentData : i,
+                y = t
+                  ? (function (e, t) {
+                      var n = {};
+                      for (var i in e)
+                        t[i] && t[i].length % 2 == 0
+                          ? (n[i] = t[i].concat(e[i]))
+                          : (n[i] = e[i]);
+                      return n;
+                    })(J, t)
+                  : J,
+                S = m && m.userAgent == b;
+              return (
+                (this.getBrowser = function () {
+                  var e,
+                    t = {};
+                  return (
+                    (t[l] = i),
+                    (t[p] = i),
+                    W.call(t, b, y.browser),
+                    (t[u] =
+                      typeof (e = t[p]) === a
+                        ? e.replace(/[^\d\.]/g, "").split(".")[0]
+                        : i),
+                    S &&
+                      m &&
+                      m.brave &&
+                      typeof m.brave.isBrave == r &&
+                      (t[l] = "Brave"),
+                    t
+                  );
+                }),
+                (this.getCPU = function () {
+                  var e = {};
+                  return (e[g] = i), W.call(e, b, y.cpu), e;
+                }),
+                (this.getDevice = function () {
+                  var e = {};
+                  return (
+                    (e[f] = i),
+                    (e[c] = i),
+                    (e[d] = i),
+                    W.call(e, b, y.device),
+                    S && !e[d] && w && w.mobile && (e[d] = v),
+                    S &&
+                      "Macintosh" == e[c] &&
+                      m &&
+                      typeof m.standalone !== o &&
+                      m.maxTouchPoints &&
+                      m.maxTouchPoints > 2 &&
+                      ((e[c] = "iPad"), (e[d] = h)),
+                    e
+                  );
+                }),
+                (this.getEngine = function () {
+                  var e = {};
+                  return (e[l] = i), (e[p] = i), W.call(e, b, y.engine), e;
+                }),
+                (this.getOS = function () {
+                  var e = {};
+                  return (
+                    (e[l] = i),
+                    (e[p] = i),
+                    W.call(e, b, y.os),
+                    S &&
+                      !e[l] &&
+                      w &&
+                      w.platform &&
+                      "Unknown" != w.platform &&
+                      (e[l] = w.platform
+                        .replace(/chrome os/i, F)
+                        .replace(/macos/i, z)),
+                    e
+                  );
+                }),
+                (this.getResult = function () {
+                  return {
+                    ua: this.getUA(),
+                    browser: this.getBrowser(),
+                    engine: this.getEngine(),
+                    os: this.getOS(),
+                    device: this.getDevice(),
+                    cpu: this.getCPU(),
+                  };
+                }),
+                (this.getUA = function () {
+                  return b;
+                }),
+                (this.setUA = function (e) {
+                  return (
+                    (b = typeof e === a && e.length > 500 ? H(e, 500) : e), this
+                  );
+                }),
+                this.setUA(b),
+                this
+              );
+            };
+          (Z.VERSION = "1.0.40"),
+            (Z.BROWSER = V([l, p, u])),
+            (Z.CPU = V([g])),
+            (Z.DEVICE = V([c, f, d, m, v, b, h, w, y])),
+            (Z.ENGINE = Z.OS = V([l, p])),
+            e.exports && (t = e.exports = Z),
+            (t.UAParser = Z);
+          var Y = typeof n !== o && (n.jQuery || n.Zepto);
+          if (Y && !Y.ua) {
+            var Q = new Z();
+            (Y.ua = Q.getResult()),
+              (Y.ua.get = function () {
+                return Q.getUA();
+              }),
+              (Y.ua.set = function (e) {
+                Q.setUA(e);
+                var t = Q.getResult();
+                for (var n in t) Y.ua[n] = t[n];
+              });
+          }
+        })("object" == typeof window ? window : Pe);
+      })(Ae, Ae.exports)),
+    Ae.exports);
+  const je = () => {
+    const e = new Me.UAParser(),
+      { name: t, version: n } = e.getBrowser(),
+      { name: i, version: r } = e.getOS(),
+      o = e.getUA(),
+      s = navigator.language,
+      a = navigator.userAgent.includes("Mobi"),
+      u = (function () {
+        if (!t || !n) return;
+        if ("userAgentData" in navigator && navigator.userAgentData)
+          return navigator.userAgentData.brands;
+        return;
+      })();
+    return {
+      browser: {
+        name: null != t ? t : Le,
+        version: null != n ? n : Le,
+        os: `${null != i ? i : Le} ${null != r ? r : Le}`,
+        userAgent: null != o ? o : Le,
+        language: null != s ? s : Le,
+        mobile: a,
+        brands: null != u ? u : Le,
+        viewportWidth: `${window.innerWidth}`,
+        viewportHeight: `${window.innerHeight}`,
+      },
+    };
+  };
+  function Ne(t) {
+    var n, i, r, o;
+    return {
+      id:
+        null !==
+          (o =
+            null ===
+              (r =
+                null ===
+                  (i =
+                    null === (n = e.faro.config) || void 0 === n
+                      ? void 0
+                      : n.sessionTracking) || void 0 === i
+                  ? void 0
+                  : i.generateSessionId) || void 0 === r
+              ? void 0
+              : r.call(i)) && void 0 !== o
+          ? o
+          : M(),
+      attributes: t,
+    };
+  }
+  const _e = { session: "sessionStorage", local: "localStorage" };
+  function De(t) {
+    var n;
+    try {
+      let e;
+      e = window[t];
+      const n = "__faro_storage_test__";
+      return e.setItem(n, n), e.removeItem(n), !0;
+    } catch (i) {
+      return (
+        null === (n = e.faro.internalLogger) ||
+          void 0 === n ||
+          n.info(`Web storage of type ${t} is not available. Reason: ${i}`),
+        !1
+      );
+    }
+  }
+  function Re(e, t) {
+    return qe(t) ? window[t].getItem(e) : null;
+  }
+  function Ue(e, t, n) {
+    if (qe(n))
+      try {
+        window[n].setItem(e, t);
+      } catch (e) {}
+  }
+  function Be(e, t) {
+    qe(t) && window[t].removeItem(e);
+  }
+  const Fe = De(_e.local),
+    ze = De(_e.session);
+  function qe(e) {
+    return e === _e.local ? Fe : e === _e.session && ze;
+  }
+  function Ve(e, t) {
+    let n,
+      i = !1;
+    const r = () => {
+      null != n ? (e(...n), (n = null), setTimeout(r, t)) : (i = !1);
+    };
+    return (...o) => {
+      i ? (n = o) : (e(...o), (i = !0), setTimeout(r, t));
+    };
+  }
+  function $e() {
+    return e.faro.transports.transports.flatMap((e) => e.getIgnoreUrls());
+  }
+  function Ge(e = "") {
+    return $e().some((t) => e && null != e.match(t));
+  }
+  function He(e) {
+    return o(e)
+      ? e
+      : e instanceof URL
+      ? e.href
+      : !S(e) && c(null == e ? void 0 : e.toString)
+      ? e.toString()
+      : void 0;
+  }
+  const We = "com.grafana.faro.session",
+    Ke = 144e5,
+    Xe = 9e5,
+    Je = Xe,
+    Ze = { enabled: !0, persistent: !1, maxSessionPersistenceTime: Je };
+  function Ye() {
+    var t, n, i;
+    const r = e.faro.config.sessionTracking;
+    let o =
+      null !==
+        (i =
+          null !==
+            (n =
+              null === (t = null == r ? void 0 : r.sampler) || void 0 === t
+                ? void 0
+                : t.call(r, { metas: e.faro.metas.value })) && void 0 !== n
+            ? n
+            : null == r
+            ? void 0
+            : r.samplingRate) && void 0 !== i
+        ? i
+        : 1;
+    if ("number" != typeof o) {
+      o = 0;
+    }
+    return Math.random() < o;
+  }
+  function Qe({
+    sessionId: t,
+    started: n,
+    lastActivity: i,
+    isSampled: r = !0,
+  } = {}) {
+    var o, s;
+    const a = E(),
+      u =
+        null ===
+          (s =
+            null === (o = e.faro.config) || void 0 === o
+              ? void 0
+              : o.sessionTracking) || void 0 === s
+          ? void 0
+          : s.generateSessionId;
+    return (
+      null == t && (t = "function" == typeof u ? u() : M()),
+      {
+        sessionId: t,
+        lastActivity: null != i ? i : a,
+        started: null != n ? n : a,
+        isSampled: r,
+      }
+    );
+  }
+  function et(e) {
+    if (null == e) return !1;
+    const t = E();
+    if (!(t - e.started < Ke)) return !1;
+    return t - e.lastActivity < Xe;
+  }
+  function tt({ fetchUserSession: t, storeUserSession: n }) {
+    return function ({ forceSessionExtend: i } = { forceSessionExtend: !1 }) {
+      var r, o, s;
+      if (!t || !n) return;
+      const a = e.faro.config.sessionTracking,
+        u = null == a ? void 0 : a.persistent;
+      if ((u && !Fe) || (!u && !ze)) return;
+      const c = t();
+      if (!1 === i && et(c))
+        n(Object.assign(Object.assign({}, c), { lastActivity: E() }));
+      else {
+        let t = nt(Qe({ isSampled: Ye() }), c);
+        n(t),
+          null === (r = e.faro.api) ||
+            void 0 === r ||
+            r.setSession(t.sessionMeta),
+          null === (o = null == a ? void 0 : a.onSessionChange) ||
+            void 0 === o ||
+            o.call(
+              a,
+              null !== (s = null == c ? void 0 : c.sessionMeta) && void 0 !== s
+                ? s
+                : null,
+              t.sessionMeta
+            );
+      }
+    };
+  }
+  function nt(t, n) {
+    var i, r, o, s, a, u, c;
+    const l = Object.assign(Object.assign({}, t), {
+        sessionMeta: {
+          id: t.sessionId,
+          attributes: Object.assign(
+            Object.assign(
+              Object.assign(
+                {},
+                null ===
+                  (r =
+                    null === (i = e.faro.config.sessionTracking) || void 0 === i
+                      ? void 0
+                      : i.session) || void 0 === r
+                  ? void 0
+                  : r.attributes
+              ),
+              null !==
+                (s =
+                  null === (o = e.faro.metas.value.session) || void 0 === o
+                    ? void 0
+                    : o.attributes) && void 0 !== s
+                ? s
+                : {}
+            ),
+            { isSampled: t.isSampled.toString() }
+          ),
+        },
+      }),
+      d =
+        null !==
+          (u =
+            null === (a = e.faro.metas.value.session) || void 0 === a
+              ? void 0
+              : a.overrides) && void 0 !== u
+          ? u
+          : null === (c = null == n ? void 0 : n.sessionMeta) || void 0 === c
+          ? void 0
+          : c.overrides;
+    S(d) || (l.sessionMeta.overrides = d);
+    const f = null == n ? void 0 : n.sessionId;
+    return null != f && (l.sessionMeta.attributes.previousSession = f), l;
+  }
+  function it({ fetchUserSession: t, storeUserSession: n }) {
+    return function (i) {
+      const r = i.session,
+        o = t();
+      let s = null == r ? void 0 : r.id;
+      const a = null == r ? void 0 : r.attributes,
+        u = null == r ? void 0 : r.overrides,
+        c = null == o ? void 0 : o.sessionMeta,
+        l = null == c ? void 0 : c.overrides,
+        d = !!u && !T(u, l),
+        f = !!a && !T(a, null == c ? void 0 : c.attributes);
+      if ((!!r && s !== (null == o ? void 0 : o.sessionId)) || f || d) {
+        const t = nt(Qe({ sessionId: s, isSampled: Ye() }), o);
+        n(t),
+          (function (t, n = {}, i = {}) {
+            var r, o, s;
+            if (!t) return;
+            const a = n.serviceName,
+              u =
+                null !==
+                  (s =
+                    null !== (r = i.serviceName) && void 0 !== r
+                      ? r
+                      : null === (o = e.faro.metas.value.app) || void 0 === o
+                      ? void 0
+                      : o.name) && void 0 !== s
+                  ? s
+                  : "";
+            a &&
+              a !== u &&
+              e.faro.api.pushEvent(xe, {
+                serviceName: a,
+                previousServiceName: u,
+              });
+          })(d, u, l),
+          e.faro.api.setSession(t.sessionMeta);
+      }
+    };
+  }
+  class rt {
+    constructor() {
+      (this.updateSession = Ve(() => this.updateUserSession(), 1e3)),
+        (this.updateUserSession = tt({
+          fetchUserSession: rt.fetchUserSession,
+          storeUserSession: rt.storeUserSession,
+        })),
+        this.init();
+    }
+    static removeUserSession() {
+      Be(We, rt.storageTypeLocal);
+    }
+    static storeUserSession(e) {
+      Ue(We, N(e), rt.storageTypeLocal);
+    }
+    static fetchUserSession() {
+      const e = Re(We, rt.storageTypeLocal);
+      return e ? JSON.parse(e) : null;
+    }
+    init() {
+      document.addEventListener("visibilitychange", () => {
+        "visible" === document.visibilityState && this.updateSession();
+      }),
+        e.faro.metas.addListener(
+          it({
+            fetchUserSession: rt.fetchUserSession,
+            storeUserSession: rt.storeUserSession,
+          })
+        );
+    }
+  }
+  rt.storageTypeLocal = _e.local;
+  class ot {
+    constructor() {
+      (this.updateSession = Ve(() => this.updateUserSession(), 1e3)),
+        (this.updateUserSession = tt({
+          fetchUserSession: ot.fetchUserSession,
+          storeUserSession: ot.storeUserSession,
+        })),
+        this.init();
+    }
+    static removeUserSession() {
+      Be(We, ot.storageTypeSession);
+    }
+    static storeUserSession(e) {
+      Ue(We, N(e), ot.storageTypeSession);
+    }
+    static fetchUserSession() {
+      const e = Re(We, ot.storageTypeSession);
+      return e ? JSON.parse(e) : null;
+    }
+    init() {
+      document.addEventListener("visibilitychange", () => {
+        "visible" === document.visibilityState && this.updateSession();
+      }),
+        e.faro.metas.addListener(
+          it({
+            fetchUserSession: ot.fetchUserSession,
+            storeUserSession: ot.storeUserSession,
+          })
+        );
+    }
+  }
+  function st(e) {
+    return (null == e ? void 0 : e.persistent) ? rt : ot;
+  }
+  ot.storageTypeSession = _e.session;
+  class at extends ge {
+    constructor() {
+      super(...arguments),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-session"),
+        (this.version = me);
+    }
+    sendSessionStartEvent(e) {
+      var t, n;
+      const i = e.session;
+      if (
+        i &&
+        i.id !==
+          (null === (t = this.notifiedSession) || void 0 === t ? void 0 : t.id)
+      ) {
+        if (
+          this.notifiedSession &&
+          this.notifiedSession.id ===
+            (null === (n = i.attributes) || void 0 === n
+              ? void 0
+              : n.previousSession)
+        )
+          return (
+            this.api.pushEvent(Oe, {}, void 0, { skipDedupe: !0 }),
+            void (this.notifiedSession = i)
+          );
+        (this.notifiedSession = i),
+          this.api.pushEvent(Ie, {}, void 0, { skipDedupe: !0 });
+      }
+    }
+    createInitialSession(e, t) {
+      var n, i, r, o, s, a;
+      let u,
+        c,
+        l = e.fetchUserSession();
+      if (t.persistent && t.maxSessionPersistenceTime && l) {
+        const e = E();
+        l.lastActivity < e - t.maxSessionPersistenceTime &&
+          (rt.removeUserSession(), (l = null));
+      }
+      if (et(l)) {
+        const e = null == l ? void 0 : l.sessionId;
+        c = Qe({
+          sessionId: e,
+          isSampled: l.isSampled || !1,
+          started: null == l ? void 0 : l.started,
+        });
+        const r = null == l ? void 0 : l.sessionMeta,
+          o = Object.assign(
+            Object.assign(
+              {},
+              null === (n = t.session) || void 0 === n ? void 0 : n.overrides
+            ),
+            null == r ? void 0 : r.overrides
+          );
+        (c.sessionMeta = Object.assign(Object.assign({}, t.session), {
+          id: e,
+          attributes: Object.assign(
+            Object.assign(
+              Object.assign(
+                {},
+                null === (i = t.session) || void 0 === i ? void 0 : i.attributes
+              ),
+              null == r ? void 0 : r.attributes
+            ),
+            { isSampled: c.isSampled.toString() }
+          ),
+          overrides: o,
+        })),
+          (u = ke);
+      } else {
+        const e =
+          null !==
+            (o = null === (r = t.session) || void 0 === r ? void 0 : r.id) &&
+          void 0 !== o
+            ? o
+            : Ne().id;
+        c = Qe({ sessionId: e, isSampled: Ye() });
+        const n =
+          null === (s = t.session) || void 0 === s ? void 0 : s.overrides;
+        (c.sessionMeta = Object.assign(
+          {
+            id: e,
+            attributes: Object.assign(
+              { isSampled: c.isSampled.toString() },
+              null === (a = t.session) || void 0 === a ? void 0 : a.attributes
+            ),
+          },
+          n ? { overrides: n } : {}
+        )),
+          (u = Ie);
+      }
+      return { initialSession: c, lifecycleType: u };
+    }
+    registerBeforeSendHook(e) {
+      var t;
+      const { updateSession: n } = new e();
+      null === (t = this.transports) ||
+        void 0 === t ||
+        t.addBeforeSendHooks((e) => {
+          var t, i, r;
+          n();
+          const o =
+            null === (t = e.meta.session) || void 0 === t
+              ? void 0
+              : t.attributes;
+          if (o && "true" === (null == o ? void 0 : o.isSampled)) {
+            let t = JSON.parse(JSON.stringify(e));
+            const n =
+              null === (i = t.meta.session) || void 0 === i
+                ? void 0
+                : i.attributes;
+            return (
+              null == n || delete n.isSampled,
+              0 === Object.keys(null != n ? n : {}).length &&
+                (null === (r = t.meta.session) ||
+                  void 0 === r ||
+                  delete r.attributes),
+              t
+            );
+          }
+          return null;
+        });
+    }
+    initialize() {
+      this.logDebug("init session instrumentation");
+      const e = this.config.sessionTracking;
+      if (null == e ? void 0 : e.enabled) {
+        const t = st(e);
+        this.registerBeforeSendHook(t);
+        const { initialSession: n, lifecycleType: i } =
+          this.createInitialSession(t, e);
+        t.storeUserSession(n);
+        const r = n.sessionMeta;
+        (this.notifiedSession = r),
+          this.api.setSession(r),
+          i === Ie && this.api.pushEvent(Ie, {}, void 0, { skipDedupe: !0 }),
+          i === ke && this.api.pushEvent(ke, {}, void 0, { skipDedupe: !0 });
+      }
+      this.metas.addListener(this.sendSessionStartEvent.bind(this));
+    }
+  }
+  const ut = "DOMError",
+    ct = "DOMException",
+    lt = "Non-Error exception captured with keys:",
+    dt = "?",
+    ft =
+      /^(?:[Uu]ncaught (?:exception: )?)?(?:((?:Eval|Internal|Range|Reference|Syntax|Type|URI|)Error): )?(.*)$/i;
+  const pt = "\n",
+    gt = "eval",
+    mt = "?",
+    vt = "@",
+    ht =
+      /^\s*at (?:(.*\).*?|.*?) ?\((?:address at )?)?((?:file|https?|blob|chrome-extension|address|native|eval|webpack|<anonymous>|[-a-z]+:|.*bundle|\/)?.*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i,
+    bt = /\((\S*)(?::(\d+))(?::(\d+))\)/,
+    wt = "eval",
+    yt = "address at ",
+    St = yt.length,
+    Tt =
+      /^\s*(.*?)(?:\((.*?)\))?(?:^|@)?((?:file|https?|blob|chrome|webpack|resource|moz-extension|safari-extension|safari-web-extension|capacitor)?:\/.*?|\[native code]|[^@]*(?:bundle|\d+\.js)|\/[\w\-. /=]+)(?::(\d+))?(?::(\d+))?\s*$/i,
+    Et = /(\S+) line (\d+)(?: > eval line \d+)* > eval/i,
+    It = " > eval",
+    kt = "safari-extension",
+    Ot = "safari-web-extension",
+    xt = /Minified React error #\d+;/i;
+  function Lt(e, t, n, i) {
+    const r = { filename: e || document.location.href, function: t || mt };
+    return void 0 !== n && (r.lineno = n), void 0 !== i && (r.colno = i), r;
+  }
+  function Ct(e, t) {
+    const n = null == e ? void 0 : e.includes(kt),
+      i = !n && (null == e ? void 0 : e.includes(Ot));
+    return n || i
+      ? [
+          (null == e ? void 0 : e.includes(vt)) ? e.split(vt)[0] : e,
+          n ? `${kt}:${t}` : `${Ot}:${t}`,
+        ]
+      : [e, t];
+  }
+  function At(e) {
+    let t = [];
+    e.stacktrace
+      ? (t = e.stacktrace.split(pt).filter((e, t) => t % 2 == 0))
+      : e.stack && (t = e.stack.split(pt));
+    const n = t.reduce((t, n, i) => {
+      let r, o, a, u, c;
+      if ((r = ht.exec(n))) {
+        if (
+          ((o = r[1]),
+          (a = r[2]),
+          (u = r[3]),
+          (c = r[4]),
+          null == a ? void 0 : a.startsWith(wt))
+        ) {
+          const e = bt.exec(a);
+          e && ((a = e[1]), (u = e[2]), (c = e[3]));
+        }
+        (a = (null == a ? void 0 : a.startsWith(yt)) ? a.substring(St) : a),
+          ([o, a] = Ct(o, a));
+      } else if ((r = Tt.exec(n))) {
+        if (
+          ((o = r[1]), (a = r[3]), (u = r[4]), (c = r[5]), a && a.includes(It))
+        ) {
+          const e = Et.exec(a);
+          e && ((o = o || gt), (a = e[1]), (u = e[2]));
+        } else
+          0 === i &&
+            !c &&
+            s(e.columnNumber) &&
+            (c = String(e.columnNumber + 1));
+        [o, a] = Ct(o, a);
+      }
+      return (
+        (a || o) &&
+          t.push(Lt(a, o, u ? Number(u) : void 0, c ? Number(c) : void 0)),
+        t
+      );
+    }, []);
+    return xt.test(e.message) ? n.slice(1) : n;
+  }
+  function Pt(e) {
+    return { frames: At(e) };
+  }
+  function Mt(e) {
+    let t,
+      n,
+      i,
+      r,
+      o = [];
+    if (v(e) && e.error)
+      (t = e.error.message), (n = e.error.name), (o = At(e.error));
+    else if ((i = h(e)) || b(e)) {
+      const { name: r, message: o } = e;
+      (n = null != r ? r : i ? ut : ct), (t = o ? `${n}: ${o}` : n);
+    } else
+      m(e)
+        ? ((t = e.message), (o = At(e)))
+        : (u(e) || (r = p(e))) &&
+          ((n = r ? e.constructor.name : void 0),
+          (t = `${lt} ${Object.keys(e)}`));
+    return [t, n, o];
+  }
+  function jt(e) {
+    const [t, n, i, r, s] = e;
+    let a,
+      u,
+      c = [];
+    const l = o(t),
+      d = Lt(n, dt, i, r);
+    return (
+      s || !l
+        ? (([a, u, c] = Mt(null != s ? s : t)), 0 === c.length && (c = [d]))
+        : l &&
+          (([a, u] = (function (e) {
+            var t, n;
+            const i = e.match(ft),
+              r =
+                null !== (t = null == i ? void 0 : i[1]) && void 0 !== t
+                  ? t
+                  : oe;
+            return [
+              null !== (n = null == i ? void 0 : i[2]) && void 0 !== n ? n : e,
+              r,
+            ];
+          })(t)),
+          (c = [d])),
+      { value: a, type: u, stackFrames: c }
+    );
+  }
+  function Nt(e, t) {
+    return m(e[0]) ? jt(e) : { value: t(e) };
+  }
+  class _t extends ge {
+    constructor(e = {}) {
+      super(),
+        (this.options = e),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-console"),
+        (this.version = me),
+        (this.errorSerializer = ce);
+    }
+    initialize() {
+      var t, n, i, r;
+      this.options = Object.assign(
+        Object.assign({}, this.options),
+        this.config.consoleInstrumentation
+      );
+      const o =
+        (null === (t = this.options) || void 0 === t
+          ? void 0
+          : t.serializeErrors) ||
+        !!(null === (n = this.options) || void 0 === n
+          ? void 0
+          : n.errorSerializer);
+      (this.errorSerializer = o
+        ? null !==
+            (r =
+              null === (i = this.options) || void 0 === i
+                ? void 0
+                : i.errorSerializer) && void 0 !== r
+          ? r
+          : se
+        : ce),
+        L.filter((e) => {
+          var t, n;
+          return !(
+            null !==
+              (n =
+                null === (t = this.options) || void 0 === t
+                  ? void 0
+                  : t.disabledLevels) && void 0 !== n
+              ? n
+              : _t.defaultDisabledLevels
+          ).includes(e);
+        }).forEach((t) => {
+          console[t] = (...n) => {
+            var i, r;
+            try {
+              if (
+                t !== e.LogLevel.ERROR ||
+                (null === (i = this.options) || void 0 === i
+                  ? void 0
+                  : i.consoleErrorAsLog)
+              )
+                if (
+                  t === e.LogLevel.ERROR &&
+                  (null === (r = this.options) || void 0 === r
+                    ? void 0
+                    : r.consoleErrorAsLog)
+                ) {
+                  const {
+                    value: e,
+                    type: i,
+                    stackFrames: r,
+                  } = Nt(n, this.errorSerializer);
+                  this.api.pushLog(e ? [_t.consoleErrorPrefix + e] : n, {
+                    level: t,
+                    context: {
+                      value: null != e ? e : "",
+                      type: null != i ? i : "",
+                      stackFrames: (null == r ? void 0 : r.length) ? se(r) : "",
+                    },
+                  });
+                } else this.api.pushLog(n, { level: t });
+              else {
+                const {
+                  value: e,
+                  type: t,
+                  stackFrames: i,
+                } = Nt(n, this.errorSerializer);
+                if (e && !t && !i)
+                  return void this.api.pushError(
+                    new Error(_t.consoleErrorPrefix + e)
+                  );
+                this.api.pushError(new Error(_t.consoleErrorPrefix + e), {
+                  type: t,
+                  stackFrames: i,
+                });
+              }
+            } catch (e) {
+              this.logError(e);
+            } finally {
+              this.unpatchedConsole[t](...n);
+            }
+          };
+        });
+    }
+  }
+  (_t.defaultDisabledLevels = [
+    e.LogLevel.DEBUG,
+    e.LogLevel.TRACE,
+    e.LogLevel.LOG,
+  ]),
+    (_t.consoleErrorPrefix = "console.error: ");
+  class Dt extends ge {
+    constructor() {
+      super(...arguments),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-errors"),
+        (this.version = me);
+    }
+    initialize() {
+      var e;
+      this.logDebug("Initializing"),
+        (function (e) {
+          const t = window.onerror;
+          window.onerror = (...n) => {
+            try {
+              const { value: t, type: i, stackFrames: r } = jt(n),
+                o = n[4];
+              if (t) {
+                const n = { type: i, stackFrames: r };
+                null != o && (n.originalError = o),
+                  e.pushError(new Error(t), n);
+              }
+            } finally {
+              null == t || t.apply(window, n);
+            }
+          };
+        })(this.api),
+        (e = this.api),
+        window.addEventListener("unhandledrejection", (t) => {
+          var n, i;
+          let r,
+            o,
+            s = t;
+          s.reason
+            ? (s = t.reason)
+            : (null === (n = t.detail) || void 0 === n ? void 0 : n.reason) &&
+              (s = null === (i = t.detail) || void 0 === i ? void 0 : i.reason);
+          let a = [];
+          d(s)
+            ? ((r = `Non-Error promise rejection captured with value: ${String(
+                s
+              )}`),
+              (o = "UnhandledRejection"))
+            : ([r, o, a] = Mt(s)),
+            r && e.pushError(new Error(r), { type: o, stackFrames: a });
+        });
+    }
+  }
+  class Rt extends ge {
+    constructor() {
+      super(...arguments),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-view"),
+        (this.version = me);
+    }
+    sendViewChangedEvent(e) {
+      var t, n, i, r;
+      const o = e.view;
+      o &&
+        o.name !==
+          (null === (t = this.notifiedView) || void 0 === t
+            ? void 0
+            : t.name) &&
+        (this.api.pushEvent(
+          Ee,
+          {
+            fromView:
+              null !==
+                (i =
+                  null === (n = this.notifiedView) || void 0 === n
+                    ? void 0
+                    : n.name) && void 0 !== i
+                ? i
+                : Le,
+            toView: null !== (r = o.name) && void 0 !== r ? r : Le,
+          },
+          void 0,
+          { skipDedupe: !0 }
+        ),
+        (this.notifiedView = o));
+    }
+    initialize() {
+      this.metas.addListener(this.sendViewChangedEvent.bind(this));
+    }
+  }
+  var Ut,
+    Bt,
+    Ft,
+    zt,
+    qt,
+    Vt = -1,
+    $t = function (e) {
+      addEventListener(
+        "pageshow",
+        function (t) {
+          t.persisted && ((Vt = t.timeStamp), e(t));
+        },
+        !0
+      );
+    },
+    Gt = function () {
+      var e =
+        self.performance &&
+        performance.getEntriesByType &&
+        performance.getEntriesByType("navigation")[0];
+      if (e && e.responseStart > 0 && e.responseStart < performance.now())
+        return e;
+    },
+    Ht = function () {
+      var e = Gt();
+      return (e && e.activationStart) || 0;
+    },
+    Wt = function (e, t) {
+      var n = Gt(),
+        i = "navigate";
+      return (
+        Vt >= 0
+          ? (i = "back-forward-cache")
+          : n &&
+            (document.prerendering || Ht() > 0
+              ? (i = "prerender")
+              : document.wasDiscarded
+              ? (i = "restore")
+              : n.type && (i = n.type.replace(/_/g, "-"))),
+        {
+          name: e,
+          value: void 0 === t ? -1 : t,
+          rating: "good",
+          delta: 0,
+          entries: [],
+          id: "v4-"
+            .concat(Date.now(), "-")
+            .concat(Math.floor(8999999999999 * Math.random()) + 1e12),
+          navigationType: i,
+        }
+      );
+    },
+    Kt = function (e, t, n) {
+      try {
+        if (PerformanceObserver.supportedEntryTypes.includes(e)) {
+          var i = new PerformanceObserver(function (e) {
+            Promise.resolve().then(function () {
+              t(e.getEntries());
+            });
+          });
+          return (
+            i.observe(Object.assign({ type: e, buffered: !0 }, n || {})), i
+          );
+        }
+      } catch (e) {}
+    },
+    Xt = function (e, t, n, i) {
+      var r, o;
+      return function (s) {
+        t.value >= 0 &&
+          (s || i) &&
+          ((o = t.value - (r || 0)) || void 0 === r) &&
+          ((r = t.value),
+          (t.delta = o),
+          (t.rating = (function (e, t) {
+            return e > t[1] ? "poor" : e > t[0] ? "needs-improvement" : "good";
+          })(t.value, n)),
+          e(t));
+      };
+    },
+    Jt = function (e) {
+      requestAnimationFrame(function () {
+        return requestAnimationFrame(function () {
+          return e();
+        });
+      });
+    },
+    Zt = function (e) {
+      document.addEventListener("visibilitychange", function () {
+        "hidden" === document.visibilityState && e();
+      });
+    },
+    Yt = function (e) {
+      var t = !1;
+      return function () {
+        t || (e(), (t = !0));
+      };
+    },
+    Qt = -1,
+    en = function () {
+      return "hidden" !== document.visibilityState || document.prerendering
+        ? 1 / 0
+        : 0;
+    },
+    tn = function (e) {
+      "hidden" === document.visibilityState &&
+        Qt > -1 &&
+        ((Qt = "visibilitychange" === e.type ? e.timeStamp : 0), rn());
+    },
+    nn = function () {
+      addEventListener("visibilitychange", tn, !0),
+        addEventListener("prerenderingchange", tn, !0);
+    },
+    rn = function () {
+      removeEventListener("visibilitychange", tn, !0),
+        removeEventListener("prerenderingchange", tn, !0);
+    },
+    on = function () {
+      return (
+        Qt < 0 &&
+          ((Qt = en()),
+          nn(),
+          $t(function () {
+            setTimeout(function () {
+              (Qt = en()), nn();
+            }, 0);
+          })),
+        {
+          get firstHiddenTime() {
+            return Qt;
+          },
+        }
+      );
+    },
+    sn = function (e) {
+      document.prerendering
+        ? addEventListener(
+            "prerenderingchange",
+            function () {
+              return e();
+            },
+            !0
+          )
+        : e();
+    },
+    an = [1800, 3e3],
+    un = function (e, t) {
+      (t = t || {}),
+        sn(function () {
+          var n,
+            i = on(),
+            r = Wt("FCP"),
+            o = Kt("paint", function (e) {
+              e.forEach(function (e) {
+                "first-contentful-paint" === e.name &&
+                  (o.disconnect(),
+                  e.startTime < i.firstHiddenTime &&
+                    ((r.value = Math.max(e.startTime - Ht(), 0)),
+                    r.entries.push(e),
+                    n(!0)));
+              });
+            });
+          o &&
+            ((n = Xt(e, r, an, t.reportAllChanges)),
+            $t(function (i) {
+              (r = Wt("FCP")),
+                (n = Xt(e, r, an, t.reportAllChanges)),
+                Jt(function () {
+                  (r.value = performance.now() - i.timeStamp), n(!0);
+                });
+            }));
+        });
+    },
+    cn = [0.1, 0.25],
+    ln = 0,
+    dn = 1 / 0,
+    fn = 0,
+    pn = function (e) {
+      e.forEach(function (e) {
+        e.interactionId &&
+          ((dn = Math.min(dn, e.interactionId)),
+          (fn = Math.max(fn, e.interactionId)),
+          (ln = fn ? (fn - dn) / 7 + 1 : 0));
+      });
+    },
+    gn = function () {
+      return Ut ? ln : performance.interactionCount || 0;
+    },
+    mn = [],
+    vn = new Map(),
+    hn = 0,
+    bn = [],
+    wn = function (e) {
+      if (
+        (bn.forEach(function (t) {
+          return t(e);
+        }),
+        e.interactionId || "first-input" === e.entryType)
+      ) {
+        var t = mn[mn.length - 1],
+          n = vn.get(e.interactionId);
+        if (n || mn.length < 10 || e.duration > t.latency) {
+          if (n)
+            e.duration > n.latency
+              ? ((n.entries = [e]), (n.latency = e.duration))
+              : e.duration === n.latency &&
+                e.startTime === n.entries[0].startTime &&
+                n.entries.push(e);
+          else {
+            var i = { id: e.interactionId, latency: e.duration, entries: [e] };
+            vn.set(i.id, i), mn.push(i);
+          }
+          mn.sort(function (e, t) {
+            return t.latency - e.latency;
+          }),
+            mn.length > 10 &&
+              mn.splice(10).forEach(function (e) {
+                return vn.delete(e.id);
+              });
+        }
+      }
+    },
+    yn = function (e) {
+      var t = self.requestIdleCallback || self.setTimeout,
+        n = -1;
+      return (
+        (e = Yt(e)),
+        "hidden" === document.visibilityState ? e() : ((n = t(e)), Zt(e)),
+        n
+      );
+    },
+    Sn = [200, 500],
+    Tn = [2500, 4e3],
+    En = {},
+    In = [800, 1800],
+    kn = function e(t) {
+      document.prerendering
+        ? sn(function () {
+            return e(t);
+          })
+        : "complete" !== document.readyState
+        ? addEventListener(
+            "load",
+            function () {
+              return e(t);
+            },
+            !0
+          )
+        : setTimeout(t, 0);
+    },
+    On = { passive: !0, capture: !0 },
+    xn = new Date(),
+    Ln = function (e, t) {
+      Bt ||
+        ((Bt = t), (Ft = e), (zt = new Date()), Pn(removeEventListener), Cn());
+    },
+    Cn = function () {
+      if (Ft >= 0 && Ft < zt - xn) {
+        var e = {
+          entryType: "first-input",
+          name: Bt.type,
+          target: Bt.target,
+          cancelable: Bt.cancelable,
+          startTime: Bt.timeStamp,
+          processingStart: Bt.timeStamp + Ft,
+        };
+        qt.forEach(function (t) {
+          t(e);
+        }),
+          (qt = []);
+      }
+    },
+    An = function (e) {
+      if (e.cancelable) {
+        var t =
+          (e.timeStamp > 1e12 ? new Date() : performance.now()) - e.timeStamp;
+        "pointerdown" == e.type
+          ? (function (e, t) {
+              var n = function () {
+                  Ln(e, t), r();
+                },
+                i = function () {
+                  r();
+                },
+                r = function () {
+                  removeEventListener("pointerup", n, On),
+                    removeEventListener("pointercancel", i, On);
+                };
+              addEventListener("pointerup", n, On),
+                addEventListener("pointercancel", i, On);
+            })(t, e)
+          : Ln(t, e);
+      }
+    },
+    Pn = function (e) {
+      ["mousedown", "keydown", "touchstart", "pointerdown"].forEach(function (
+        t
+      ) {
+        return e(t, An, On);
+      });
+    },
+    Mn = [100, 300];
+  class jn {
+    constructor(e, t) {
+      (this.pushMeasurement = e), (this.webVitalConfig = t);
+    }
+    initialize() {
+      Object.entries(jn.mapping).forEach(([e, t]) => {
+        var n;
+        t(
+          (t) => {
+            this.pushMeasurement({
+              type: "web-vitals",
+              values: { [e]: t.value },
+            });
+          },
+          {
+            reportAllChanges:
+              null === (n = this.webVitalConfig) || void 0 === n
+                ? void 0
+                : n.reportAllChanges,
+          }
+        );
+      });
+    }
+  }
+  jn.mapping = {
+    cls: function (e, t) {
+      (t = t || {}),
+        un(
+          Yt(function () {
+            var n,
+              i = Wt("CLS", 0),
+              r = 0,
+              o = [],
+              s = function (e) {
+                e.forEach(function (e) {
+                  if (!e.hadRecentInput) {
+                    var t = o[0],
+                      n = o[o.length - 1];
+                    r &&
+                    e.startTime - n.startTime < 1e3 &&
+                    e.startTime - t.startTime < 5e3
+                      ? ((r += e.value), o.push(e))
+                      : ((r = e.value), (o = [e]));
+                  }
+                }),
+                  r > i.value && ((i.value = r), (i.entries = o), n());
+              },
+              a = Kt("layout-shift", s);
+            a &&
+              ((n = Xt(e, i, cn, t.reportAllChanges)),
+              Zt(function () {
+                s(a.takeRecords()), n(!0);
+              }),
+              $t(function () {
+                (r = 0),
+                  (i = Wt("CLS", 0)),
+                  (n = Xt(e, i, cn, t.reportAllChanges)),
+                  Jt(function () {
+                    return n();
+                  });
+              }),
+              setTimeout(n, 0));
+          })
+        );
+    },
+    fcp: un,
+    fid: function (e, t) {
+      (t = t || {}),
+        sn(function () {
+          var n,
+            i = on(),
+            r = Wt("FID"),
+            o = function (e) {
+              e.startTime < i.firstHiddenTime &&
+                ((r.value = e.processingStart - e.startTime),
+                r.entries.push(e),
+                n(!0));
+            },
+            s = function (e) {
+              e.forEach(o);
+            },
+            a = Kt("first-input", s);
+          (n = Xt(e, r, Mn, t.reportAllChanges)),
+            a &&
+              (Zt(
+                Yt(function () {
+                  s(a.takeRecords()), a.disconnect();
+                })
+              ),
+              $t(function () {
+                var i;
+                (r = Wt("FID")),
+                  (n = Xt(e, r, Mn, t.reportAllChanges)),
+                  (qt = []),
+                  (Ft = -1),
+                  (Bt = null),
+                  Pn(addEventListener),
+                  (i = o),
+                  qt.push(i),
+                  Cn();
+              }));
+        });
+    },
+    inp: function (e, t) {
+      "PerformanceEventTiming" in self &&
+        "interactionId" in PerformanceEventTiming.prototype &&
+        ((t = t || {}),
+        sn(function () {
+          var n;
+          "interactionCount" in performance ||
+            Ut ||
+            (Ut = Kt("event", pn, {
+              type: "event",
+              buffered: !0,
+              durationThreshold: 0,
+            }));
+          var i,
+            r = Wt("INP"),
+            o = function (e) {
+              yn(function () {
+                e.forEach(wn);
+                var t = (function () {
+                  var e = Math.min(mn.length - 1, Math.floor((gn() - hn) / 50));
+                  return mn[e];
+                })();
+                t &&
+                  t.latency !== r.value &&
+                  ((r.value = t.latency), (r.entries = t.entries), i());
+              });
+            },
+            s = Kt("event", o, {
+              durationThreshold:
+                null !== (n = t.durationThreshold) && void 0 !== n ? n : 40,
+            });
+          (i = Xt(e, r, Sn, t.reportAllChanges)),
+            s &&
+              (s.observe({ type: "first-input", buffered: !0 }),
+              Zt(function () {
+                o(s.takeRecords()), i(!0);
+              }),
+              $t(function () {
+                (hn = gn()),
+                  (mn.length = 0),
+                  vn.clear(),
+                  (r = Wt("INP")),
+                  (i = Xt(e, r, Sn, t.reportAllChanges));
+              }));
+        }));
+    },
+    lcp: function (e, t) {
+      (t = t || {}),
+        sn(function () {
+          var n,
+            i = on(),
+            r = Wt("LCP"),
+            o = function (e) {
+              t.reportAllChanges || (e = e.slice(-1)),
+                e.forEach(function (e) {
+                  e.startTime < i.firstHiddenTime &&
+                    ((r.value = Math.max(e.startTime - Ht(), 0)),
+                    (r.entries = [e]),
+                    n());
+                });
+            },
+            s = Kt("largest-contentful-paint", o);
+          if (s) {
+            n = Xt(e, r, Tn, t.reportAllChanges);
+            var a = Yt(function () {
+              En[r.id] ||
+                (o(s.takeRecords()), s.disconnect(), (En[r.id] = !0), n(!0));
+            });
+            ["keydown", "click"].forEach(function (e) {
+              addEventListener(
+                e,
+                function () {
+                  return yn(a);
+                },
+                { once: !0, capture: !0 }
+              );
+            }),
+              Zt(a),
+              $t(function (i) {
+                (r = Wt("LCP")),
+                  (n = Xt(e, r, Tn, t.reportAllChanges)),
+                  Jt(function () {
+                    (r.value = performance.now() - i.timeStamp),
+                      (En[r.id] = !0),
+                      n(!0);
+                  });
+              });
+          }
+        });
+    },
+    ttfb: function (e, t) {
+      t = t || {};
+      var n = Wt("TTFB"),
+        i = Xt(e, n, In, t.reportAllChanges);
+      kn(function () {
+        var r = Gt();
+        r &&
+          ((n.value = Math.max(r.responseStart - Ht(), 0)),
+          (n.entries = [r]),
+          i(!0),
+          $t(function () {
+            (n = Wt("TTFB", 0)), (i = Xt(e, n, In, t.reportAllChanges))(!0);
+          }));
+      });
+    },
+  };
+  var Nn,
+    _n,
+    Dn = function () {
+      var e =
+        self.performance &&
+        performance.getEntriesByType &&
+        performance.getEntriesByType("navigation")[0];
+      if (e && e.responseStart > 0 && e.responseStart < performance.now())
+        return e;
+    },
+    Rn = function (e) {
+      if ("loading" === document.readyState) return "loading";
+      var t = Dn();
+      if (t) {
+        if (e < t.domInteractive) return "loading";
+        if (
+          0 === t.domContentLoadedEventStart ||
+          e < t.domContentLoadedEventStart
+        )
+          return "dom-interactive";
+        if (0 === t.domComplete || e < t.domComplete)
+          return "dom-content-loaded";
+      }
+      return "complete";
+    },
+    Un = function (e) {
+      var t = e.nodeName;
+      return 1 === e.nodeType
+        ? t.toLowerCase()
+        : t.toUpperCase().replace(/^#/, "");
+    },
+    Bn = function (e, t) {
+      var n = "";
+      try {
+        for (; e && 9 !== e.nodeType; ) {
+          var i = e,
+            r = i.id
+              ? "#" + i.id
+              : Un(i) +
+                (i.classList &&
+                i.classList.value &&
+                i.classList.value.trim() &&
+                i.classList.value.trim().length
+                  ? "." + i.classList.value.trim().replace(/\s+/g, ".")
+                  : "");
+          if (n.length + r.length > (t || 100) - 1) return n || r;
+          if (((n = n ? r + ">" + n : r), i.id)) break;
+          e = i.parentNode;
+        }
+      } catch (e) {}
+      return n;
+    },
+    Fn = -1,
+    zn = function () {
+      return Fn;
+    },
+    qn = function (e) {
+      addEventListener(
+        "pageshow",
+        function (t) {
+          t.persisted && ((Fn = t.timeStamp), e(t));
+        },
+        !0
+      );
+    },
+    Vn = function () {
+      var e = Dn();
+      return (e && e.activationStart) || 0;
+    },
+    $n = function (e, t) {
+      var n = Dn(),
+        i = "navigate";
+      return (
+        zn() >= 0
+          ? (i = "back-forward-cache")
+          : n &&
+            (document.prerendering || Vn() > 0
+              ? (i = "prerender")
+              : document.wasDiscarded
+              ? (i = "restore")
+              : n.type && (i = n.type.replace(/_/g, "-"))),
+        {
+          name: e,
+          value: void 0 === t ? -1 : t,
+          rating: "good",
+          delta: 0,
+          entries: [],
+          id: "v4-"
+            .concat(Date.now(), "-")
+            .concat(Math.floor(8999999999999 * Math.random()) + 1e12),
+          navigationType: i,
+        }
+      );
+    },
+    Gn = function (e, t, n) {
+      try {
+        if (PerformanceObserver.supportedEntryTypes.includes(e)) {
+          var i = new PerformanceObserver(function (e) {
+            Promise.resolve().then(function () {
+              t(e.getEntries());
+            });
+          });
+          return (
+            i.observe(Object.assign({ type: e, buffered: !0 }, n || {})), i
+          );
+        }
+      } catch (e) {}
+    },
+    Hn = function (e, t, n, i) {
+      var r, o;
+      return function (s) {
+        t.value >= 0 &&
+          (s || i) &&
+          ((o = t.value - (r || 0)) || void 0 === r) &&
+          ((r = t.value),
+          (t.delta = o),
+          (t.rating = (function (e, t) {
+            return e > t[1] ? "poor" : e > t[0] ? "needs-improvement" : "good";
+          })(t.value, n)),
+          e(t));
+      };
+    },
+    Wn = function (e) {
+      requestAnimationFrame(function () {
+        return requestAnimationFrame(function () {
+          return e();
+        });
+      });
+    },
+    Kn = function (e) {
+      document.addEventListener("visibilitychange", function () {
+        "hidden" === document.visibilityState && e();
+      });
+    },
+    Xn = function (e) {
+      var t = !1;
+      return function () {
+        t || (e(), (t = !0));
+      };
+    },
+    Jn = -1,
+    Zn = function () {
+      return "hidden" !== document.visibilityState || document.prerendering
+        ? 1 / 0
+        : 0;
+    },
+    Yn = function (e) {
+      "hidden" === document.visibilityState &&
+        Jn > -1 &&
+        ((Jn = "visibilitychange" === e.type ? e.timeStamp : 0), ei());
+    },
+    Qn = function () {
+      addEventListener("visibilitychange", Yn, !0),
+        addEventListener("prerenderingchange", Yn, !0);
+    },
+    ei = function () {
+      removeEventListener("visibilitychange", Yn, !0),
+        removeEventListener("prerenderingchange", Yn, !0);
+    },
+    ti = function () {
+      return (
+        Jn < 0 &&
+          ((Jn = Zn()),
+          Qn(),
+          qn(function () {
+            setTimeout(function () {
+              (Jn = Zn()), Qn();
+            }, 0);
+          })),
+        {
+          get firstHiddenTime() {
+            return Jn;
+          },
+        }
+      );
+    },
+    ni = function (e) {
+      document.prerendering
+        ? addEventListener(
+            "prerenderingchange",
+            function () {
+              return e();
+            },
+            !0
+          )
+        : e();
+    },
+    ii = [1800, 3e3],
+    ri = function (e, t) {
+      (t = t || {}),
+        ni(function () {
+          var n,
+            i = ti(),
+            r = $n("FCP"),
+            o = Gn("paint", function (e) {
+              e.forEach(function (e) {
+                "first-contentful-paint" === e.name &&
+                  (o.disconnect(),
+                  e.startTime < i.firstHiddenTime &&
+                    ((r.value = Math.max(e.startTime - Vn(), 0)),
+                    r.entries.push(e),
+                    n(!0)));
+              });
+            });
+          o &&
+            ((n = Hn(e, r, ii, t.reportAllChanges)),
+            qn(function (i) {
+              (r = $n("FCP")),
+                (n = Hn(e, r, ii, t.reportAllChanges)),
+                Wn(function () {
+                  (r.value = performance.now() - i.timeStamp), n(!0);
+                });
+            }));
+        });
+    },
+    oi = [0.1, 0.25],
+    si = 0,
+    ai = 1 / 0,
+    ui = 0,
+    ci = function (e) {
+      e.forEach(function (e) {
+        e.interactionId &&
+          ((ai = Math.min(ai, e.interactionId)),
+          (ui = Math.max(ui, e.interactionId)),
+          (si = ui ? (ui - ai) / 7 + 1 : 0));
+      });
+    },
+    li = function () {
+      return Nn ? si : performance.interactionCount || 0;
+    },
+    di = function () {
+      "interactionCount" in performance ||
+        Nn ||
+        (Nn = Gn("event", ci, {
+          type: "event",
+          buffered: !0,
+          durationThreshold: 0,
+        }));
+    },
+    fi = [],
+    pi = new Map(),
+    gi = 0,
+    mi = [],
+    vi = function (e) {
+      if (
+        (mi.forEach(function (t) {
+          return t(e);
+        }),
+        e.interactionId || "first-input" === e.entryType)
+      ) {
+        var t = fi[fi.length - 1],
+          n = pi.get(e.interactionId);
+        if (n || fi.length < 10 || e.duration > t.latency) {
+          if (n)
+            e.duration > n.latency
+              ? ((n.entries = [e]), (n.latency = e.duration))
+              : e.duration === n.latency &&
+                e.startTime === n.entries[0].startTime &&
+                n.entries.push(e);
+          else {
+            var i = { id: e.interactionId, latency: e.duration, entries: [e] };
+            pi.set(i.id, i), fi.push(i);
+          }
+          fi.sort(function (e, t) {
+            return t.latency - e.latency;
+          }),
+            fi.length > 10 &&
+              fi.splice(10).forEach(function (e) {
+                return pi.delete(e.id);
+              });
+        }
+      }
+    },
+    hi = function (e) {
+      var t = self.requestIdleCallback || self.setTimeout,
+        n = -1;
+      return (
+        (e = Xn(e)),
+        "hidden" === document.visibilityState ? e() : ((n = t(e)), Kn(e)),
+        n
+      );
+    },
+    bi = [200, 500],
+    wi = function (e, t) {
+      "PerformanceEventTiming" in self &&
+        "interactionId" in PerformanceEventTiming.prototype &&
+        ((t = t || {}),
+        ni(function () {
+          var n;
+          di();
+          var i,
+            r = $n("INP"),
+            o = function (e) {
+              hi(function () {
+                e.forEach(vi);
+                var t = (function () {
+                  var e = Math.min(fi.length - 1, Math.floor((li() - gi) / 50));
+                  return fi[e];
+                })();
+                t &&
+                  t.latency !== r.value &&
+                  ((r.value = t.latency), (r.entries = t.entries), i());
+              });
+            },
+            s = Gn("event", o, {
+              durationThreshold:
+                null !== (n = t.durationThreshold) && void 0 !== n ? n : 40,
+            });
+          (i = Hn(e, r, bi, t.reportAllChanges)),
+            s &&
+              (s.observe({ type: "first-input", buffered: !0 }),
+              Kn(function () {
+                o(s.takeRecords()), i(!0);
+              }),
+              qn(function () {
+                (gi = li()),
+                  (fi.length = 0),
+                  pi.clear(),
+                  (r = $n("INP")),
+                  (i = Hn(e, r, bi, t.reportAllChanges));
+              }));
+        }));
+    },
+    yi = [],
+    Si = [],
+    Ti = 0,
+    Ei = new WeakMap(),
+    Ii = new Map(),
+    ki = -1,
+    Oi = function (e) {
+      (yi = yi.concat(e)), xi();
+    },
+    xi = function () {
+      ki < 0 && (ki = hi(Li));
+    },
+    Li = function () {
+      Ii.size > 10 &&
+        Ii.forEach(function (e, t) {
+          pi.has(t) || Ii.delete(t);
+        });
+      var e = fi.map(function (e) {
+          return Ei.get(e.entries[0]);
+        }),
+        t = Si.length - 50;
+      Si = Si.filter(function (n, i) {
+        return i >= t || e.includes(n);
+      });
+      for (var n = new Set(), i = 0; i < Si.length; i++) {
+        var r = Si[i];
+        ji(r.startTime, r.processingEnd).forEach(function (e) {
+          n.add(e);
+        });
+      }
+      var o = yi.length - 1 - 50;
+      (yi = yi.filter(function (e, t) {
+        return (e.startTime > Ti && t > o) || n.has(e);
+      })),
+        (ki = -1);
+    };
+  mi.push(
+    function (e) {
+      e.interactionId &&
+        e.target &&
+        !Ii.has(e.interactionId) &&
+        Ii.set(e.interactionId, e.target);
+    },
+    function (e) {
+      var t,
+        n = e.startTime + e.duration;
+      Ti = Math.max(Ti, e.processingEnd);
+      for (var i = Si.length - 1; i >= 0; i--) {
+        var r = Si[i];
+        if (Math.abs(n - r.renderTime) <= 8) {
+          ((t = r).startTime = Math.min(e.startTime, t.startTime)),
+            (t.processingStart = Math.min(
+              e.processingStart,
+              t.processingStart
+            )),
+            (t.processingEnd = Math.max(e.processingEnd, t.processingEnd)),
+            t.entries.push(e);
+          break;
+        }
+      }
+      t ||
+        ((t = {
+          startTime: e.startTime,
+          processingStart: e.processingStart,
+          processingEnd: e.processingEnd,
+          renderTime: n,
+          entries: [e],
+        }),
+        Si.push(t)),
+        (e.interactionId || "first-input" === e.entryType) && Ei.set(e, t),
+        xi();
+    }
+  );
+  var Ci,
+    Ai,
+    Pi,
+    Mi,
+    ji = function (e, t) {
+      for (var n, i = [], r = 0; (n = yi[r]); r++)
+        if (!(n.startTime + n.duration < e)) {
+          if (n.startTime > t) break;
+          i.push(n);
+        }
+      return i;
+    },
+    Ni = [2500, 4e3],
+    _i = {},
+    Di = [800, 1800],
+    Ri = function e(t) {
+      document.prerendering
+        ? ni(function () {
+            return e(t);
+          })
+        : "complete" !== document.readyState
+        ? addEventListener(
+            "load",
+            function () {
+              return e(t);
+            },
+            !0
+          )
+        : setTimeout(t, 0);
+    },
+    Ui = function (e, t) {
+      t = t || {};
+      var n = $n("TTFB"),
+        i = Hn(e, n, Di, t.reportAllChanges);
+      Ri(function () {
+        var r = Dn();
+        r &&
+          ((n.value = Math.max(r.responseStart - Vn(), 0)),
+          (n.entries = [r]),
+          i(!0),
+          qn(function () {
+            (n = $n("TTFB", 0)), (i = Hn(e, n, Di, t.reportAllChanges))(!0);
+          }));
+      });
+    },
+    Bi = { passive: !0, capture: !0 },
+    Fi = new Date(),
+    zi = function (e, t) {
+      Ci ||
+        ((Ci = t), (Ai = e), (Pi = new Date()), $i(removeEventListener), qi());
+    },
+    qi = function () {
+      if (Ai >= 0 && Ai < Pi - Fi) {
+        var e = {
+          entryType: "first-input",
+          name: Ci.type,
+          target: Ci.target,
+          cancelable: Ci.cancelable,
+          startTime: Ci.timeStamp,
+          processingStart: Ci.timeStamp + Ai,
+        };
+        Mi.forEach(function (t) {
+          t(e);
+        }),
+          (Mi = []);
+      }
+    },
+    Vi = function (e) {
+      if (e.cancelable) {
+        var t =
+          (e.timeStamp > 1e12 ? new Date() : performance.now()) - e.timeStamp;
+        "pointerdown" == e.type
+          ? (function (e, t) {
+              var n = function () {
+                  zi(e, t), r();
+                },
+                i = function () {
+                  r();
+                },
+                r = function () {
+                  removeEventListener("pointerup", n, Bi),
+                    removeEventListener("pointercancel", i, Bi);
+                };
+              addEventListener("pointerup", n, Bi),
+                addEventListener("pointercancel", i, Bi);
+            })(t, e)
+          : zi(t, e);
+      }
+    },
+    $i = function (e) {
+      ["mousedown", "keydown", "touchstart", "pointerdown"].forEach(function (
+        t
+      ) {
+        return e(t, Vi, Bi);
+      });
+    },
+    Gi = [100, 300],
+    Hi = function (e, t) {
+      !(function (e, t) {
+        (t = t || {}),
+          ni(function () {
+            var n,
+              i = ti(),
+              r = $n("FID"),
+              o = function (e) {
+                e.startTime < i.firstHiddenTime &&
+                  ((r.value = e.processingStart - e.startTime),
+                  r.entries.push(e),
+                  n(!0));
+              },
+              s = function (e) {
+                e.forEach(o);
+              },
+              a = Gn("first-input", s);
+            (n = Hn(e, r, Gi, t.reportAllChanges)),
+              a &&
+                (Kn(
+                  Xn(function () {
+                    s(a.takeRecords()), a.disconnect();
+                  })
+                ),
+                qn(function () {
+                  var i;
+                  (r = $n("FID")),
+                    (n = Hn(e, r, Gi, t.reportAllChanges)),
+                    (Mi = []),
+                    (Ai = -1),
+                    (Ci = null),
+                    $i(addEventListener),
+                    (i = o),
+                    Mi.push(i),
+                    qi();
+                }));
+          });
+      })(function (t) {
+        var n = (function (e) {
+          var t = e.entries[0],
+            n = {
+              eventTarget: Bn(t.target),
+              eventType: t.name,
+              eventTime: t.startTime,
+              eventEntry: t,
+              loadState: Rn(t.startTime),
+            };
+          return Object.assign(e, { attribution: n });
+        })(t);
+        e(n);
+      }, t);
+    };
+  const Wi = "com.grafana.faro.lastNavigationId",
+    Ki = "load_state",
+    Xi = "time_to_first_byte";
+  class Ji {
+    constructor(e, t) {
+      (this.corePushMeasurement = e), (this.webVitalConfig = t);
+    }
+    initialize() {
+      this.measureCLS(),
+        this.measureFCP(),
+        this.measureFID(),
+        this.measureINP(),
+        this.measureLCP(),
+        this.measureTTFB();
+    }
+    measureCLS() {
+      var e;
+      !(function (e, t) {
+        !(function (e, t) {
+          (t = t || {}),
+            ri(
+              Xn(function () {
+                var n,
+                  i = $n("CLS", 0),
+                  r = 0,
+                  o = [],
+                  s = function (e) {
+                    e.forEach(function (e) {
+                      if (!e.hadRecentInput) {
+                        var t = o[0],
+                          n = o[o.length - 1];
+                        r &&
+                        e.startTime - n.startTime < 1e3 &&
+                        e.startTime - t.startTime < 5e3
+                          ? ((r += e.value), o.push(e))
+                          : ((r = e.value), (o = [e]));
+                      }
+                    }),
+                      r > i.value && ((i.value = r), (i.entries = o), n());
+                  },
+                  a = Gn("layout-shift", s);
+                a &&
+                  ((n = Hn(e, i, oi, t.reportAllChanges)),
+                  Kn(function () {
+                    s(a.takeRecords()), n(!0);
+                  }),
+                  qn(function () {
+                    (r = 0),
+                      (i = $n("CLS", 0)),
+                      (n = Hn(e, i, oi, t.reportAllChanges)),
+                      Wn(function () {
+                        return n();
+                      });
+                  }),
+                  setTimeout(n, 0));
+              })
+            );
+        })(function (t) {
+          var n = (function (e) {
+            var t,
+              n = {};
+            if (e.entries.length) {
+              var i = e.entries.reduce(function (e, t) {
+                return e && e.value > t.value ? e : t;
+              });
+              if (i && i.sources && i.sources.length) {
+                var r =
+                  (t = i.sources).find(function (e) {
+                    return e.node && 1 === e.node.nodeType;
+                  }) || t[0];
+                r &&
+                  (n = {
+                    largestShiftTarget: Bn(r.node),
+                    largestShiftTime: i.startTime,
+                    largestShiftValue: i.value,
+                    largestShiftSource: r,
+                    largestShiftEntry: i,
+                    loadState: Rn(i.startTime),
+                  });
+              }
+            }
+            return Object.assign(e, { attribution: n });
+          })(t);
+          e(n);
+        }, t);
+      })(
+        (e) => {
+          const {
+              loadState: t,
+              largestShiftValue: n,
+              largestShiftTime: i,
+              largestShiftTarget: r,
+            } = e.attribution,
+            o = this.buildInitialValues(e);
+          this.addIfPresent(o, "largest_shift_value", n),
+            this.addIfPresent(o, "largest_shift_time", i);
+          const s = this.buildInitialContext(e);
+          this.addIfPresent(s, Ki, t),
+            this.addIfPresent(s, "largest_shift_target", r),
+            this.pushMeasurement(o, s);
+        },
+        {
+          reportAllChanges:
+            null === (e = this.webVitalConfig) || void 0 === e
+              ? void 0
+              : e.reportAllChanges,
+        }
+      );
+    }
+    measureFCP() {
+      var e;
+      !(function (e, t) {
+        ri(function (t) {
+          var n = (function (e) {
+            var t = {
+              timeToFirstByte: 0,
+              firstByteToFCP: e.value,
+              loadState: Rn(zn()),
+            };
+            if (e.entries.length) {
+              var n = Dn(),
+                i = e.entries[e.entries.length - 1];
+              if (n) {
+                var r = n.activationStart || 0,
+                  o = Math.max(0, n.responseStart - r);
+                t = {
+                  timeToFirstByte: o,
+                  firstByteToFCP: e.value - o,
+                  loadState: Rn(e.entries[0].startTime),
+                  navigationEntry: n,
+                  fcpEntry: i,
+                };
+              }
+            }
+            return Object.assign(e, { attribution: t });
+          })(t);
+          e(n);
+        }, t);
+      })(
+        (e) => {
+          const {
+              firstByteToFCP: t,
+              timeToFirstByte: n,
+              loadState: i,
+            } = e.attribution,
+            r = this.buildInitialValues(e);
+          this.addIfPresent(r, "first_byte_to_fcp", t),
+            this.addIfPresent(r, Xi, n);
+          const o = this.buildInitialContext(e);
+          this.addIfPresent(o, Ki, i), this.pushMeasurement(r, o);
+        },
+        {
+          reportAllChanges:
+            null === (e = this.webVitalConfig) || void 0 === e
+              ? void 0
+              : e.reportAllChanges,
+        }
+      );
+    }
+    measureFID() {
+      var e;
+      Hi(
+        (e) => {
+          const {
+              eventTime: t,
+              eventTarget: n,
+              eventType: i,
+              loadState: r,
+            } = e.attribution,
+            o = this.buildInitialValues(e);
+          this.addIfPresent(o, "event_time", t);
+          const s = this.buildInitialContext(e);
+          this.addIfPresent(s, "event_target", n),
+            this.addIfPresent(s, "event_type", i),
+            this.addIfPresent(s, Ki, r),
+            this.pushMeasurement(o, s);
+        },
+        {
+          reportAllChanges:
+            null === (e = this.webVitalConfig) || void 0 === e
+              ? void 0
+              : e.reportAllChanges,
+        }
+      );
+    }
+    measureINP() {
+      var e;
+      !(function (e, t) {
+        _n || (_n = Gn("long-animation-frame", Oi)),
+          wi(function (t) {
+            var n = (function (e) {
+              var t = e.entries[0],
+                n = Ei.get(t),
+                i = t.processingStart,
+                r = n.processingEnd,
+                o = n.entries.sort(function (e, t) {
+                  return e.processingStart - t.processingStart;
+                }),
+                s = ji(t.startTime, r),
+                a = e.entries.find(function (e) {
+                  return e.target;
+                }),
+                u = (a && a.target) || Ii.get(t.interactionId),
+                c = [t.startTime + t.duration, r].concat(
+                  s.map(function (e) {
+                    return e.startTime + e.duration;
+                  })
+                ),
+                l = Math.max.apply(Math, c),
+                d = {
+                  interactionTarget: Bn(u),
+                  interactionTargetElement: u,
+                  interactionType: t.name.startsWith("key")
+                    ? "keyboard"
+                    : "pointer",
+                  interactionTime: t.startTime,
+                  nextPaintTime: l,
+                  processedEventEntries: o,
+                  longAnimationFrameEntries: s,
+                  inputDelay: i - t.startTime,
+                  processingDuration: r - i,
+                  presentationDelay: Math.max(l - r, 0),
+                  loadState: Rn(t.startTime),
+                };
+              return Object.assign(e, { attribution: d });
+            })(t);
+            e(n);
+          }, t);
+      })(
+        (e) => {
+          const {
+              interactionTime: t,
+              presentationDelay: n,
+              inputDelay: i,
+              processingDuration: r,
+              nextPaintTime: o,
+              loadState: s,
+              interactionTarget: a,
+              interactionType: u,
+            } = e.attribution,
+            c = this.buildInitialValues(e);
+          this.addIfPresent(c, "interaction_time", t),
+            this.addIfPresent(c, "presentation_delay", n),
+            this.addIfPresent(c, "input_delay", i),
+            this.addIfPresent(c, "processing_duration", r),
+            this.addIfPresent(c, "next_paint_time", o);
+          const l = this.buildInitialContext(e);
+          this.addIfPresent(l, Ki, s),
+            this.addIfPresent(l, "interaction_target", a),
+            this.addIfPresent(l, "interaction_type", u),
+            this.pushMeasurement(c, l);
+        },
+        {
+          reportAllChanges:
+            null === (e = this.webVitalConfig) || void 0 === e
+              ? void 0
+              : e.reportAllChanges,
+        }
+      );
+    }
+    measureLCP() {
+      var e;
+      !(function (e, t) {
+        !(function (e, t) {
+          (t = t || {}),
+            ni(function () {
+              var n,
+                i = ti(),
+                r = $n("LCP"),
+                o = function (e) {
+                  t.reportAllChanges || (e = e.slice(-1)),
+                    e.forEach(function (e) {
+                      e.startTime < i.firstHiddenTime &&
+                        ((r.value = Math.max(e.startTime - Vn(), 0)),
+                        (r.entries = [e]),
+                        n());
+                    });
+                },
+                s = Gn("largest-contentful-paint", o);
+              if (s) {
+                n = Hn(e, r, Ni, t.reportAllChanges);
+                var a = Xn(function () {
+                  _i[r.id] ||
+                    (o(s.takeRecords()),
+                    s.disconnect(),
+                    (_i[r.id] = !0),
+                    n(!0));
+                });
+                ["keydown", "click"].forEach(function (e) {
+                  addEventListener(
+                    e,
+                    function () {
+                      return hi(a);
+                    },
+                    { once: !0, capture: !0 }
+                  );
+                }),
+                  Kn(a),
+                  qn(function (i) {
+                    (r = $n("LCP")),
+                      (n = Hn(e, r, Ni, t.reportAllChanges)),
+                      Wn(function () {
+                        (r.value = performance.now() - i.timeStamp),
+                          (_i[r.id] = !0),
+                          n(!0);
+                      });
+                  });
+              }
+            });
+        })(function (t) {
+          var n = (function (e) {
+            var t = {
+              timeToFirstByte: 0,
+              resourceLoadDelay: 0,
+              resourceLoadDuration: 0,
+              elementRenderDelay: e.value,
+            };
+            if (e.entries.length) {
+              var n = Dn();
+              if (n) {
+                var i = n.activationStart || 0,
+                  r = e.entries[e.entries.length - 1],
+                  o =
+                    r.url &&
+                    performance
+                      .getEntriesByType("resource")
+                      .filter(function (e) {
+                        return e.name === r.url;
+                      })[0],
+                  s = Math.max(0, n.responseStart - i),
+                  a = Math.max(s, o ? (o.requestStart || o.startTime) - i : 0),
+                  u = Math.max(a, o ? o.responseEnd - i : 0),
+                  c = Math.max(u, r.startTime - i);
+                (t = {
+                  element: Bn(r.element),
+                  timeToFirstByte: s,
+                  resourceLoadDelay: a - s,
+                  resourceLoadDuration: u - a,
+                  elementRenderDelay: c - u,
+                  navigationEntry: n,
+                  lcpEntry: r,
+                }),
+                  r.url && (t.url = r.url),
+                  o && (t.lcpResourceEntry = o);
+              }
+            }
+            return Object.assign(e, { attribution: t });
+          })(t);
+          e(n);
+        }, t);
+      })(
+        (e) => {
+          const {
+              elementRenderDelay: t,
+              resourceLoadDelay: n,
+              resourceLoadDuration: i,
+              timeToFirstByte: r,
+              element: o,
+            } = e.attribution,
+            s = this.buildInitialValues(e);
+          this.addIfPresent(s, "element_render_delay", t),
+            this.addIfPresent(s, "resource_load_delay", n),
+            this.addIfPresent(s, "resource_load_duration", i),
+            this.addIfPresent(s, Xi, r);
+          const a = this.buildInitialContext(e);
+          this.addIfPresent(a, "element", o), this.pushMeasurement(s, a);
+        },
+        {
+          reportAllChanges:
+            null === (e = this.webVitalConfig) || void 0 === e
+              ? void 0
+              : e.reportAllChanges,
+        }
+      );
+    }
+    measureTTFB() {
+      var e;
+      !(function (e, t) {
+        Ui(function (t) {
+          var n = (function (e) {
+            var t = {
+              waitingDuration: 0,
+              cacheDuration: 0,
+              dnsDuration: 0,
+              connectionDuration: 0,
+              requestDuration: 0,
+            };
+            if (e.entries.length) {
+              var n = e.entries[0],
+                i = n.activationStart || 0,
+                r = Math.max((n.workerStart || n.fetchStart) - i, 0),
+                o = Math.max(n.domainLookupStart - i, 0),
+                s = Math.max(n.connectStart - i, 0),
+                a = Math.max(n.connectEnd - i, 0);
+              t = {
+                waitingDuration: r,
+                cacheDuration: o - r,
+                dnsDuration: s - o,
+                connectionDuration: a - s,
+                requestDuration: e.value - a,
+                navigationEntry: n,
+              };
+            }
+            return Object.assign(e, { attribution: t });
+          })(t);
+          e(n);
+        }, t);
+      })(
+        (e) => {
+          const {
+              dnsDuration: t,
+              connectionDuration: n,
+              requestDuration: i,
+              waitingDuration: r,
+              cacheDuration: o,
+            } = e.attribution,
+            s = this.buildInitialValues(e);
+          this.addIfPresent(s, "dns_duration", t),
+            this.addIfPresent(s, "connection_duration", n),
+            this.addIfPresent(s, "request_duration", i),
+            this.addIfPresent(s, "waiting_duration", r),
+            this.addIfPresent(s, "cache_duration", o);
+          const a = this.buildInitialContext(e);
+          this.pushMeasurement(s, a);
+        },
+        {
+          reportAllChanges:
+            null === (e = this.webVitalConfig) || void 0 === e
+              ? void 0
+              : e.reportAllChanges,
+        }
+      );
+    }
+    buildInitialValues(e) {
+      const t = e.name.toLowerCase();
+      return { [t]: e.value, delta: e.delta };
+    }
+    buildInitialContext(e) {
+      var t;
+      const n = null !== (t = Re(Wi, _e.session)) && void 0 !== t ? t : Le;
+      return {
+        id: e.id,
+        rating: e.rating,
+        navigation_type: e.navigationType,
+        navigation_entry_id: n,
+      };
+    }
+    pushMeasurement(e, t) {
+      this.corePushMeasurement(
+        { type: "web-vitals", values: e },
+        { context: t }
+      );
+    }
+    addIfPresent(e, t, n) {
+      n && (e[t] = n);
+    }
+  }
+  class Zi extends ge {
+    constructor() {
+      super(...arguments),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-web-vitals"),
+        (this.version = me);
+    }
+    initialize() {
+      this.logDebug("Initializing");
+      this.intializeWebVitalsInstrumentation().initialize();
+    }
+    intializeWebVitalsInstrumentation() {
+      var e, t, n;
+      return !1 ===
+        (null === (e = this.config) || void 0 === e
+          ? void 0
+          : e.trackWebVitalsAttribution) ||
+        !1 ===
+          (null ===
+            (n =
+              null === (t = this.config) || void 0 === t
+                ? void 0
+                : t.webVitalsInstrumentation) || void 0 === n
+            ? void 0
+            : n.trackAttribution)
+        ? new jn(this.api.pushMeasurement, this.config.webVitalsInstrumentation)
+        : new Ji(
+            this.api.pushMeasurement,
+            this.config.webVitalsInstrumentation
+          );
+    }
+  }
+  function Yi(e, t) {
+    var n = {};
+    for (var i in e)
+      Object.prototype.hasOwnProperty.call(e, i) &&
+        t.indexOf(i) < 0 &&
+        (n[i] = e[i]);
+    if (null != e && "function" == typeof Object.getOwnPropertySymbols) {
+      var r = 0;
+      for (i = Object.getOwnPropertySymbols(e); r < i.length; r++)
+        t.indexOf(i[r]) < 0 &&
+          Object.prototype.propertyIsEnumerable.call(e, i[r]) &&
+          (n[i[r]] = e[i[r]]);
+    }
+    return n;
+  }
+  function Qi(e, t, n, i) {
+    return new (n || (n = Promise))(function (r, o) {
+      function s(e) {
+        try {
+          u(i.next(e));
+        } catch (e) {
+          o(e);
+        }
+      }
+      function a(e) {
+        try {
+          u(i.throw(e));
+        } catch (e) {
+          o(e);
+        }
+      }
+      function u(e) {
+        var t;
+        e.done
+          ? r(e.value)
+          : ((t = e.value),
+            t instanceof n
+              ? t
+              : new n(function (e) {
+                  e(t);
+                })).then(s, a);
+      }
+      u((i = i.apply(e, t || [])).next());
+    });
+  }
+  "function" == typeof SuppressedError && SuppressedError;
+  const er = "resource",
+    tr = /^00-[a-f0-9]{32}-[a-f0-9]{16}-[0-9]{1,2}$/;
+  function nr(e = []) {
+    for (const t of e)
+      if ("traceparent" === t.name) {
+        if (!tr.test(t.description)) continue;
+        const [, e, n] = t.description.split("-");
+        if (null != e && null != n) return { traceId: e, spanId: n };
+        break;
+      }
+  }
+  function ir(e, t = {}) {
+    for (const [n, i] of Object.entries(t)) {
+      const t = e[n];
+      return null != t && (l(i) ? i.includes(t) : t === i);
+    }
+    return !0;
+  }
+  function rr(e) {
+    const {
+      connectEnd: t,
+      connectStart: n,
+      decodedBodySize: i,
+      domainLookupEnd: r,
+      domainLookupStart: o,
+      duration: s,
+      encodedBodySize: a,
+      fetchStart: u,
+      initiatorType: c,
+      name: l,
+      nextHopProtocol: d,
+      redirectEnd: f,
+      redirectStart: p,
+      renderBlockingStatus: g,
+      requestStart: m,
+      responseEnd: v,
+      responseStart: h,
+      responseStatus: b,
+      secureConnectionStart: w,
+      transferSize: y,
+      workerStart: S,
+    } = e;
+    return {
+      name: l,
+      duration: sr(s),
+      tcpHandshakeTime: sr(t - n),
+      dnsLookupTime: sr(r - o),
+      tlsNegotiationTime: sr(t - w),
+      responseStatus: sr(b),
+      redirectTime: sr(f - p),
+      requestTime: sr(h - m),
+      responseTime: sr(v - h),
+      fetchTime: sr(v - u),
+      serviceWorkerTime: sr(u - S),
+      decodedBodySize: sr(i),
+      encodedBodySize: sr(a),
+      cacheHitStatus: (function () {
+        let e = "fullLoad";
+        0 === y
+          ? i > 0 && (e = "cache")
+          : null != b
+          ? 304 === b && (e = "conditionalFetch")
+          : a > 0 && y < a && (e = "conditionalFetch");
+        return e;
+      })(),
+      renderBlockingStatus: sr(g),
+      protocol: d,
+      initiatorType: c,
+      visibilityState: document.visibilityState,
+      ttfb: sr(h - m),
+      transferSize: sr(y),
+    };
+  }
+  function or(e) {
+    const {
+        activationStart: t,
+        domComplete: n,
+        domContentLoadedEventEnd: i,
+        domContentLoadedEventStart: r,
+        domInteractive: o,
+        fetchStart: s,
+        loadEventEnd: a,
+        loadEventStart: u,
+        responseStart: c,
+        type: l,
+      } = e,
+      d = (function () {
+        var e;
+        if (
+          null !=
+          (null === (e = performance.timing) || void 0 === e
+            ? void 0
+            : e.domLoading)
+        )
+          return performance.timing.domLoading - performance.timeOrigin;
+        return null;
+      })();
+    return Object.assign(Object.assign({}, rr(e)), {
+      pageLoadTime: sr(n - s),
+      documentParsingTime: sr(d ? o - d : null),
+      domProcessingTime: sr(n - o),
+      domContentLoadHandlerTime: sr(i - r),
+      onLoadTime: sr(a - u),
+      ttfb: sr(Math.max(c - (null != t ? t : 0), 0)),
+      type: l,
+    });
+  }
+  function sr(e) {
+    return null == e
+      ? Le
+      : "number" == typeof e
+      ? Math.round(e > 0 ? e : 0).toString()
+      : e.toString();
+  }
+  const ar = { initiatorType: ["xmlhttprequest", "fetch"] };
+  const ur = new D();
+  class cr extends ge {
+    constructor() {
+      super(...arguments),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-performance"),
+        (this.version = me);
+    }
+    initialize() {
+      "PerformanceObserver" in window
+        ? (function (e) {
+            if ("complete" === document.readyState) e();
+            else {
+              const t = () => {
+                "complete" === document.readyState &&
+                  (e(), document.removeEventListener("readystatechange", t));
+              };
+              document.addEventListener("readystatechange", t);
+            }
+          })(() =>
+            Qi(this, void 0, void 0, function* () {
+              const t = this.api.pushEvent,
+                { faroNavigationId: n } = yield (function (e) {
+                  let t;
+                  const n = new Promise((e) => {
+                    t = e;
+                  });
+                  return (
+                    new PerformanceObserver((n) => {
+                      var i;
+                      const [r] = n.getEntries();
+                      if (null == r || Ge(r.name)) return;
+                      const o = r.toJSON();
+                      let s = nr(null == o ? void 0 : o.serverTiming);
+                      const a =
+                          null !== (i = Re(Wi, _e.session)) && void 0 !== i
+                            ? i
+                            : Le,
+                        u = Object.assign(Object.assign({}, or(o)), {
+                          faroNavigationId: M(),
+                          faroPreviousNavigationId: a,
+                        });
+                      Ue(Wi, u.faroNavigationId, _e.session),
+                        e("faro.performance.navigation", u, void 0, {
+                          spanContext: s,
+                          timestampOverwriteMs:
+                            performance.timeOrigin + o.startTime,
+                        }),
+                        t(u);
+                    }).observe({ type: "navigation", buffered: !0 }),
+                    n
+                  );
+                })(t);
+              null != n &&
+                (function (t, n, i) {
+                  const r = e.faro.config.trackResources;
+                  new PerformanceObserver((o) => {
+                    const s = o.getEntries();
+                    for (const o of s) {
+                      if (Ge(o.name)) return;
+                      const s = o.toJSON();
+                      let a = nr(null == s ? void 0 : s.serverTiming);
+                      if ((null == r && ir(s, ar)) || r) {
+                        const r = Object.assign(Object.assign({}, rr(s)), {
+                          faroNavigationId: t,
+                          faroResourceId: M(),
+                        });
+                        e.faro.config.trackUserActionsPreview &&
+                          (null == i || i.notify({ type: er })),
+                          n("faro.performance.resource", r, void 0, {
+                            spanContext: a,
+                            timestampOverwriteMs:
+                              performance.timeOrigin + s.startTime,
+                          });
+                      }
+                    }
+                  }).observe({ type: er, buffered: !0 });
+                })(n, t, ur);
+            })
+          )
+        : this.logDebug(
+            "performance observer not supported. Disable performance instrumentation."
+          );
+    }
+  }
+  const lr = "resource-entry",
+    dr = "http-request-start",
+    fr = "http-request-end",
+    pr = "dom-mutation",
+    gr = "data-faro-user-action-name";
+  const mr = "fetch",
+    vr = "xhr";
+  function hr() {
+    const e = new D();
+    function t(t) {
+      e.notify({ type: dr, request: t });
+    }
+    function n(t) {
+      e.notify({ type: fr, request: t });
+    }
+    return (
+      (function ({ onRequestEnd: e, onRequestStart: t }) {
+        const n = window.fetch;
+        window.fetch = function () {
+          var i, r;
+          const o = null !== (i = He(arguments[0])) && void 0 !== i ? i : "",
+            s = Ge(o),
+            a = (null !== (r = arguments[1]) && void 0 !== r ? r : {}).method,
+            u = M();
+          return (
+            s || t({ url: o, method: a, requestId: u, apiType: mr }),
+            n
+              .apply(this, arguments)
+              .then(
+                (t) => (
+                  s || e({ url: o, method: a, requestId: u, apiType: mr }), t
+                )
+              )
+              .catch((t) => {
+                throw (
+                  (s || e({ url: o, method: a, requestId: u, apiType: mr }), t)
+                );
+              })
+          );
+        };
+      })({ onRequestStart: t, onRequestEnd: n }),
+      (function ({ onRequestStart: e, onRequestEnd: t }) {
+        const n = XMLHttpRequest.prototype.open;
+        XMLHttpRequest.prototype.open = function () {
+          const i = arguments[1],
+            r = Ge(i),
+            o = arguments[0],
+            s = M();
+          this.addEventListener("loadstart", function () {
+            r || e({ url: i, method: o, requestId: s, apiType: vr });
+          }),
+            this.addEventListener("load", function () {
+              r || t({ url: i, method: o, requestId: s, apiType: vr });
+            }),
+            this.addEventListener("error", function () {
+              r || t({ url: i, method: o, requestId: s, apiType: vr });
+            }),
+            this.addEventListener("abort", function () {
+              r || t({ url: i, method: o, requestId: s, apiType: vr });
+            }),
+            n.apply(this, arguments);
+        };
+      })({ onRequestStart: t, onRequestEnd: n }),
+      e
+    );
+  }
+  function br(e) {
+    const { api: t, config: n } = e,
+      i = hr(),
+      r = (function () {
+        const e = new D();
+        return (
+          new MutationObserver((t, n) => {
+            e.notify({ type: pr });
+          }).observe(document, {
+            attributes: !0,
+            childList: !0,
+            subtree: !0,
+            characterData: !0,
+          }),
+          e
+        );
+      })(),
+      o = (function () {
+        const e = new D();
+        return (
+          ur.subscribe((t) => {
+            t.type === er && e.notify({ type: lr });
+          }),
+          e
+        );
+      })();
+    let s,
+      a = !1;
+    return function (e) {
+      var u;
+      let c;
+      const l = "apiEvent" === (d = e).type && "string" == typeof d.name;
+      var d;
+      if (
+        ((c = l
+          ? e.name
+          : (function (e, t) {
+              const n = (function (e) {
+                  const t = e.split("data-")[1],
+                    n =
+                      null == t
+                        ? void 0
+                        : t.replace(/-(.)/g, (e, t) => t.toUpperCase());
+                  return null == n ? void 0 : n.replace(/-/g, "");
+                })(t),
+                i = e.dataset;
+              for (const e in i) if (e === n) return i[e];
+              return;
+            })(
+              e.target,
+              null !== (u = n.trackUserActionsDataAttributeName) && void 0 !== u
+                ? u
+                : "faroUserActionName"
+            )),
+        a || null == c)
+      )
+        return;
+      a = !0;
+      const f = E();
+      let p;
+      const g = M();
+      fe.notify({ type: te, name: c, startTime: f, parentId: g }),
+        (s = yr(
+          s,
+          () => {
+            (p = E()),
+              (a = !1),
+              (function (e, t) {
+                fe.notify({ type: ie, name: e, parentId: t });
+              })(c, g);
+          },
+          100
+        ));
+      const m = new Map();
+      let v,
+        h = !1;
+      const b = new D()
+        .merge(i, r, o)
+        .takeWhile(() => a)
+        .filter((e) => !!(!h || (Tr(e) && m.has(e.request.requestId))))
+        .subscribe((n) => {
+          (function (e) {
+            return e.type === dr;
+          })(n) && m.set(n.request.requestId, n.request),
+            Tr(n) && m.delete(n.request.requestId),
+            (s = yr(
+              s,
+              () => {
+                p = E();
+                const n = Object.assign(
+                    {
+                      api: t,
+                      userActionName: c,
+                      startTime: f,
+                      endTime: p,
+                      actionId: g,
+                      event: e,
+                    },
+                    l ? { attributes: e.attributes } : {}
+                  ),
+                  i = m.size > 0;
+                h && !i && (clearTimeout(v), (h = !1)),
+                  i
+                    ? ((h = !0),
+                      fe.notify({
+                        type: re,
+                        name: c,
+                        parentId: g,
+                        reason: "pending-requests",
+                        haltTime: E(),
+                      }),
+                      (v = yr(
+                        void 0,
+                        () => {
+                          Sr(b), wr(n), (a = !1), (h = !1);
+                        },
+                        1e4
+                      )))
+                    : (Sr(b), wr(n), (a = !1), (h = !1));
+              },
+              100
+            ));
+        });
+    };
+  }
+  function wr(e) {
+    const {
+        api: t,
+        userActionName: n,
+        startTime: i,
+        endTime: r,
+        actionId: o,
+        event: s,
+        attributes: a,
+      } = e,
+      u = r - i,
+      c = s.type;
+    fe.notify({
+      type: ne,
+      name: n,
+      id: o,
+      startTime: i,
+      endTime: r,
+      duration: u,
+      eventType: c,
+    }),
+      t.pushEvent(
+        n,
+        Object.assign(
+          {
+            userActionStartTime: i.toString(),
+            userActionEndTime: r.toString(),
+            userActionDuration: u.toString(),
+            userActionEventType: c,
+          },
+          _(a)
+        ),
+        void 0,
+        {
+          timestampOverwriteMs: i,
+          customPayloadTransformer: (e) => ((e.action = { id: o, name: n }), e),
+        }
+      );
+  }
+  function yr(e, t, n) {
+    return (
+      e && clearTimeout(e),
+      (e = setTimeout(() => {
+        t();
+      }, n))
+    );
+  }
+  function Sr(e) {
+    null == e || e.unsubscribe(), (e = void 0);
+  }
+  function Tr(e) {
+    return e.type === fr;
+  }
+  let Er;
+  class Ir extends ge {
+    constructor() {
+      super(...arguments),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-user-action"),
+        (this.version = me);
+    }
+    initialize() {
+      (Er = br(e.faro)),
+        window.addEventListener("pointerdown", Er),
+        window.addEventListener("keydown", Er);
+    }
+  }
+  function kr(e = {}) {
+    const t = [new Ir(), new Dt(), new Zi(), new at(), new Rt()];
+    return (
+      !1 !== e.enablePerformanceInstrumentation && t.unshift(new cr()),
+      !1 !== e.captureConsole &&
+        t.push(new _t({ disabledLevels: e.captureConsoleDisabledLevels })),
+      t
+    );
+  }
+  const Or = "browser",
+    xr = () => {
+      const e = window.k6;
+      return {
+        k6: Object.assign(
+          { isK6Browser: !0 },
+          (null == e ? void 0 : e.testRunId) && {
+            testRunId: null == e ? void 0 : e.testRunId,
+          }
+        ),
+      };
+    };
+  let Lr, Cr;
+  function Ar({ generatePageId: e, initialPageMeta: t } = {}) {
+    return () => {
+      const n = location.href;
+      return (
+        c(e) && Lr !== n && ((Lr = n), (Cr = e(location))),
+        {
+          page: Object.assign(
+            Object.assign({ url: n }, Cr ? { id: Cr } : {}),
+            t
+          ),
+        }
+      );
+    };
+  }
+  class Pr extends Y {
+    constructor(e) {
+      var t, n, i, r;
+      super(),
+        (this.options = e),
+        (this.name = "@grafana/faro-web-sdk:transport-fetch"),
+        (this.version = me),
+        (this.disabledUntil = new Date()),
+        (this.rateLimitBackoffMs =
+          null !== (t = e.defaultRateLimitBackoffMs) && void 0 !== t ? t : 5e3),
+        (this.getNow =
+          null !== (n = e.getNow) && void 0 !== n ? n : () => Date.now()),
+        (this.promiseBuffer = A({
+          size: null !== (i = e.bufferSize) && void 0 !== i ? i : 30,
+          concurrency: null !== (r = e.concurrency) && void 0 !== r ? r : 5,
+        }));
+    }
+    send(e) {
+      return Qi(this, void 0, void 0, function* () {
+        try {
+          if (this.disabledUntil > new Date(this.getNow()))
+            return (
+              this.logWarn(
+                `Dropping transport item due to too many requests. Backoff until ${this.disabledUntil}`
+              ),
+              Promise.resolve()
+            );
+          yield this.promiseBuffer.add(() => {
+            const t = JSON.stringify(ee(e)),
+              { url: n, requestOptions: i, apiKey: r } = this.options,
+              o = null != i ? i : {},
+              { headers: s } = o,
+              a = Yi(o, ["headers"]);
+            let u;
+            const c = this.metas.value.session;
+            return (
+              null != c && (u = c.id),
+              fetch(
+                n,
+                Object.assign(
+                  {
+                    method: "POST",
+                    headers: Object.assign(
+                      Object.assign(
+                        Object.assign(
+                          { "Content-Type": "application/json" },
+                          null != s ? s : {}
+                        ),
+                        r ? { "x-api-key": r } : {}
+                      ),
+                      u ? { "x-faro-session-id": u } : {}
+                    ),
+                    body: t,
+                    keepalive: t.length <= 6e4,
+                  },
+                  null != a ? a : {}
+                )
+              )
+                .then((e) =>
+                  Qi(this, void 0, void 0, function* () {
+                    if (202 === e.status) {
+                      "invalid" === e.headers.get("X-Faro-Session-Status") &&
+                        this.extendFaroSession(this.config, this.logDebug);
+                    }
+                    return (
+                      429 === e.status &&
+                        ((this.disabledUntil = this.getRetryAfterDate(e)),
+                        this.logWarn(
+                          `Too many requests, backing off until ${this.disabledUntil}`
+                        )),
+                      e.text().catch(C),
+                      e
+                    );
+                  })
+                )
+                .catch((e) => {
+                  this.logError(
+                    "Failed sending payload to the receiver\n",
+                    JSON.parse(t),
+                    e
+                  );
+                })
+            );
+          });
+        } catch (e) {
+          this.logError(e);
+        }
+      });
+    }
+    getIgnoreUrls() {
+      var e;
+      return [this.options.url].concat(
+        null !== (e = this.config.ignoreUrls) && void 0 !== e ? e : []
+      );
+    }
+    isBatched() {
+      return !0;
+    }
+    getRetryAfterDate(e) {
+      const t = this.getNow(),
+        n = e.headers.get("Retry-After");
+      if (n) {
+        const e = Number(n);
+        if (!isNaN(e)) return new Date(1e3 * e + t);
+        const i = Date.parse(n);
+        if (!isNaN(i)) return new Date(i);
+      }
+      return new Date(t + this.rateLimitBackoffMs);
+    }
+    extendFaroSession(e, t) {
+      const n = "Session expired",
+        i = e.sessionTracking;
+      if (null == i ? void 0 : i.enabled) {
+        const { fetchUserSession: e, storeUserSession: r } = st(i);
+        tt({ fetchUserSession: e, storeUserSession: r })({
+          forceSessionExtend: !0,
+        }),
+          t(`${n} created new session.`);
+      } else t(`${n}.`);
+    }
+  }
+  function Mr(e) {
+    var t;
+    const n = [],
+      i = K(e.unpatchedConsole, e.internalLoggerLevel);
+    e.transports
+      ? ((e.url || e.apiKey) &&
+          i.error(
+            'if "transports" is defined, "url" and "apiKey" should not be defined'
+          ),
+        n.push(...e.transports))
+      : e.url
+      ? n.push(new Pr({ url: e.url, apiKey: e.apiKey }))
+      : i.error('either "url" or "transports" must be defined');
+    const {
+        dedupe: r = !0,
+        eventDomain: o = Or,
+        globalObjectKey: s = Se,
+        instrumentations: a = kr(),
+        internalLoggerLevel: u = $,
+        isolate: c = !1,
+        logArgsSerializer: l = ce,
+        metas: d = Nr(e),
+        paused: f = !1,
+        preventGlobalExposure: p = !1,
+        unpatchedConsole: g = G,
+        trackUserActionsPreview: m = !1,
+        trackUserActionsDataAttributeName: v = gr,
+      } = e,
+      h = Yi(e, [
+        "dedupe",
+        "eventDomain",
+        "globalObjectKey",
+        "instrumentations",
+        "internalLoggerLevel",
+        "isolate",
+        "logArgsSerializer",
+        "metas",
+        "paused",
+        "preventGlobalExposure",
+        "unpatchedConsole",
+        "trackUserActionsPreview",
+        "trackUserActionsDataAttributeName",
+      ]);
+    return Object.assign(Object.assign({}, h), {
+      batching: Object.assign(Object.assign({}, Te), e.batching),
+      dedupe: r,
+      globalObjectKey: s,
+      instrumentations: jr(a, e),
+      internalLoggerLevel: u,
+      isolate: c,
+      logArgsSerializer: l,
+      metas: d,
+      parseStacktrace: Pt,
+      paused: f,
+      preventGlobalExposure: p,
+      transports: n,
+      unpatchedConsole: g,
+      eventDomain: o,
+      ignoreUrls: (null !== (t = e.ignoreUrls) && void 0 !== t ? t : []).concat(
+        [/\/collect(?:\/[\w]*)?$/]
+      ),
+      sessionTracking: Object.assign(
+        Object.assign(Object.assign({}, Ze), e.sessionTracking),
+        _r({
+          trackGeolocation: e.trackGeolocation,
+          sessionTracking: e.sessionTracking,
+        })
+      ),
+      trackUserActionsPreview: m,
+      trackUserActionsDataAttributeName: v,
+    });
+  }
+  function jr(e, { trackUserActionsPreview: t }) {
+    return e.filter(
+      (e) =>
+        !("@grafana/faro-web-sdk:instrumentation-user-action" === e.name && !t)
+    );
+  }
+  function Nr(e) {
+    var t, n;
+    const { page: i, generatePageId: r } =
+        null !== (t = null == e ? void 0 : e.pageTracking) && void 0 !== t
+          ? t
+          : {},
+      o = [
+        je,
+        Ar({ generatePageId: r, initialPageMeta: i }),
+        ...(null !== (n = e.metas) && void 0 !== n ? n : []),
+      ];
+    return u(window.k6) ? [...o, xr] : o;
+  }
+  function _r({ trackGeolocation: e, sessionTracking: t }) {
+    var n;
+    const i = {};
+    return (
+      a(e) && (i.geoLocationTrackingEnabled = e),
+      S(i)
+        ? {}
+        : {
+            session: Object.assign(
+              Object.assign(
+                {},
+                null !== (n = null == t ? void 0 : t.session) && void 0 !== n
+                  ? n
+                  : {}
+              ),
+              { overrides: i }
+            ),
+          }
+    );
+  }
+  return (
+    (e.BaseExtension = Z),
+    (e.BaseInstrumentation = ge),
+    (e.BaseTransport = Y),
+    (e.ConsoleInstrumentation = _t),
+    (e.ConsoleTransport = class extends Y {
+      constructor(e = {}) {
+        super(),
+          (this.options = e),
+          (this.name = "@grafana/faro-web-sdk:transport-console"),
+          (this.version = me);
+      }
+      send(t) {
+        var n;
+        return this.unpatchedConsole[
+          null !== (n = this.options.level) && void 0 !== n
+            ? n
+            : e.LogLevel.DEBUG
+        ]("New event", ee([t]));
+      }
+    }),
+    (e.Conventions = {
+      EventNames: {
+        CLICK: "click",
+        NAVIGATION: "navigation",
+        SESSION_START: "session_start",
+        VIEW_CHANGED: "view_changed",
+      },
+    }),
+    (e.EVENT_CLICK = "click"),
+    (e.EVENT_NAVIGATION = "navigation"),
+    (e.EVENT_ROUTE_CHANGE = "route_change"),
+    (e.EVENT_SESSION_EXTEND = Oe),
+    (e.EVENT_SESSION_RESUME = ke),
+    (e.EVENT_SESSION_START = Ie),
+    (e.EVENT_VIEW_CHANGED = Ee),
+    (e.ErrorsInstrumentation = Dt),
+    (e.FetchTransport = Pr),
+    (e.MAX_SESSION_PERSISTENCE_TIME = Je),
+    (e.MAX_SESSION_PERSISTENCE_TIME_BUFFER = 6e4),
+    (e.Observable = D),
+    (e.PerformanceInstrumentation = cr),
+    (e.PersistentSessionsManager = rt),
+    (e.SESSION_EXPIRATION_TIME = Ke),
+    (e.SESSION_INACTIVITY_TIME = Xe),
+    (e.STORAGE_KEY = We),
+    (e.SessionInstrumentation = at),
+    (e.USER_ACTION_CANCEL = ie),
+    (e.USER_ACTION_END = ne),
+    (e.USER_ACTION_START = te),
+    (e.UserActionInstrumentation = Ir),
+    (e.VERSION = me),
+    (e.ViewInstrumentation = Rt),
+    (e.VolatileSessionsManager = ot),
+    (e.WebVitalsInstrumentation = Zi),
+    (e.allLogLevels = L),
+    (e.apiMessageBus = fe),
+    (e.browserMeta = je),
+    (e.buildStackFrame = Lt),
+    (e.createInternalLogger = K),
+    (e.createPromiseBuffer = A),
+    (e.createSession = Ne),
+    (e.deepEqual = T),
+    (e.defaultEventDomain = Or),
+    (e.defaultExceptionType = oe),
+    (e.defaultGlobalObjectKey = Se),
+    (e.defaultInternalLoggerLevel = $),
+    (e.defaultLogLevel = x),
+    (e.genShortID = M),
+    (e.getCurrentTimestamp = I),
+    (e.getDataFromSafariExtensions = Ct),
+    (e.getIgnoreUrls = $e),
+    (e.getInternalFaroFromGlobalObject = function () {
+      return j[ve];
+    }),
+    (e.getStackFramesFromError = At),
+    (e.getTransportBody = ee),
+    (e.getUrlFromResource = He),
+    (e.getWebInstrumentations = kr),
+    (e.globalObject = j),
+    (e.initializeFaro = function (e) {
+      const t = Mr(e);
+      if (t) return ye(t);
+    }),
+    (e.internalGlobalObjectKey = ve),
+    (e.isArray = l),
+    (e.isBoolean = a),
+    (e.isDomError = h),
+    (e.isDomException = b),
+    (e.isElement = (e) => w && i(e, Element)),
+    (e.isElementDefined = w),
+    (e.isEmpty = S),
+    (e.isError = m),
+    (e.isErrorDefined = g),
+    (e.isErrorEvent = v),
+    (e.isEvent = p),
+    (e.isEventDefined = f),
+    (e.isFunction = c),
+    (e.isInstanceOf = i),
+    (e.isInt = (e) => s(e) && Number.isInteger(e)),
+    (e.isInternalFaroOnGlobalObject = be),
+    (e.isMap = (e) => y && i(e, Map)),
+    (e.isMapDefined = y),
+    (e.isNull = r),
+    (e.isNumber = s),
+    (e.isObject = u),
+    (e.isPrimitive = d),
+    (e.isRegExp = (e) => n(e, "RegExp")),
+    (e.isString = o),
+    (e.isSymbol = (e) => t(e, "symbol")),
+    (e.isSyntheticEvent = (e) =>
+      u(e) &&
+      "nativeEvent" in e &&
+      "preventDefault" in e &&
+      "stopPropagation" in e),
+    (e.isThenable = (e) => c(null == e ? void 0 : e.then)),
+    (e.isToString = n),
+    (e.isTypeof = t),
+    (e.isUndefined = (e) => t(e, "undefined")),
+    (e.makeCoreConfig = Mr),
+    (e.noop = C),
+    (e.parseStacktrace = Pt),
+    (e.sdkMeta = () => ({
+      sdk: {
+        name: "@grafana/faro-core",
+        version: me,
+        integrations: e.faro.config.instrumentations.map(
+          ({ name: e, version: t }) => ({ name: e, version: t })
+        ),
+      },
+    })),
+    (e.setInternalFaroOnGlobalObject = he),
+    (e.startUserAction = function (e, t) {
+      null == Er ||
+        Er(
+          (function (e, t) {
+            return { name: e, attributes: t, type: "apiEvent" };
+          })(e, t)
+        );
+    }),
+    (e.transportItemTypeToBodyKey = B),
+    (e.unknownString = Le),
+    (e.userActionDataAttribute = gr),
+    e
+  );
+})({});
+
+export default GrafanaFaroWebSdk;

--- a/export/grafana-faro-web-tracing.js
+++ b/export/grafana-faro-web-tracing.js
@@ -1,0 +1,4248 @@
+// vendored @grafana/faro-web-tracing v1.18.1 https://unpkg.com/@grafana/faro-web-tracing@1.18.1/dist/bundle/faro-web-tracing.iife.js
+
+var GrafanaFaroWebTracing = function (t, e) {
+  "use strict";
+  var n =
+      "object" == typeof globalThis
+        ? globalThis
+        : "object" == typeof self
+        ? self
+        : "object" == typeof window
+        ? window
+        : "object" == typeof global
+        ? global
+        : {},
+    r = "1.9.0",
+    o = /^(\d+)\.(\d+)\.(\d+)(-(.+))?$/;
+  var i = (function (t) {
+      var e = new Set([t]),
+        n = new Set(),
+        r = t.match(o);
+      if (!r)
+        return function () {
+          return !1;
+        };
+      var i = +r[1],
+        s = +r[2],
+        a = +r[3];
+      if (null != r[4])
+        return function (e) {
+          return e === t;
+        };
+      function u(t) {
+        return n.add(t), !1;
+      }
+      function c(t) {
+        return e.add(t), !0;
+      }
+      return function (t) {
+        if (e.has(t)) return !0;
+        if (n.has(t)) return !1;
+        var r = t.match(o);
+        if (!r) return u(t);
+        var l = +r[1],
+          p = +r[2],
+          d = +r[3];
+        return null != r[4] || i !== l
+          ? u(t)
+          : 0 === i
+          ? s === p && a <= d
+            ? c(t)
+            : u(t)
+          : s <= p
+          ? c(t)
+          : u(t);
+      };
+    })(r),
+    s = r.split(".")[0],
+    a = Symbol.for("opentelemetry.js.api." + s),
+    u = n;
+  function c(t, e, n, o) {
+    var i;
+    void 0 === o && (o = !1);
+    var s = (u[a] = null !== (i = u[a]) && void 0 !== i ? i : { version: r });
+    if (!o && s[t]) {
+      var c = new Error(
+        "@opentelemetry/api: Attempted duplicate registration of API: " + t
+      );
+      return n.error(c.stack || c.message), !1;
+    }
+    if (s.version !== r) {
+      c = new Error(
+        "@opentelemetry/api: Registration of version v" +
+          s.version +
+          " for " +
+          t +
+          " does not match previously registered API v" +
+          r
+      );
+      return n.error(c.stack || c.message), !1;
+    }
+    return (
+      (s[t] = e),
+      n.debug(
+        "@opentelemetry/api: Registered a global for " + t + " v" + r + "."
+      ),
+      !0
+    );
+  }
+  function l(t) {
+    var e,
+      n,
+      r = null === (e = u[a]) || void 0 === e ? void 0 : e.version;
+    if (r && i(r)) return null === (n = u[a]) || void 0 === n ? void 0 : n[t];
+  }
+  function p(t, e) {
+    e.debug(
+      "@opentelemetry/api: Unregistering a global for " + t + " v" + r + "."
+    );
+    var n = u[a];
+    n && delete n[t];
+  }
+  var d,
+    h = function (t, e) {
+      var n = "function" == typeof Symbol && t[Symbol.iterator];
+      if (!n) return t;
+      var r,
+        o,
+        i = n.call(t),
+        s = [];
+      try {
+        for (; (void 0 === e || e-- > 0) && !(r = i.next()).done; )
+          s.push(r.value);
+      } catch (t) {
+        o = { error: t };
+      } finally {
+        try {
+          r && !r.done && (n = i.return) && n.call(i);
+        } finally {
+          if (o) throw o.error;
+        }
+      }
+      return s;
+    },
+    f = function (t, e, n) {
+      if (n || 2 === arguments.length)
+        for (var r, o = 0, i = e.length; o < i; o++)
+          (!r && o in e) ||
+            (r || (r = Array.prototype.slice.call(e, 0, o)), (r[o] = e[o]));
+      return t.concat(r || Array.prototype.slice.call(e));
+    },
+    g = (function () {
+      function t(t) {
+        this._namespace = t.namespace || "DiagComponentLogger";
+      }
+      return (
+        (t.prototype.debug = function () {
+          for (var t = [], e = 0; e < arguments.length; e++)
+            t[e] = arguments[e];
+          return m("debug", this._namespace, t);
+        }),
+        (t.prototype.error = function () {
+          for (var t = [], e = 0; e < arguments.length; e++)
+            t[e] = arguments[e];
+          return m("error", this._namespace, t);
+        }),
+        (t.prototype.info = function () {
+          for (var t = [], e = 0; e < arguments.length; e++)
+            t[e] = arguments[e];
+          return m("info", this._namespace, t);
+        }),
+        (t.prototype.warn = function () {
+          for (var t = [], e = 0; e < arguments.length; e++)
+            t[e] = arguments[e];
+          return m("warn", this._namespace, t);
+        }),
+        (t.prototype.verbose = function () {
+          for (var t = [], e = 0; e < arguments.length; e++)
+            t[e] = arguments[e];
+          return m("verbose", this._namespace, t);
+        }),
+        t
+      );
+    })();
+  function m(t, e, n) {
+    var r = l("diag");
+    if (r) return n.unshift(e), r[t].apply(r, f([], h(n), !1));
+  }
+  !(function (t) {
+    (t[(t.NONE = 0)] = "NONE"),
+      (t[(t.ERROR = 30)] = "ERROR"),
+      (t[(t.WARN = 50)] = "WARN"),
+      (t[(t.INFO = 60)] = "INFO"),
+      (t[(t.DEBUG = 70)] = "DEBUG"),
+      (t[(t.VERBOSE = 80)] = "VERBOSE"),
+      (t[(t.ALL = 9999)] = "ALL");
+  })(d || (d = {}));
+  var _ = function (t, e) {
+      var n = "function" == typeof Symbol && t[Symbol.iterator];
+      if (!n) return t;
+      var r,
+        o,
+        i = n.call(t),
+        s = [];
+      try {
+        for (; (void 0 === e || e-- > 0) && !(r = i.next()).done; )
+          s.push(r.value);
+      } catch (t) {
+        o = { error: t };
+      } finally {
+        try {
+          r && !r.done && (n = i.return) && n.call(i);
+        } finally {
+          if (o) throw o.error;
+        }
+      }
+      return s;
+    },
+    v = function (t, e, n) {
+      if (n || 2 === arguments.length)
+        for (var r, o = 0, i = e.length; o < i; o++)
+          (!r && o in e) ||
+            (r || (r = Array.prototype.slice.call(e, 0, o)), (r[o] = e[o]));
+      return t.concat(r || Array.prototype.slice.call(e));
+    },
+    y = (function () {
+      function t() {
+        function t(t) {
+          return function () {
+            for (var e = [], n = 0; n < arguments.length; n++)
+              e[n] = arguments[n];
+            var r = l("diag");
+            if (r) return r[t].apply(r, v([], _(e), !1));
+          };
+        }
+        var e = this;
+        (e.setLogger = function (t, n) {
+          var r, o, i;
+          if ((void 0 === n && (n = { logLevel: d.INFO }), t === e)) {
+            var s = new Error(
+              "Cannot use diag as the logger for itself. Please use a DiagLogger implementation like ConsoleDiagLogger or a custom implementation"
+            );
+            return (
+              e.error(null !== (r = s.stack) && void 0 !== r ? r : s.message),
+              !1
+            );
+          }
+          "number" == typeof n && (n = { logLevel: n });
+          var a = l("diag"),
+            u = (function (t, e) {
+              function n(n, r) {
+                var o = e[n];
+                return "function" == typeof o && t >= r
+                  ? o.bind(e)
+                  : function () {};
+              }
+              return (
+                t < d.NONE ? (t = d.NONE) : t > d.ALL && (t = d.ALL),
+                (e = e || {}),
+                {
+                  error: n("error", d.ERROR),
+                  warn: n("warn", d.WARN),
+                  info: n("info", d.INFO),
+                  debug: n("debug", d.DEBUG),
+                  verbose: n("verbose", d.VERBOSE),
+                }
+              );
+            })(null !== (o = n.logLevel) && void 0 !== o ? o : d.INFO, t);
+          if (a && !n.suppressOverrideMessage) {
+            var p =
+              null !== (i = new Error().stack) && void 0 !== i
+                ? i
+                : "<failed to generate stacktrace>";
+            a.warn("Current logger will be overwritten from " + p),
+              u.warn(
+                "Current logger will overwrite one already registered from " + p
+              );
+          }
+          return c("diag", u, e, !0);
+        }),
+          (e.disable = function () {
+            p("diag", e);
+          }),
+          (e.createComponentLogger = function (t) {
+            return new g(t);
+          }),
+          (e.verbose = t("verbose")),
+          (e.debug = t("debug")),
+          (e.info = t("info")),
+          (e.warn = t("warn")),
+          (e.error = t("error"));
+      }
+      return (
+        (t.instance = function () {
+          return this._instance || (this._instance = new t()), this._instance;
+        }),
+        t
+      );
+    })(),
+    S = function (t, e) {
+      var n = "function" == typeof Symbol && t[Symbol.iterator];
+      if (!n) return t;
+      var r,
+        o,
+        i = n.call(t),
+        s = [];
+      try {
+        for (; (void 0 === e || e-- > 0) && !(r = i.next()).done; )
+          s.push(r.value);
+      } catch (t) {
+        o = { error: t };
+      } finally {
+        try {
+          r && !r.done && (n = i.return) && n.call(i);
+        } finally {
+          if (o) throw o.error;
+        }
+      }
+      return s;
+    },
+    b = function (t) {
+      var e = "function" == typeof Symbol && Symbol.iterator,
+        n = e && t[e],
+        r = 0;
+      if (n) return n.call(t);
+      if (t && "number" == typeof t.length)
+        return {
+          next: function () {
+            return (
+              t && r >= t.length && (t = void 0),
+              { value: t && t[r++], done: !t }
+            );
+          },
+        };
+      throw new TypeError(
+        e ? "Object is not iterable." : "Symbol.iterator is not defined."
+      );
+    },
+    E = (function () {
+      function t(t) {
+        this._entries = t ? new Map(t) : new Map();
+      }
+      return (
+        (t.prototype.getEntry = function (t) {
+          var e = this._entries.get(t);
+          if (e) return Object.assign({}, e);
+        }),
+        (t.prototype.getAllEntries = function () {
+          return Array.from(this._entries.entries()).map(function (t) {
+            var e = S(t, 2);
+            return [e[0], e[1]];
+          });
+        }),
+        (t.prototype.setEntry = function (e, n) {
+          var r = new t(this._entries);
+          return r._entries.set(e, n), r;
+        }),
+        (t.prototype.removeEntry = function (e) {
+          var n = new t(this._entries);
+          return n._entries.delete(e), n;
+        }),
+        (t.prototype.removeEntries = function () {
+          for (var e, n, r = [], o = 0; o < arguments.length; o++)
+            r[o] = arguments[o];
+          var i = new t(this._entries);
+          try {
+            for (var s = b(r), a = s.next(); !a.done; a = s.next()) {
+              var u = a.value;
+              i._entries.delete(u);
+            }
+          } catch (t) {
+            e = { error: t };
+          } finally {
+            try {
+              a && !a.done && (n = s.return) && n.call(s);
+            } finally {
+              if (e) throw e.error;
+            }
+          }
+          return i;
+        }),
+        (t.prototype.clear = function () {
+          return new t();
+        }),
+        t
+      );
+    })(),
+    T = Symbol("BaggageEntryMetadata"),
+    w = y.instance();
+  function C(t) {
+    return void 0 === t && (t = {}), new E(new Map(Object.entries(t)));
+  }
+  function A(t) {
+    return Symbol.for(t);
+  }
+  var O,
+    R,
+    N = function t(e) {
+      var n = this;
+      (n._currentContext = e ? new Map(e) : new Map()),
+        (n.getValue = function (t) {
+          return n._currentContext.get(t);
+        }),
+        (n.setValue = function (e, r) {
+          var o = new t(n._currentContext);
+          return o._currentContext.set(e, r), o;
+        }),
+        (n.deleteValue = function (e) {
+          var r = new t(n._currentContext);
+          return r._currentContext.delete(e), r;
+        });
+    },
+    x = new N(),
+    P =
+      ((O = function (t, e) {
+        return (
+          (O =
+            Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array &&
+              function (t, e) {
+                t.__proto__ = e;
+              }) ||
+            function (t, e) {
+              for (var n in e)
+                Object.prototype.hasOwnProperty.call(e, n) && (t[n] = e[n]);
+            }),
+          O(t, e)
+        );
+      }),
+      function (t, e) {
+        if ("function" != typeof e && null !== e)
+          throw new TypeError(
+            "Class extends value " + String(e) + " is not a constructor or null"
+          );
+        function n() {
+          this.constructor = t;
+        }
+        O(t, e),
+          (t.prototype =
+            null === e
+              ? Object.create(e)
+              : ((n.prototype = e.prototype), new n()));
+      }),
+    L = (function () {
+      function t() {}
+      return (
+        (t.prototype.createGauge = function (t, e) {
+          return z;
+        }),
+        (t.prototype.createHistogram = function (t, e) {
+          return q;
+        }),
+        (t.prototype.createCounter = function (t, e) {
+          return $;
+        }),
+        (t.prototype.createUpDownCounter = function (t, e) {
+          return G;
+        }),
+        (t.prototype.createObservableGauge = function (t, e) {
+          return W;
+        }),
+        (t.prototype.createObservableCounter = function (t, e) {
+          return K;
+        }),
+        (t.prototype.createObservableUpDownCounter = function (t, e) {
+          return X;
+        }),
+        (t.prototype.addBatchObservableCallback = function (t, e) {}),
+        (t.prototype.removeBatchObservableCallback = function (t) {}),
+        t
+      );
+    })(),
+    D = function () {},
+    I = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), (e.prototype.add = function (t, e) {}), e;
+    })(D),
+    M = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), (e.prototype.add = function (t, e) {}), e;
+    })(D),
+    k = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), (e.prototype.record = function (t, e) {}), e;
+    })(D),
+    j = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), (e.prototype.record = function (t, e) {}), e;
+    })(D),
+    U = (function () {
+      function t() {}
+      return (
+        (t.prototype.addCallback = function (t) {}),
+        (t.prototype.removeCallback = function (t) {}),
+        t
+      );
+    })(),
+    B = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), e;
+    })(U),
+    F = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), e;
+    })(U),
+    H = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), e;
+    })(U),
+    V = new L(),
+    $ = new I(),
+    z = new k(),
+    q = new j(),
+    G = new M(),
+    K = new B(),
+    W = new F(),
+    X = new H(),
+    Q = {
+      get: function (t, e) {
+        if (null != t) return t[e];
+      },
+      keys: function (t) {
+        return null == t ? [] : Object.keys(t);
+      },
+    },
+    Y = {
+      set: function (t, e, n) {
+        null != t && (t[e] = n);
+      },
+    },
+    Z = function (t, e) {
+      var n = "function" == typeof Symbol && t[Symbol.iterator];
+      if (!n) return t;
+      var r,
+        o,
+        i = n.call(t),
+        s = [];
+      try {
+        for (; (void 0 === e || e-- > 0) && !(r = i.next()).done; )
+          s.push(r.value);
+      } catch (t) {
+        o = { error: t };
+      } finally {
+        try {
+          r && !r.done && (n = i.return) && n.call(i);
+        } finally {
+          if (o) throw o.error;
+        }
+      }
+      return s;
+    },
+    J = function (t, e, n) {
+      if (n || 2 === arguments.length)
+        for (var r, o = 0, i = e.length; o < i; o++)
+          (!r && o in e) ||
+            (r || (r = Array.prototype.slice.call(e, 0, o)), (r[o] = e[o]));
+      return t.concat(r || Array.prototype.slice.call(e));
+    },
+    tt = (function () {
+      function t() {}
+      return (
+        (t.prototype.active = function () {
+          return x;
+        }),
+        (t.prototype.with = function (t, e, n) {
+          for (var r = [], o = 3; o < arguments.length; o++)
+            r[o - 3] = arguments[o];
+          return e.call.apply(e, J([n], Z(r), !1));
+        }),
+        (t.prototype.bind = function (t, e) {
+          return e;
+        }),
+        (t.prototype.enable = function () {
+          return this;
+        }),
+        (t.prototype.disable = function () {
+          return this;
+        }),
+        t
+      );
+    })(),
+    et = function (t, e) {
+      var n = "function" == typeof Symbol && t[Symbol.iterator];
+      if (!n) return t;
+      var r,
+        o,
+        i = n.call(t),
+        s = [];
+      try {
+        for (; (void 0 === e || e-- > 0) && !(r = i.next()).done; )
+          s.push(r.value);
+      } catch (t) {
+        o = { error: t };
+      } finally {
+        try {
+          r && !r.done && (n = i.return) && n.call(i);
+        } finally {
+          if (o) throw o.error;
+        }
+      }
+      return s;
+    },
+    nt = function (t, e, n) {
+      if (n || 2 === arguments.length)
+        for (var r, o = 0, i = e.length; o < i; o++)
+          (!r && o in e) ||
+            (r || (r = Array.prototype.slice.call(e, 0, o)), (r[o] = e[o]));
+      return t.concat(r || Array.prototype.slice.call(e));
+    },
+    rt = "context",
+    ot = new tt(),
+    it = (function () {
+      function t() {}
+      return (
+        (t.getInstance = function () {
+          return this._instance || (this._instance = new t()), this._instance;
+        }),
+        (t.prototype.setGlobalContextManager = function (t) {
+          return c(rt, t, y.instance());
+        }),
+        (t.prototype.active = function () {
+          return this._getContextManager().active();
+        }),
+        (t.prototype.with = function (t, e, n) {
+          for (var r, o = [], i = 3; i < arguments.length; i++)
+            o[i - 3] = arguments[i];
+          return (r = this._getContextManager()).with.apply(
+            r,
+            nt([t, e, n], et(o), !1)
+          );
+        }),
+        (t.prototype.bind = function (t, e) {
+          return this._getContextManager().bind(t, e);
+        }),
+        (t.prototype._getContextManager = function () {
+          return l(rt) || ot;
+        }),
+        (t.prototype.disable = function () {
+          this._getContextManager().disable(), p(rt, y.instance());
+        }),
+        t
+      );
+    })();
+  !(function (t) {
+    (t[(t.NONE = 0)] = "NONE"), (t[(t.SAMPLED = 1)] = "SAMPLED");
+  })(R || (R = {}));
+  var st = "0000000000000000",
+    at = "00000000000000000000000000000000",
+    ut = { traceId: at, spanId: st, traceFlags: R.NONE },
+    ct = (function () {
+      function t(t) {
+        void 0 === t && (t = ut), (this._spanContext = t);
+      }
+      return (
+        (t.prototype.spanContext = function () {
+          return this._spanContext;
+        }),
+        (t.prototype.setAttribute = function (t, e) {
+          return this;
+        }),
+        (t.prototype.setAttributes = function (t) {
+          return this;
+        }),
+        (t.prototype.addEvent = function (t, e) {
+          return this;
+        }),
+        (t.prototype.addLink = function (t) {
+          return this;
+        }),
+        (t.prototype.addLinks = function (t) {
+          return this;
+        }),
+        (t.prototype.setStatus = function (t) {
+          return this;
+        }),
+        (t.prototype.updateName = function (t) {
+          return this;
+        }),
+        (t.prototype.end = function (t) {}),
+        (t.prototype.isRecording = function () {
+          return !1;
+        }),
+        (t.prototype.recordException = function (t, e) {}),
+        t
+      );
+    })(),
+    lt = A("OpenTelemetry Context Key SPAN");
+  function pt(t) {
+    return t.getValue(lt) || void 0;
+  }
+  function dt() {
+    return pt(it.getInstance().active());
+  }
+  function ht(t, e) {
+    return t.setValue(lt, e);
+  }
+  function ft(t) {
+    return t.deleteValue(lt);
+  }
+  function gt(t, e) {
+    return ht(t, new ct(e));
+  }
+  function mt(t) {
+    var e;
+    return null === (e = pt(t)) || void 0 === e ? void 0 : e.spanContext();
+  }
+  var _t = /^([0-9a-f]{32})$/i,
+    vt = /^[0-9a-f]{16}$/i;
+  function yt(t) {
+    return _t.test(t) && t !== at;
+  }
+  function St(t) {
+    return yt(t.traceId) && ((e = t.spanId), vt.test(e) && e !== st);
+    var e;
+  }
+  function bt(t) {
+    return new ct(t);
+  }
+  var Et = it.getInstance(),
+    Tt = (function () {
+      function t() {}
+      return (
+        (t.prototype.startSpan = function (t, e, n) {
+          if (
+            (void 0 === n && (n = Et.active()),
+            Boolean(null == e ? void 0 : e.root))
+          )
+            return new ct();
+          var r,
+            o = n && mt(n);
+          return "object" == typeof (r = o) &&
+            "string" == typeof r.spanId &&
+            "string" == typeof r.traceId &&
+            "number" == typeof r.traceFlags &&
+            St(o)
+            ? new ct(o)
+            : new ct();
+        }),
+        (t.prototype.startActiveSpan = function (t, e, n, r) {
+          var o, i, s;
+          if (!(arguments.length < 2)) {
+            2 === arguments.length
+              ? (s = e)
+              : 3 === arguments.length
+              ? ((o = e), (s = n))
+              : ((o = e), (i = n), (s = r));
+            var a = null != i ? i : Et.active(),
+              u = this.startSpan(t, o, a),
+              c = ht(a, u);
+            return Et.with(c, s, void 0, u);
+          }
+        }),
+        t
+      );
+    })();
+  var wt,
+    Ct,
+    At,
+    Ot = new Tt(),
+    Rt = (function () {
+      function t(t, e, n, r) {
+        (this._provider = t),
+          (this.name = e),
+          (this.version = n),
+          (this.options = r);
+      }
+      return (
+        (t.prototype.startSpan = function (t, e, n) {
+          return this._getTracer().startSpan(t, e, n);
+        }),
+        (t.prototype.startActiveSpan = function (t, e, n, r) {
+          var o = this._getTracer();
+          return Reflect.apply(o.startActiveSpan, o, arguments);
+        }),
+        (t.prototype._getTracer = function () {
+          if (this._delegate) return this._delegate;
+          var t = this._provider.getDelegateTracer(
+            this.name,
+            this.version,
+            this.options
+          );
+          return t ? ((this._delegate = t), this._delegate) : Ot;
+        }),
+        t
+      );
+    })(),
+    Nt = new ((function () {
+      function t() {}
+      return (
+        (t.prototype.getTracer = function (t, e, n) {
+          return new Tt();
+        }),
+        t
+      );
+    })())(),
+    xt = (function () {
+      function t() {}
+      return (
+        (t.prototype.getTracer = function (t, e, n) {
+          var r;
+          return null !== (r = this.getDelegateTracer(t, e, n)) && void 0 !== r
+            ? r
+            : new Rt(this, t, e, n);
+        }),
+        (t.prototype.getDelegate = function () {
+          var t;
+          return null !== (t = this._delegate) && void 0 !== t ? t : Nt;
+        }),
+        (t.prototype.setDelegate = function (t) {
+          this._delegate = t;
+        }),
+        (t.prototype.getDelegateTracer = function (t, e, n) {
+          var r;
+          return null === (r = this._delegate) || void 0 === r
+            ? void 0
+            : r.getTracer(t, e, n);
+        }),
+        t
+      );
+    })();
+  !(function (t) {
+    (t[(t.NOT_RECORD = 0)] = "NOT_RECORD"),
+      (t[(t.RECORD = 1)] = "RECORD"),
+      (t[(t.RECORD_AND_SAMPLED = 2)] = "RECORD_AND_SAMPLED");
+  })(wt || (wt = {})),
+    (function (t) {
+      (t[(t.INTERNAL = 0)] = "INTERNAL"),
+        (t[(t.SERVER = 1)] = "SERVER"),
+        (t[(t.CLIENT = 2)] = "CLIENT"),
+        (t[(t.PRODUCER = 3)] = "PRODUCER"),
+        (t[(t.CONSUMER = 4)] = "CONSUMER");
+    })(Ct || (Ct = {})),
+    (function (t) {
+      (t[(t.UNSET = 0)] = "UNSET"),
+        (t[(t.OK = 1)] = "OK"),
+        (t[(t.ERROR = 2)] = "ERROR");
+    })(At || (At = {}));
+  var Pt = it.getInstance(),
+    Lt = y.instance(),
+    Dt = new ((function () {
+      function t() {}
+      return (
+        (t.prototype.getMeter = function (t, e, n) {
+          return V;
+        }),
+        t
+      );
+    })())(),
+    It = "metrics",
+    Mt = (function () {
+      function t() {}
+      return (
+        (t.getInstance = function () {
+          return this._instance || (this._instance = new t()), this._instance;
+        }),
+        (t.prototype.setGlobalMeterProvider = function (t) {
+          return c(It, t, y.instance());
+        }),
+        (t.prototype.getMeterProvider = function () {
+          return l(It) || Dt;
+        }),
+        (t.prototype.getMeter = function (t, e, n) {
+          return this.getMeterProvider().getMeter(t, e, n);
+        }),
+        (t.prototype.disable = function () {
+          p(It, y.instance());
+        }),
+        t
+      );
+    })().getInstance(),
+    kt = (function () {
+      function t() {}
+      return (
+        (t.prototype.inject = function (t, e) {}),
+        (t.prototype.extract = function (t, e) {
+          return t;
+        }),
+        (t.prototype.fields = function () {
+          return [];
+        }),
+        t
+      );
+    })(),
+    jt = A("OpenTelemetry Baggage Key");
+  function Ut(t) {
+    return t.getValue(jt) || void 0;
+  }
+  function Bt() {
+    return Ut(it.getInstance().active());
+  }
+  function Ft(t, e) {
+    return t.setValue(jt, e);
+  }
+  function Ht(t) {
+    return t.deleteValue(jt);
+  }
+  var Vt = "propagation",
+    $t = new kt(),
+    zt = (function () {
+      function t() {
+        (this.createBaggage = C),
+          (this.getBaggage = Ut),
+          (this.getActiveBaggage = Bt),
+          (this.setBaggage = Ft),
+          (this.deleteBaggage = Ht);
+      }
+      return (
+        (t.getInstance = function () {
+          return this._instance || (this._instance = new t()), this._instance;
+        }),
+        (t.prototype.setGlobalPropagator = function (t) {
+          return c(Vt, t, y.instance());
+        }),
+        (t.prototype.inject = function (t, e, n) {
+          return (
+            void 0 === n && (n = Y), this._getGlobalPropagator().inject(t, e, n)
+          );
+        }),
+        (t.prototype.extract = function (t, e, n) {
+          return (
+            void 0 === n && (n = Q),
+            this._getGlobalPropagator().extract(t, e, n)
+          );
+        }),
+        (t.prototype.fields = function () {
+          return this._getGlobalPropagator().fields();
+        }),
+        (t.prototype.disable = function () {
+          p(Vt, y.instance());
+        }),
+        (t.prototype._getGlobalPropagator = function () {
+          return l(Vt) || $t;
+        }),
+        t
+      );
+    })(),
+    qt = zt.getInstance(),
+    Gt = "trace",
+    Kt = (function () {
+      function t() {
+        (this._proxyTracerProvider = new xt()),
+          (this.wrapSpanContext = bt),
+          (this.isSpanContextValid = St),
+          (this.deleteSpan = ft),
+          (this.getSpan = pt),
+          (this.getActiveSpan = dt),
+          (this.getSpanContext = mt),
+          (this.setSpan = ht),
+          (this.setSpanContext = gt);
+      }
+      return (
+        (t.getInstance = function () {
+          return this._instance || (this._instance = new t()), this._instance;
+        }),
+        (t.prototype.setGlobalTracerProvider = function (t) {
+          var e = c(Gt, this._proxyTracerProvider, y.instance());
+          return e && this._proxyTracerProvider.setDelegate(t), e;
+        }),
+        (t.prototype.getTracerProvider = function () {
+          return l(Gt) || this._proxyTracerProvider;
+        }),
+        (t.prototype.getTracer = function (t, e) {
+          return this.getTracerProvider().getTracer(t, e);
+        }),
+        (t.prototype.disable = function () {
+          p(Gt, y.instance()), (this._proxyTracerProvider = new xt());
+        }),
+        t
+      );
+    })().getInstance();
+  const Wt = A("OpenTelemetry SDK Context Key SUPPRESS_TRACING");
+  function Xt(t) {
+    return t.setValue(Wt, !0);
+  }
+  function Qt(t) {
+    return !0 === t.getValue(Wt);
+  }
+  const Yt = "=",
+    Zt = ";",
+    Jt = ",",
+    te = "baggage";
+  function ee(t) {
+    const e = t.split(Zt);
+    if (e.length <= 0) return;
+    const n = e.shift();
+    if (!n) return;
+    const r = n.indexOf(Yt);
+    if (r <= 0) return;
+    const o = decodeURIComponent(n.substring(0, r).trim()),
+      i = decodeURIComponent(n.substring(r + 1).trim());
+    let s;
+    var a;
+    return (
+      e.length > 0 &&
+        ("string" != typeof (a = e.join(Zt)) &&
+          (w.error(
+            "Cannot create baggage metadata from unknown type: " + typeof a
+          ),
+          (a = "")),
+        (s = {
+          __TYPE__: T,
+          toString: function () {
+            return a;
+          },
+        })),
+      { key: o, value: i, metadata: s }
+    );
+  }
+  class ne {
+    inject(t, e, n) {
+      const r = qt.getBaggage(t);
+      if (!r || Qt(t)) return;
+      const o = (function (t) {
+          return t.getAllEntries().map(([t, e]) => {
+            let n = `${encodeURIComponent(t)}=${encodeURIComponent(e.value)}`;
+            return (
+              void 0 !== e.metadata && (n += Zt + e.metadata.toString()), n
+            );
+          });
+        })(r)
+          .filter((t) => t.length <= 4096)
+          .slice(0, 180),
+        i = (function (t) {
+          return t.reduce((t, e) => {
+            const n = `${t}${"" !== t ? Jt : ""}${e}`;
+            return n.length > 8192 ? t : n;
+          }, "");
+        })(o);
+      i.length > 0 && n.set(e, te, i);
+    }
+    extract(t, e, n) {
+      const r = n.get(e, te),
+        o = Array.isArray(r) ? r.join(Jt) : r;
+      if (!o) return t;
+      const i = {};
+      if (0 === o.length) return t;
+      return (
+        o.split(Jt).forEach((t) => {
+          const e = ee(t);
+          if (e) {
+            const t = { value: e.value };
+            e.metadata && (t.metadata = e.metadata), (i[e.key] = t);
+          }
+        }),
+        0 === Object.entries(i).length
+          ? t
+          : qt.setBaggage(t, qt.createBaggage(i))
+      );
+    }
+    fields() {
+      return [te];
+    }
+  }
+  function re(t) {
+    const e = {};
+    if ("object" != typeof t || null == t) return e;
+    for (const [n, r] of Object.entries(t))
+      oe(n)
+        ? ie(r)
+          ? Array.isArray(r)
+            ? (e[n] = r.slice())
+            : (e[n] = r)
+          : Lt.warn(`Invalid attribute value set for key: ${n}`)
+        : Lt.warn(`Invalid attribute key: ${n}`);
+    return e;
+  }
+  function oe(t) {
+    return "string" == typeof t && t.length > 0;
+  }
+  function ie(t) {
+    return (
+      null == t ||
+      (Array.isArray(t)
+        ? (function (t) {
+            let e;
+            for (const n of t)
+              if (null != n) {
+                if (!e) {
+                  if (se(n)) {
+                    e = typeof n;
+                    continue;
+                  }
+                  return !1;
+                }
+                if (typeof n !== e) return !1;
+              }
+            return !0;
+          })(t)
+        : se(t))
+    );
+  }
+  function se(t) {
+    switch (typeof t) {
+      case "number":
+      case "boolean":
+      case "string":
+        return !0;
+    }
+    return !1;
+  }
+  function ae() {
+    return (t) => {
+      Lt.error(
+        (function (t) {
+          return "string" == typeof t
+            ? t
+            : JSON.stringify(
+                (function (t) {
+                  const e = {};
+                  let n = t;
+                  for (; null !== n; )
+                    Object.getOwnPropertyNames(n).forEach((t) => {
+                      if (e[t]) return;
+                      const r = n[t];
+                      r && (e[t] = String(r));
+                    }),
+                      (n = Object.getPrototypeOf(n));
+                  return e;
+                })(t)
+              );
+        })(t)
+      );
+    };
+  }
+  let ue = ae();
+  function ce(t) {
+    try {
+      ue(t);
+    } catch {}
+  }
+  function le(t) {}
+  const pe =
+      "object" == typeof globalThis
+        ? globalThis
+        : "object" == typeof self
+        ? self
+        : "object" == typeof window
+        ? window
+        : "object" == typeof global
+        ? global
+        : {},
+    de = performance,
+    he = "exception.type",
+    fe = "exception.message",
+    ge = "http.method",
+    me = "http.url",
+    _e = "http.host",
+    ve = "http.scheme",
+    ye = "http.status_code",
+    Se = "http.user_agent",
+    be = "http.request_content_length_uncompressed",
+    Ee = "process.runtime.name",
+    Te = "telemetry.sdk.name",
+    we = "telemetry.sdk.language",
+    Ce = "telemetry.sdk.version",
+    Ae = "service.name",
+    Oe = "telemetry.sdk.language",
+    Re = "telemetry.sdk.name",
+    Ne = "telemetry.sdk.version",
+    xe = {
+      [Te]: "opentelemetry",
+      [Ee]: "browser",
+      [we]: "webjs",
+      [Ce]: "2.0.0",
+    };
+  function Pe(t) {}
+  const Le = Math.pow(10, 6),
+    De = Math.pow(10, 9);
+  function Ie(t) {
+    const e = t / 1e3;
+    return [Math.trunc(e), Math.round((t % 1e3) * Le)];
+  }
+  function Me() {
+    let t = de.timeOrigin;
+    if ("number" != typeof t) {
+      const e = de;
+      t = e.timing && e.timing.fetchStart;
+    }
+    return t;
+  }
+  function ke(t) {
+    return Ve(Ie(Me()), Ie("number" == typeof t ? t : de.now()));
+  }
+  function je(t) {
+    if (Fe(t)) return t;
+    if ("number" == typeof t) return t < Me() ? ke(t) : Ie(t);
+    if (t instanceof Date) return Ie(t.getTime());
+    throw TypeError("Invalid input type");
+  }
+  function Ue(t, e) {
+    let n = e[0] - t[0],
+      r = e[1] - t[1];
+    return r < 0 && ((n -= 1), (r += De)), [n, r];
+  }
+  function Be(t) {
+    return t[0] * De + t[1];
+  }
+  function Fe(t) {
+    return (
+      Array.isArray(t) &&
+      2 === t.length &&
+      "number" == typeof t[0] &&
+      "number" == typeof t[1]
+    );
+  }
+  function He(t) {
+    return Fe(t) || "number" == typeof t || t instanceof Date;
+  }
+  function Ve(t, e) {
+    const n = [t[0] + e[0], t[1] + e[1]];
+    return n[1] >= De && ((n[1] -= De), (n[0] += 1)), n;
+  }
+  var $e;
+  !(function (t) {
+    (t[(t.SUCCESS = 0)] = "SUCCESS"), (t[(t.FAILED = 1)] = "FAILED");
+  })($e || ($e = {}));
+  class ze {
+    _propagators;
+    _fields;
+    constructor(t = {}) {
+      (this._propagators = t.propagators ?? []),
+        (this._fields = Array.from(
+          new Set(
+            this._propagators
+              .map((t) => ("function" == typeof t.fields ? t.fields() : []))
+              .reduce((t, e) => t.concat(e), [])
+          )
+        ));
+    }
+    inject(t, e, n) {
+      for (const r of this._propagators)
+        try {
+          r.inject(t, e, n);
+        } catch (t) {
+          Lt.warn(
+            `Failed to inject with ${r.constructor.name}. Err: ${t.message}`
+          );
+        }
+    }
+    extract(t, e, n) {
+      return this._propagators.reduce((t, r) => {
+        try {
+          return r.extract(t, e, n);
+        } catch (t) {
+          Lt.warn(
+            `Failed to extract with ${r.constructor.name}. Err: ${t.message}`
+          );
+        }
+        return t;
+      }, t);
+    }
+    fields() {
+      return this._fields.slice();
+    }
+  }
+  const qe = "[_0-9a-z-*/]",
+    Ge = new RegExp(
+      `^(?:${`[a-z]${qe}{0,255}`}|${`[a-z0-9]${qe}{0,240}@[a-z]${qe}{0,13}`})$`
+    ),
+    Ke = /^[ -~]{0,255}[!-~]$/,
+    We = /,|=/;
+  class Xe {
+    _internalState = new Map();
+    constructor(t) {
+      t && this._parse(t);
+    }
+    set(t, e) {
+      const n = this._clone();
+      return (
+        n._internalState.has(t) && n._internalState.delete(t),
+        n._internalState.set(t, e),
+        n
+      );
+    }
+    unset(t) {
+      const e = this._clone();
+      return e._internalState.delete(t), e;
+    }
+    get(t) {
+      return this._internalState.get(t);
+    }
+    serialize() {
+      return this._keys()
+        .reduce((t, e) => (t.push(e + "=" + this.get(e)), t), [])
+        .join(",");
+    }
+    _parse(t) {
+      t.length > 512 ||
+        ((this._internalState = t
+          .split(",")
+          .reverse()
+          .reduce((t, e) => {
+            const n = e.trim(),
+              r = n.indexOf("=");
+            if (-1 !== r) {
+              const o = n.slice(0, r),
+                i = n.slice(r + 1, e.length);
+              (function (t) {
+                return Ge.test(t);
+              })(o) &&
+                (function (t) {
+                  return Ke.test(t) && !We.test(t);
+                })(i) &&
+                t.set(o, i);
+            }
+            return t;
+          }, new Map())),
+        this._internalState.size > 32 &&
+          (this._internalState = new Map(
+            Array.from(this._internalState.entries()).reverse().slice(0, 32)
+          )));
+    }
+    _keys() {
+      return Array.from(this._internalState.keys()).reverse();
+    }
+    _clone() {
+      const t = new Xe();
+      return (t._internalState = new Map(this._internalState)), t;
+    }
+  }
+  const Qe = "traceparent",
+    Ye = "tracestate",
+    Ze = new RegExp(
+      "^\\s?((?!ff)[\\da-f]{2})-((?![0]{32})[\\da-f]{32})-((?![0]{16})[\\da-f]{16})-([\\da-f]{2})(-.*)?\\s?$"
+    );
+  function Je(t) {
+    const e = Ze.exec(t);
+    return e
+      ? "00" === e[1] && e[5]
+        ? null
+        : { traceId: e[2], spanId: e[3], traceFlags: parseInt(e[4], 16) }
+      : null;
+  }
+  class tn {
+    inject(t, e, n) {
+      const r = Kt.getSpanContext(t);
+      if (!r || Qt(t) || !St(r)) return;
+      const o = `00-${r.traceId}-${r.spanId}-0${Number(
+        r.traceFlags || R.NONE
+      ).toString(16)}`;
+      n.set(e, Qe, o), r.traceState && n.set(e, Ye, r.traceState.serialize());
+    }
+    extract(t, e, n) {
+      const r = n.get(e, Qe);
+      if (!r) return t;
+      const o = Array.isArray(r) ? r[0] : r;
+      if ("string" != typeof o) return t;
+      const i = Je(o);
+      if (!i) return t;
+      i.isRemote = !0;
+      const s = n.get(e, Ye);
+      if (s) {
+        const t = Array.isArray(s) ? s.join(",") : s;
+        i.traceState = new Xe("string" == typeof t ? t : void 0);
+      }
+      return Kt.setSpanContext(t, i);
+    }
+    fields() {
+      return [Qe, Ye];
+    }
+  }
+  const en = A("OpenTelemetry SDK Context Key RPC_METADATA");
+  var nn;
+  !(function (t) {
+    t.HTTP = "http";
+  })(nn || (nn = {}));
+  const rn = "[object Object]",
+    on = "[object Null]",
+    sn = "[object Undefined]",
+    an = Function.prototype.toString,
+    un = an.call(Object),
+    cn = Object.getPrototypeOf,
+    ln = Object.prototype,
+    pn = ln.hasOwnProperty,
+    dn = Symbol ? Symbol.toStringTag : void 0,
+    hn = ln.toString;
+  function fn(t) {
+    if (
+      !(function (t) {
+        return null != t && "object" == typeof t;
+      })(t) ||
+      (function (t) {
+        if (null == t) return void 0 === t ? sn : on;
+        return dn && dn in Object(t)
+          ? (function (t) {
+              const e = pn.call(t, dn),
+                n = t[dn];
+              let r = !1;
+              try {
+                (t[dn] = void 0), (r = !0);
+              } catch (t) {}
+              const o = hn.call(t);
+              r && (e ? (t[dn] = n) : delete t[dn]);
+              return o;
+            })(t)
+          : (function (t) {
+              return hn.call(t);
+            })(t);
+      })(t) !== rn
+    )
+      return !1;
+    const e = cn(t);
+    if (null === e) return !0;
+    const n = pn.call(e, "constructor") && e.constructor;
+    return "function" == typeof n && n instanceof n && an.call(n) === un;
+  }
+  const gn = 20;
+  function mn(...t) {
+    let e = t.shift();
+    const n = new WeakMap();
+    for (; t.length > 0; ) e = vn(e, t.shift(), 0, n);
+    return e;
+  }
+  function _n(t) {
+    return Sn(t) ? t.slice() : t;
+  }
+  function vn(t, e, n = 0, r) {
+    let o;
+    if (!(n > gn)) {
+      if ((n++, Tn(t) || Tn(e) || bn(e))) o = _n(e);
+      else if (Sn(t)) {
+        if (((o = t.slice()), Sn(e)))
+          for (let t = 0, n = e.length; t < n; t++) o.push(_n(e[t]));
+        else if (En(e)) {
+          const t = Object.keys(e);
+          for (let n = 0, r = t.length; n < r; n++) {
+            const r = t[n];
+            o[r] = _n(e[r]);
+          }
+        }
+      } else if (En(t))
+        if (En(e)) {
+          if (
+            !(function (t, e) {
+              if (!fn(t) || !fn(e)) return !1;
+              return !0;
+            })(t, e)
+          )
+            return e;
+          o = Object.assign({}, t);
+          const i = Object.keys(e);
+          for (let s = 0, a = i.length; s < a; s++) {
+            const a = i[s],
+              u = e[a];
+            if (Tn(u)) void 0 === u ? delete o[a] : (o[a] = u);
+            else {
+              const i = o[a],
+                s = u;
+              if (yn(t, a, r) || yn(e, a, r)) delete o[a];
+              else {
+                if (En(i) && En(s)) {
+                  const n = r.get(i) || [],
+                    o = r.get(s) || [];
+                  n.push({ obj: t, key: a }),
+                    o.push({ obj: e, key: a }),
+                    r.set(i, n),
+                    r.set(s, o);
+                }
+                o[a] = vn(o[a], u, n, r);
+              }
+            }
+          }
+        } else o = e;
+      return o;
+    }
+  }
+  function yn(t, e, n) {
+    const r = n.get(t[e]) || [];
+    for (let n = 0, o = r.length; n < o; n++) {
+      const o = r[n];
+      if (o.key === e && o.obj === t) return !0;
+    }
+    return !1;
+  }
+  function Sn(t) {
+    return Array.isArray(t);
+  }
+  function bn(t) {
+    return "function" == typeof t;
+  }
+  function En(t) {
+    return !Tn(t) && !Sn(t) && !bn(t) && "object" == typeof t;
+  }
+  function Tn(t) {
+    return (
+      "string" == typeof t ||
+      "number" == typeof t ||
+      "boolean" == typeof t ||
+      void 0 === t ||
+      t instanceof Date ||
+      t instanceof RegExp ||
+      null === t
+    );
+  }
+  class wn extends Error {
+    constructor(t) {
+      super(t), Object.setPrototypeOf(this, wn.prototype);
+    }
+  }
+  function Cn(t, e) {
+    return "string" == typeof e ? t === e : !!t.match(e);
+  }
+  function An(t, e) {
+    if (!e) return !1;
+    for (const n of e) if (Cn(t, n)) return !0;
+    return !1;
+  }
+  class On {
+    _promise;
+    _resolve;
+    _reject;
+    constructor() {
+      this._promise = new Promise((t, e) => {
+        (this._resolve = t), (this._reject = e);
+      });
+    }
+    get promise() {
+      return this._promise;
+    }
+    resolve(t) {
+      this._resolve(t);
+    }
+    reject(t) {
+      this._reject(t);
+    }
+  }
+  class Rn {
+    _callback;
+    _that;
+    _isCalled = !1;
+    _deferred = new On();
+    constructor(t, e) {
+      (this._callback = t), (this._that = e);
+    }
+    get isCalled() {
+      return this._isCalled;
+    }
+    get promise() {
+      return this._deferred.promise;
+    }
+    call(...t) {
+      if (!this._isCalled) {
+        this._isCalled = !0;
+        try {
+          Promise.resolve(this._callback.call(this._that, ...t)).then(
+            (t) => this._deferred.resolve(t),
+            (t) => this._deferred.reject(t)
+          );
+        } catch (t) {
+          this._deferred.reject(t);
+        }
+      }
+      return this._deferred.promise;
+    }
+  }
+  const Nn = {
+    ALL: d.ALL,
+    VERBOSE: d.VERBOSE,
+    DEBUG: d.DEBUG,
+    INFO: d.INFO,
+    WARN: d.WARN,
+    ERROR: d.ERROR,
+    NONE: d.NONE,
+  };
+  const xn = {
+    _export: function (t, e) {
+      return new Promise((n) => {
+        Pt.with(Xt(Pt.active()), () => {
+          t.export(e, (t) => {
+            n(t);
+          });
+        });
+      });
+    },
+  };
+  var Pn = Object.freeze({
+    __proto__: null,
+    AnchoredClock: class {
+      _monotonicClock;
+      _epochMillis;
+      _performanceMillis;
+      constructor(t, e) {
+        (this._monotonicClock = e),
+          (this._epochMillis = t.now()),
+          (this._performanceMillis = e.now());
+      }
+      now() {
+        const t = this._monotonicClock.now() - this._performanceMillis;
+        return this._epochMillis + t;
+      }
+    },
+    BindOnceFuture: Rn,
+    CompositePropagator: ze,
+    get ExportResultCode() {
+      return $e;
+    },
+    get RPCType() {
+      return nn;
+    },
+    SDK_INFO: xe,
+    TRACE_PARENT_HEADER: Qe,
+    TRACE_STATE_HEADER: Ye,
+    TimeoutError: wn,
+    TraceState: Xe,
+    W3CBaggagePropagator: ne,
+    W3CTraceContextPropagator: tn,
+    _globalThis: pe,
+    addHrTimes: Ve,
+    callWithTimeout: function (t, e) {
+      let n;
+      const r = new Promise(function (t, r) {
+        n = setTimeout(function () {
+          r(new wn("Operation timed out."));
+        }, e);
+      });
+      return Promise.race([t, r]).then(
+        (t) => (clearTimeout(n), t),
+        (t) => {
+          throw (clearTimeout(n), t);
+        }
+      );
+    },
+    deleteRPCMetadata: function (t) {
+      return t.deleteValue(en);
+    },
+    diagLogLevelFromString: function (t) {
+      if (null == t) return;
+      const e = Nn[t.toUpperCase()];
+      return null == e
+        ? (Lt.warn(
+            `Unknown log level "${t}", expected one of ${Object.keys(
+              Nn
+            )}, using default`
+          ),
+          d.INFO)
+        : e;
+    },
+    getBooleanFromEnv: function (t) {},
+    getNumberFromEnv: le,
+    getRPCMetadata: function (t) {
+      return t.getValue(en);
+    },
+    getStringFromEnv: function (t) {},
+    getStringListFromEnv: function (t) {},
+    getTimeOrigin: Me,
+    globalErrorHandler: ce,
+    hrTime: ke,
+    hrTimeDuration: Ue,
+    hrTimeToMicroseconds: function (t) {
+      return 1e6 * t[0] + t[1] / 1e3;
+    },
+    hrTimeToMilliseconds: function (t) {
+      return 1e3 * t[0] + t[1] / 1e6;
+    },
+    hrTimeToNanoseconds: Be,
+    hrTimeToTimeStamp: function (t) {
+      const e = `${"0".repeat(9)}${t[1]}Z`,
+        n = e.substring(e.length - 9 - 1);
+      return new Date(1e3 * t[0]).toISOString().replace("000Z", n);
+    },
+    internal: xn,
+    isAttributeValue: ie,
+    isTimeInput: He,
+    isTimeInputHrTime: Fe,
+    isTracingSuppressed: Qt,
+    isUrlIgnored: An,
+    loggingErrorHandler: ae,
+    merge: mn,
+    millisToHrTime: Ie,
+    otperformance: de,
+    parseKeyPairsIntoRecord: function (t) {
+      return "string" != typeof t || 0 === t.length
+        ? {}
+        : t
+            .split(Jt)
+            .map((t) => ee(t))
+            .filter((t) => void 0 !== t && t.value.length > 0)
+            .reduce((t, e) => ((t[e.key] = e.value), t), {});
+    },
+    parseTraceParent: Je,
+    sanitizeAttributes: re,
+    setGlobalErrorHandler: function (t) {
+      ue = t;
+    },
+    setRPCMetadata: function (t, e) {
+      return t.setValue(en, e);
+    },
+    suppressTracing: Xt,
+    timeInputToHrTime: je,
+    unrefTimer: Pe,
+    unsuppressTracing: function (t) {
+      return t.deleteValue(Wt);
+    },
+    urlMatches: Cn,
+  });
+  function Ln(t) {
+    if (Object.prototype.hasOwnProperty.call(t, "__esModule")) return t;
+    var e = t.default;
+    if ("function" == typeof e) {
+      var n = function t() {
+        return this instanceof t
+          ? Reflect.construct(e, arguments, this.constructor)
+          : e.apply(this, arguments);
+      };
+      n.prototype = e.prototype;
+    } else n = {};
+    return (
+      Object.defineProperty(n, "__esModule", { value: !0 }),
+      Object.keys(t).forEach(function (e) {
+        var r = Object.getOwnPropertyDescriptor(t, e);
+        Object.defineProperty(
+          n,
+          e,
+          r.get
+            ? r
+            : {
+                enumerable: !0,
+                get: function () {
+                  return t[e];
+                },
+              }
+        );
+      }),
+      n
+    );
+  }
+  var Dn,
+    In = {},
+    Mn = {};
+  function kn() {
+    if (Dn) return Mn;
+    function t(t) {
+      return Object.keys(t).map((n) => e(n, t[n]));
+    }
+    function e(t, e) {
+      return { key: t, value: n(e) };
+    }
+    function n(t) {
+      const r = typeof t;
+      return "string" === r
+        ? { stringValue: t }
+        : "number" === r
+        ? Number.isInteger(t)
+          ? { intValue: t }
+          : { doubleValue: t }
+        : "boolean" === r
+        ? { boolValue: t }
+        : t instanceof Uint8Array
+        ? { bytesValue: t }
+        : Array.isArray(t)
+        ? { arrayValue: { values: t.map(n) } }
+        : "object" === r && null != t
+        ? {
+            kvlistValue: { values: Object.entries(t).map(([t, n]) => e(t, n)) },
+          }
+        : {};
+    }
+    return (
+      (Dn = 1),
+      Object.defineProperty(Mn, "__esModule", { value: !0 }),
+      (Mn.toAnyValue =
+        Mn.toKeyValue =
+        Mn.toAttributes =
+        Mn.createInstrumentationScope =
+        Mn.createResource =
+          void 0),
+      (Mn.createResource = function (e) {
+        return { attributes: t(e.attributes), droppedAttributesCount: 0 };
+      }),
+      (Mn.createInstrumentationScope = function (t) {
+        return { name: t.name, version: t.version };
+      }),
+      (Mn.toAttributes = t),
+      (Mn.toKeyValue = e),
+      (Mn.toAnyValue = n),
+      Mn
+    );
+  }
+  var jn,
+    Un,
+    Bn,
+    Fn = {},
+    Hn = Ln(Pn),
+    Vn = {};
+  function $n() {
+    if (jn) return Vn;
+    function t(t) {
+      return t >= 48 && t <= 57
+        ? t - 48
+        : t >= 97 && t <= 102
+        ? t - 87
+        : t - 55;
+    }
+    return (
+      (jn = 1),
+      Object.defineProperty(Vn, "__esModule", { value: !0 }),
+      (Vn.hexToBinary = void 0),
+      (Vn.hexToBinary = function (e) {
+        const n = new Uint8Array(e.length / 2);
+        let r = 0;
+        for (let o = 0; o < e.length; o += 2) {
+          const i = t(e.charCodeAt(o)),
+            s = t(e.charCodeAt(o + 1));
+          n[r++] = (i << 4) | s;
+        }
+        return n;
+      }),
+      Vn
+    );
+  }
+  function zn() {
+    if (Un) return Fn;
+    (Un = 1),
+      Object.defineProperty(Fn, "__esModule", { value: !0 }),
+      (Fn.getOtlpEncoder =
+        Fn.encodeAsString =
+        Fn.encodeAsLongBits =
+        Fn.toLongBits =
+        Fn.hrTimeToNanos =
+          void 0);
+    const t = Hn,
+      e = $n();
+    function n(t) {
+      const e = BigInt(1e9);
+      return BigInt(t[0]) * e + BigInt(t[1]);
+    }
+    function r(t) {
+      return {
+        low: Number(BigInt.asUintN(32, t)),
+        high: Number(BigInt.asUintN(32, t >> BigInt(32))),
+      };
+    }
+    function o(t) {
+      return r(n(t));
+    }
+    function i(t) {
+      return n(t).toString();
+    }
+    (Fn.hrTimeToNanos = n),
+      (Fn.toLongBits = r),
+      (Fn.encodeAsLongBits = o),
+      (Fn.encodeAsString = i);
+    const s = "undefined" != typeof BigInt ? i : t.hrTimeToNanoseconds;
+    function a(t) {
+      return t;
+    }
+    function u(t) {
+      if (void 0 !== t) return (0, e.hexToBinary)(t);
+    }
+    const c = {
+      encodeHrTime: o,
+      encodeSpanContext: e.hexToBinary,
+      encodeOptionalSpanContext: u,
+    };
+    return (
+      (Fn.getOtlpEncoder = function (t) {
+        if (void 0 === t) return c;
+        const n = t.useLongBits ?? !0,
+          r = t.useHex ?? !1;
+        return {
+          encodeHrTime: n ? o : s,
+          encodeSpanContext: r ? a : e.hexToBinary,
+          encodeOptionalSpanContext: r ? a : u,
+        };
+      }),
+      Fn
+    );
+  }
+  function qn() {
+    if (Bn) return In;
+    (Bn = 1),
+      Object.defineProperty(In, "__esModule", { value: !0 }),
+      (In.createExportTraceServiceRequest =
+        In.toOtlpSpanEvent =
+        In.toOtlpLink =
+        In.sdkSpanToOtlpSpan =
+          void 0);
+    const t = kn(),
+      e = zn();
+    function n(e, n) {
+      const i = e.spanContext(),
+        s = e.status,
+        a = e.parentSpanContext?.spanId
+          ? n.encodeSpanContext(e.parentSpanContext?.spanId)
+          : void 0;
+      return {
+        traceId: n.encodeSpanContext(i.traceId),
+        spanId: n.encodeSpanContext(i.spanId),
+        parentSpanId: a,
+        traceState: i.traceState?.serialize(),
+        name: e.name,
+        kind: null == e.kind ? 0 : e.kind + 1,
+        startTimeUnixNano: n.encodeHrTime(e.startTime),
+        endTimeUnixNano: n.encodeHrTime(e.endTime),
+        attributes: (0, t.toAttributes)(e.attributes),
+        droppedAttributesCount: e.droppedAttributesCount,
+        events: e.events.map((t) => o(t, n)),
+        droppedEventsCount: e.droppedEventsCount,
+        status: { code: s.code, message: s.message },
+        links: e.links.map((t) => r(t, n)),
+        droppedLinksCount: e.droppedLinksCount,
+      };
+    }
+    function r(e, n) {
+      return {
+        attributes: e.attributes ? (0, t.toAttributes)(e.attributes) : [],
+        spanId: n.encodeSpanContext(e.context.spanId),
+        traceId: n.encodeSpanContext(e.context.traceId),
+        traceState: e.context.traceState?.serialize(),
+        droppedAttributesCount: e.droppedAttributesCount || 0,
+      };
+    }
+    function o(e, n) {
+      return {
+        attributes: e.attributes ? (0, t.toAttributes)(e.attributes) : [],
+        name: e.name,
+        timeUnixNano: n.encodeHrTime(e.time),
+        droppedAttributesCount: e.droppedAttributesCount || 0,
+      };
+    }
+    function i(e, r) {
+      const o = (function (t) {
+          const e = new Map();
+          for (const n of t) {
+            let t = e.get(n.resource);
+            t || ((t = new Map()), e.set(n.resource, t));
+            const r = `${n.instrumentationScope.name}@${
+              n.instrumentationScope.version || ""
+            }:${n.instrumentationScope.schemaUrl || ""}`;
+            let o = t.get(r);
+            o || ((o = []), t.set(r, o)), o.push(n);
+          }
+          return e;
+        })(e),
+        i = [],
+        s = o.entries();
+      let a = s.next();
+      for (; !a.done; ) {
+        const [e, o] = a.value,
+          u = [],
+          c = o.values();
+        let l = c.next();
+        for (; !l.done; ) {
+          const e = l.value;
+          if (e.length > 0) {
+            const o = e.map((t) => n(t, r));
+            u.push({
+              scope: (0, t.createInstrumentationScope)(
+                e[0].instrumentationScope
+              ),
+              spans: o,
+              schemaUrl: e[0].instrumentationScope.schemaUrl,
+            });
+          }
+          l = c.next();
+        }
+        const p = {
+          resource: (0, t.createResource)(e),
+          scopeSpans: u,
+          schemaUrl: void 0,
+        };
+        i.push(p), (a = s.next());
+      }
+      return i;
+    }
+    return (
+      (In.sdkSpanToOtlpSpan = n),
+      (In.toOtlpLink = r),
+      (In.toOtlpSpanEvent = o),
+      (In.createExportTraceServiceRequest = function (t, n) {
+        return { resourceSpans: i(t, (0, e.getOtlpEncoder)(n)) };
+      }),
+      In
+    );
+  }
+  var Gn,
+    Kn = qn(),
+    Wn = {};
+  function Xn() {
+    return (
+      Gn ||
+        ((Gn = 1),
+        (function (t) {
+          var e;
+          Object.defineProperty(t, "__esModule", { value: !0 }),
+            (t.ESpanKind = void 0),
+            ((e = t.ESpanKind || (t.ESpanKind = {}))[
+              (e.SPAN_KIND_UNSPECIFIED = 0)
+            ] = "SPAN_KIND_UNSPECIFIED"),
+            (e[(e.SPAN_KIND_INTERNAL = 1)] = "SPAN_KIND_INTERNAL"),
+            (e[(e.SPAN_KIND_SERVER = 2)] = "SPAN_KIND_SERVER"),
+            (e[(e.SPAN_KIND_CLIENT = 3)] = "SPAN_KIND_CLIENT"),
+            (e[(e.SPAN_KIND_PRODUCER = 4)] = "SPAN_KIND_PRODUCER"),
+            (e[(e.SPAN_KIND_CONSUMER = 5)] = "SPAN_KIND_CONSUMER");
+        })(Wn)),
+      Wn
+    );
+  }
+  var Qn = Xn();
+  class Yn {
+    constructor(t) {
+      this.config = t;
+    }
+    export(t, n) {
+      const r = Kn.createExportTraceServiceRequest(t, {
+        useHex: !0,
+        useLongBits: !1,
+      });
+      this.config.api.pushTraces(r),
+        (function (t = []) {
+          var n, r;
+          for (const o of t) {
+            const { scopeSpans: t } = o;
+            for (const o of t) {
+              const { scope: t, spans: i = [] } = o;
+              for (const o of i) {
+                if (o.kind !== Qn.ESpanKind.SPAN_KIND_CLIENT) continue;
+                const i = {
+                    traceId: o.traceId.toString(),
+                    spanId: o.spanId.toString(),
+                  },
+                  s = {};
+                for (const t of o.attributes)
+                  s[t.key] = String(Object.values(t.value)[0]);
+                Number.isNaN(o.endTimeUnixNano) ||
+                  Number.isNaN(o.startTimeUnixNano) ||
+                  (s.duration_ns = String(
+                    Number(o.endTimeUnixNano) - Number(o.startTimeUnixNano)
+                  ));
+                const a = (
+                  null !== (n = null == t ? void 0 : t.name) && void 0 !== n
+                    ? n
+                    : ""
+                ).indexOf("-");
+                let u = e.unknownString;
+                (null == t ? void 0 : t.name) &&
+                  (-1 === a &&
+                    (u =
+                      null !== (r = t.name.split("/")[1]) && void 0 !== r
+                        ? r
+                        : t.name),
+                  a > -1 && (u = null == t ? void 0 : t.name.substring(a + 1))),
+                  e.faro.api.pushEvent(`faro.tracing.${u}`, s, void 0, {
+                    spanContext: i,
+                    timestampOverwriteMs: Number(o.endTimeUnixNano) / 1e6,
+                    customPayloadTransformer: (t) => {
+                      var e, n;
+                      return (
+                        null != s["faro.action.user.name"] &&
+                          null != s["faro.action.user.parentId"] &&
+                          ((t.action = {
+                            name: s["faro.action.user.name"],
+                            parentId: s["faro.action.user.parentId"],
+                          }),
+                          null === (e = t.attributes) ||
+                            void 0 === e ||
+                            delete e["faro.action.user.name"],
+                          null === (n = t.attributes) ||
+                            void 0 === n ||
+                            delete n["faro.action.user.parentId"]),
+                        t
+                      );
+                    },
+                  });
+              }
+            }
+          }
+        })(r.resourceSpans),
+        n({ code: $e.SUCCESS });
+    }
+    shutdown() {
+      return Promise.resolve(void 0);
+    }
+  }
+  const Zn = "session.id";
+  "function" == typeof SuppressedError && SuppressedError;
+  class Jn {
+    emit(t) {}
+  }
+  const tr = new Jn();
+  const er = new (class {
+    getLogger(t, e, n) {
+      return new Jn();
+    }
+  })();
+  class nr {
+    constructor(t, e, n, r) {
+      (this._provider = t),
+        (this.name = e),
+        (this.version = n),
+        (this.options = r);
+    }
+    emit(t) {
+      this._getLogger().emit(t);
+    }
+    _getLogger() {
+      if (this._delegate) return this._delegate;
+      const t = this._provider.getDelegateLogger(
+        this.name,
+        this.version,
+        this.options
+      );
+      return t ? ((this._delegate = t), this._delegate) : tr;
+    }
+  }
+  class rr {
+    getLogger(t, e, n) {
+      var r;
+      return null !== (r = this.getDelegateLogger(t, e, n)) && void 0 !== r
+        ? r
+        : new nr(this, t, e, n);
+    }
+    getDelegate() {
+      var t;
+      return null !== (t = this._delegate) && void 0 !== t ? t : er;
+    }
+    setDelegate(t) {
+      this._delegate = t;
+    }
+    getDelegateLogger(t, e, n) {
+      var r;
+      return null === (r = this._delegate) || void 0 === r
+        ? void 0
+        : r.getLogger(t, e, n);
+    }
+  }
+  const or =
+      "object" == typeof globalThis
+        ? globalThis
+        : "object" == typeof self
+        ? self
+        : "object" == typeof window
+        ? window
+        : "object" == typeof global
+        ? global
+        : {},
+    ir = Symbol.for("io.opentelemetry.js.api.logs"),
+    sr = or;
+  class ar {
+    constructor() {
+      this._proxyLoggerProvider = new rr();
+    }
+    static getInstance() {
+      return this._instance || (this._instance = new ar()), this._instance;
+    }
+    setGlobalLoggerProvider(t) {
+      return sr[ir]
+        ? this.getLoggerProvider()
+        : ((sr[ir] = ((e = 1), (n = t), (r = er), (t) => (t === e ? n : r))),
+          this._proxyLoggerProvider.setDelegate(t),
+          t);
+      var e, n, r;
+    }
+    getLoggerProvider() {
+      var t, e;
+      return null !==
+        (e = null === (t = sr[ir]) || void 0 === t ? void 0 : t.call(sr, 1)) &&
+        void 0 !== e
+        ? e
+        : this._proxyLoggerProvider;
+    }
+    getLogger(t, e, n) {
+      return this.getLoggerProvider().getLogger(t, e, n);
+    }
+    disable() {
+      delete sr[ir], (this._proxyLoggerProvider = new rr());
+    }
+  }
+  const ur = ar.getInstance();
+  var cr, lr;
+  var pr = (function () {
+    if (lr) return cr;
+    function t(t) {
+      return "function" == typeof t;
+    }
+    lr = 1;
+    var e = console.error.bind(console);
+    function n(t, e, n) {
+      var r = !!t[e] && t.propertyIsEnumerable(e);
+      Object.defineProperty(t, e, {
+        configurable: !0,
+        enumerable: r,
+        writable: !0,
+        value: n,
+      });
+    }
+    function r(n) {
+      n &&
+        n.logger &&
+        (t(n.logger)
+          ? (e = n.logger)
+          : e("new logger isn't a function, not replacing"));
+    }
+    function o(r, o, i) {
+      if (r && r[o]) {
+        if (!i) return e("no wrapper function"), void e(new Error().stack);
+        if (t(r[o]) && t(i)) {
+          var s = r[o],
+            a = i(s, o);
+          return (
+            n(a, "__original", s),
+            n(a, "__unwrap", function () {
+              r[o] === a && n(r, o, s);
+            }),
+            n(a, "__wrapped", !0),
+            n(r, o, a),
+            a
+          );
+        }
+        e("original object and wrapper must be functions");
+      } else e("no original function " + o + " to wrap");
+    }
+    function i(t, n) {
+      return t && t[n]
+        ? t[n].__unwrap
+          ? t[n].__unwrap()
+          : void e(
+              "no original to unwrap to -- has " +
+                n +
+                " already been unwrapped?"
+            )
+        : (e("no function to unwrap."), void e(new Error().stack));
+    }
+    return (
+      (r.wrap = o),
+      (r.massWrap = function (t, n, r) {
+        if (!t)
+          return (
+            e("must provide one or more modules to patch"),
+            void e(new Error().stack)
+          );
+        Array.isArray(t) || (t = [t]),
+          n && Array.isArray(n)
+            ? t.forEach(function (t) {
+                n.forEach(function (e) {
+                  o(t, e, r);
+                });
+              })
+            : e("must provide one or more functions to wrap on modules");
+      }),
+      (r.unwrap = i),
+      (r.massUnwrap = function (t, n) {
+        if (!t)
+          return (
+            e("must provide one or more modules to patch"),
+            void e(new Error().stack)
+          );
+        Array.isArray(t) || (t = [t]),
+          n && Array.isArray(n)
+            ? t.forEach(function (t) {
+                n.forEach(function (e) {
+                  i(t, e);
+                });
+              })
+            : e("must provide one or more functions to unwrap on modules");
+      }),
+      (cr = r)
+    );
+  })();
+  class dr {
+    instrumentationName;
+    instrumentationVersion;
+    _config = {};
+    _tracer;
+    _meter;
+    _logger;
+    _diag;
+    constructor(t, e, n) {
+      (this.instrumentationName = t),
+        (this.instrumentationVersion = e),
+        this.setConfig(n),
+        (this._diag = Lt.createComponentLogger({ namespace: t })),
+        (this._tracer = Kt.getTracer(t, e)),
+        (this._meter = Mt.getMeter(t, e)),
+        (this._logger = ur.getLogger(t, e)),
+        this._updateMetricInstruments();
+    }
+    _wrap = pr.wrap;
+    _unwrap = pr.unwrap;
+    _massWrap = pr.massWrap;
+    _massUnwrap = pr.massUnwrap;
+    get meter() {
+      return this._meter;
+    }
+    setMeterProvider(t) {
+      (this._meter = t.getMeter(
+        this.instrumentationName,
+        this.instrumentationVersion
+      )),
+        this._updateMetricInstruments();
+    }
+    get logger() {
+      return this._logger;
+    }
+    setLoggerProvider(t) {
+      this._logger = t.getLogger(
+        this.instrumentationName,
+        this.instrumentationVersion
+      );
+    }
+    getModuleDefinitions() {
+      const t = this.init() ?? [];
+      return Array.isArray(t) ? t : [t];
+    }
+    _updateMetricInstruments() {}
+    getConfig() {
+      return this._config;
+    }
+    setConfig(t) {
+      this._config = { enabled: !0, ...t };
+    }
+    setTracerProvider(t) {
+      this._tracer = t.getTracer(
+        this.instrumentationName,
+        this.instrumentationVersion
+      );
+    }
+    get tracer() {
+      return this._tracer;
+    }
+    _runSpanCustomizationHook(t, e, n, r) {
+      if (t)
+        try {
+          t(n, r);
+        } catch (t) {
+          this._diag.error(
+            "Error running span customization hook due to exception in handler",
+            { triggerName: e },
+            t
+          );
+        }
+    }
+  }
+  class hr extends dr {
+    constructor(t, e, n) {
+      super(t, e, n), this._config.enabled && this.enable();
+    }
+  }
+  function fr(t, e, n) {
+    let r, o;
+    try {
+      o = t();
+    } catch (t) {
+      r = t;
+    } finally {
+      return e(r, o), o;
+    }
+  }
+  function gr(t) {
+    return (
+      "function" == typeof t &&
+      "function" == typeof t.__original &&
+      "function" == typeof t.__unwrap &&
+      !0 === t.__wrapped
+    );
+  }
+  const mr = (t) =>
+    null !== t && "object" == typeof t && "function" == typeof t.then;
+  class _r {
+    _rawAttributes;
+    _asyncAttributesPending = !1;
+    _memoizedAttributes;
+    static FromAttributeList(t) {
+      const e = new _r({});
+      return (
+        (e._rawAttributes = t),
+        (e._asyncAttributesPending = t.filter(([t, e]) => mr(e)).length > 0),
+        e
+      );
+    }
+    constructor(t) {
+      const e = t.attributes ?? {};
+      this._rawAttributes = Object.entries(e).map(
+        ([t, e]) => (mr(e) && (this._asyncAttributesPending = !0), [t, e])
+      );
+    }
+    get asyncAttributesPending() {
+      return this._asyncAttributesPending;
+    }
+    async waitForAsyncAttributes() {
+      if (this.asyncAttributesPending) {
+        for (let t = 0; t < this._rawAttributes.length; t++) {
+          const [e, n] = this._rawAttributes[t];
+          try {
+            this._rawAttributes[t] = [e, mr(n) ? await n : n];
+          } catch (n) {
+            Lt.debug("a resource's async attributes promise rejected: %s", n),
+              (this._rawAttributes[t] = [e, void 0]);
+          }
+        }
+        this._asyncAttributesPending = !1;
+      }
+    }
+    get attributes() {
+      if (
+        (this.asyncAttributesPending &&
+          Lt.error(
+            "Accessing resource attributes before async attributes settled"
+          ),
+        this._memoizedAttributes)
+      )
+        return this._memoizedAttributes;
+      const t = {};
+      for (const [e, n] of this._rawAttributes)
+        mr(n)
+          ? Lt.debug(`Unsettled resource attribute ${e} skipped`)
+          : null != n && (t[e] ??= n);
+      return this._asyncAttributesPending || (this._memoizedAttributes = t), t;
+    }
+    getRawAttributes() {
+      return this._rawAttributes;
+    }
+    merge(t) {
+      return null == t
+        ? this
+        : _r.FromAttributeList([
+            ...t.getRawAttributes(),
+            ...this.getRawAttributes(),
+          ]);
+    }
+  }
+  function vr(t) {
+    return _r.FromAttributeList(Object.entries(t));
+  }
+  function yr() {
+    return vr({
+      [Ae]: "unknown_service",
+      [Oe]: xe[Oe],
+      [Re]: xe[Re],
+      [Ne]: xe[Ne],
+    });
+  }
+  class Sr {
+    _spanContext;
+    kind;
+    parentSpanContext;
+    attributes = {};
+    links = [];
+    events = [];
+    startTime;
+    resource;
+    instrumentationScope;
+    _droppedAttributesCount = 0;
+    _droppedEventsCount = 0;
+    _droppedLinksCount = 0;
+    name;
+    status = { code: At.UNSET };
+    endTime = [0, 0];
+    _ended = !1;
+    _duration = [-1, -1];
+    _spanProcessor;
+    _spanLimits;
+    _attributeValueLengthLimit;
+    _performanceStartTime;
+    _performanceOffset;
+    _startTimeProvided;
+    constructor(t) {
+      const e = Date.now();
+      (this._spanContext = t.spanContext),
+        (this._performanceStartTime = de.now()),
+        (this._performanceOffset = e - (this._performanceStartTime + Me())),
+        (this._startTimeProvided = null != t.startTime),
+        (this._spanLimits = t.spanLimits),
+        (this._attributeValueLengthLimit =
+          this._spanLimits.attributeValueLengthLimit || 0),
+        (this._spanProcessor = t.spanProcessor),
+        (this.name = t.name),
+        (this.parentSpanContext = t.parentSpanContext),
+        (this.kind = t.kind),
+        (this.links = t.links || []),
+        (this.startTime = this._getTime(t.startTime ?? e)),
+        (this.resource = t.resource),
+        (this.instrumentationScope = t.scope),
+        null != t.attributes && this.setAttributes(t.attributes),
+        this._spanProcessor.onStart(this, t.context);
+    }
+    spanContext() {
+      return this._spanContext;
+    }
+    setAttribute(t, e) {
+      if (null == e || this._isSpanEnded()) return this;
+      if (0 === t.length) return Lt.warn(`Invalid attribute key: ${t}`), this;
+      if (!ie(e))
+        return Lt.warn(`Invalid attribute value set for key: ${t}`), this;
+      const { attributeCountLimit: n } = this._spanLimits;
+      return void 0 !== n &&
+        Object.keys(this.attributes).length >= n &&
+        !Object.prototype.hasOwnProperty.call(this.attributes, t)
+        ? (this._droppedAttributesCount++, this)
+        : ((this.attributes[t] = this._truncateToSize(e)), this);
+    }
+    setAttributes(t) {
+      for (const [e, n] of Object.entries(t)) this.setAttribute(e, n);
+      return this;
+    }
+    addEvent(t, e, n) {
+      if (this._isSpanEnded()) return this;
+      const { eventCountLimit: r } = this._spanLimits;
+      if (0 === r)
+        return Lt.warn("No events allowed."), this._droppedEventsCount++, this;
+      void 0 !== r &&
+        this.events.length >= r &&
+        (0 === this._droppedEventsCount && Lt.debug("Dropping extra events."),
+        this.events.shift(),
+        this._droppedEventsCount++),
+        He(e) && (He(n) || (n = e), (e = void 0));
+      const o = re(e);
+      return (
+        this.events.push({
+          name: t,
+          attributes: o,
+          time: this._getTime(n),
+          droppedAttributesCount: 0,
+        }),
+        this
+      );
+    }
+    addLink(t) {
+      return this.links.push(t), this;
+    }
+    addLinks(t) {
+      return this.links.push(...t), this;
+    }
+    setStatus(t) {
+      return (
+        this._isSpanEnded() ||
+          ((this.status = { ...t }),
+          null != this.status.message &&
+            "string" != typeof t.message &&
+            (Lt.warn(
+              `Dropping invalid status.message of type '${typeof t.message}', expected 'string'`
+            ),
+            delete this.status.message)),
+        this
+      );
+    }
+    updateName(t) {
+      return this._isSpanEnded() || (this.name = t), this;
+    }
+    end(t) {
+      this._isSpanEnded()
+        ? Lt.error(
+            `${this.name} ${this._spanContext.traceId}-${this._spanContext.spanId} - You can only call end() on a span once.`
+          )
+        : ((this._ended = !0),
+          (this.endTime = this._getTime(t)),
+          (this._duration = Ue(this.startTime, this.endTime)),
+          this._duration[0] < 0 &&
+            (Lt.warn(
+              "Inconsistent start and end time, startTime > endTime. Setting span duration to 0ms.",
+              this.startTime,
+              this.endTime
+            ),
+            (this.endTime = this.startTime.slice()),
+            (this._duration = [0, 0])),
+          this._droppedEventsCount > 0 &&
+            Lt.warn(
+              `Dropped ${this._droppedEventsCount} events because eventCountLimit reached`
+            ),
+          this._spanProcessor.onEnd(this));
+    }
+    _getTime(t) {
+      if ("number" == typeof t && t <= de.now())
+        return ke(t + this._performanceOffset);
+      if ("number" == typeof t) return Ie(t);
+      if (t instanceof Date) return Ie(t.getTime());
+      if (Fe(t)) return t;
+      if (this._startTimeProvided) return Ie(Date.now());
+      const e = de.now() - this._performanceStartTime;
+      return Ve(this.startTime, Ie(e));
+    }
+    isRecording() {
+      return !1 === this._ended;
+    }
+    recordException(t, e) {
+      const n = {};
+      "string" == typeof t
+        ? (n[fe] = t)
+        : t &&
+          (t.code ? (n[he] = t.code.toString()) : t.name && (n[he] = t.name),
+          t.message && (n[fe] = t.message),
+          t.stack && (n["exception.stacktrace"] = t.stack)),
+        n[he] || n[fe]
+          ? this.addEvent("exception", n, e)
+          : Lt.warn(`Failed to record an exception ${t}`);
+    }
+    get duration() {
+      return this._duration;
+    }
+    get ended() {
+      return this._ended;
+    }
+    get droppedAttributesCount() {
+      return this._droppedAttributesCount;
+    }
+    get droppedEventsCount() {
+      return this._droppedEventsCount;
+    }
+    get droppedLinksCount() {
+      return this._droppedLinksCount;
+    }
+    _isSpanEnded() {
+      if (this._ended) {
+        const t = new Error(
+          `Operation attempted on ended Span {traceId: ${this._spanContext.traceId}, spanId: ${this._spanContext.spanId}}`
+        );
+        Lt.warn(
+          `Cannot execute the operation on ended Span {traceId: ${this._spanContext.traceId}, spanId: ${this._spanContext.spanId}}`,
+          t
+        );
+      }
+      return this._ended;
+    }
+    _truncateToLimitUtil(t, e) {
+      return t.length <= e ? t : t.substring(0, e);
+    }
+    _truncateToSize(t) {
+      const e = this._attributeValueLengthLimit;
+      return e <= 0
+        ? (Lt.warn(`Attribute value limit must be positive, got ${e}`), t)
+        : "string" == typeof t
+        ? this._truncateToLimitUtil(t, e)
+        : Array.isArray(t)
+        ? t.map((t) =>
+            "string" == typeof t ? this._truncateToLimitUtil(t, e) : t
+          )
+        : t;
+    }
+  }
+  var br;
+  !(function (t) {
+    (t[(t.NOT_RECORD = 0)] = "NOT_RECORD"),
+      (t[(t.RECORD = 1)] = "RECORD"),
+      (t[(t.RECORD_AND_SAMPLED = 2)] = "RECORD_AND_SAMPLED");
+  })(br || (br = {}));
+  class Er {
+    shouldSample() {
+      return { decision: br.NOT_RECORD };
+    }
+    toString() {
+      return "AlwaysOffSampler";
+    }
+  }
+  class Tr {
+    shouldSample() {
+      return { decision: br.RECORD_AND_SAMPLED };
+    }
+    toString() {
+      return "AlwaysOnSampler";
+    }
+  }
+  class wr {
+    _root;
+    _remoteParentSampled;
+    _remoteParentNotSampled;
+    _localParentSampled;
+    _localParentNotSampled;
+    constructor(t) {
+      (this._root = t.root),
+        this._root ||
+          (ce(
+            new Error("ParentBasedSampler must have a root sampler configured")
+          ),
+          (this._root = new Tr())),
+        (this._remoteParentSampled = t.remoteParentSampled ?? new Tr()),
+        (this._remoteParentNotSampled = t.remoteParentNotSampled ?? new Er()),
+        (this._localParentSampled = t.localParentSampled ?? new Tr()),
+        (this._localParentNotSampled = t.localParentNotSampled ?? new Er());
+    }
+    shouldSample(t, e, n, r, o, i) {
+      const s = Kt.getSpanContext(t);
+      return s && St(s)
+        ? s.isRemote
+          ? s.traceFlags & R.SAMPLED
+            ? this._remoteParentSampled.shouldSample(t, e, n, r, o, i)
+            : this._remoteParentNotSampled.shouldSample(t, e, n, r, o, i)
+          : s.traceFlags & R.SAMPLED
+          ? this._localParentSampled.shouldSample(t, e, n, r, o, i)
+          : this._localParentNotSampled.shouldSample(t, e, n, r, o, i)
+        : this._root.shouldSample(t, e, n, r, o, i);
+    }
+    toString() {
+      return `ParentBased{root=${this._root.toString()}, remoteParentSampled=${this._remoteParentSampled.toString()}, remoteParentNotSampled=${this._remoteParentNotSampled.toString()}, localParentSampled=${this._localParentSampled.toString()}, localParentNotSampled=${this._localParentNotSampled.toString()}}`;
+    }
+  }
+  class Cr {
+    _ratio;
+    _upperBound;
+    constructor(t = 0) {
+      (this._ratio = t),
+        (this._ratio = this._normalize(t)),
+        (this._upperBound = Math.floor(4294967295 * this._ratio));
+    }
+    shouldSample(t, e) {
+      return {
+        decision:
+          yt(e) && this._accumulate(e) < this._upperBound
+            ? br.RECORD_AND_SAMPLED
+            : br.NOT_RECORD,
+      };
+    }
+    toString() {
+      return `TraceIdRatioBased{${this._ratio}}`;
+    }
+    _normalize(t) {
+      return "number" != typeof t || isNaN(t) ? 0 : t >= 1 ? 1 : t <= 0 ? 0 : t;
+    }
+    _accumulate(t) {
+      let e = 0;
+      for (let n = 0; n < t.length / 8; n++) {
+        const r = 8 * n;
+        e = (e ^ parseInt(t.slice(r, r + 8), 16)) >>> 0;
+      }
+      return e;
+    }
+  }
+  const Ar = 1;
+  function Or() {
+    return {
+      sampler: Rr(),
+      forceFlushTimeoutMillis: 3e4,
+      generalLimits: {
+        attributeValueLengthLimit: 1 / 0,
+        attributeCountLimit: 128,
+      },
+      spanLimits: {
+        attributeValueLengthLimit: 1 / 0,
+        attributeCountLimit: 128,
+        linkCountLimit: 128,
+        eventCountLimit: 128,
+        attributePerEventCountLimit: 128,
+        attributePerLinkCountLimit: 128,
+      },
+    };
+  }
+  function Rr() {
+    const t = "parentbased_always_on";
+    switch (t) {
+      case "always_on":
+        return new Tr();
+      case "always_off":
+        return new Er();
+      case "parentbased_always_on":
+        return new wr({ root: new Tr() });
+      case "parentbased_always_off":
+        return new wr({ root: new Er() });
+      case "traceidratio":
+        return new Cr(Nr());
+      case "parentbased_traceidratio":
+        return new wr({ root: new Cr(Nr()) });
+      default:
+        return (
+          Lt.error(
+            `OTEL_TRACES_SAMPLER value "${t}" invalid, defaulting to "parentbased_always_on".`
+          ),
+          new wr({ root: new Tr() })
+        );
+    }
+  }
+  function Nr() {
+    return (
+      Lt.error(`OTEL_TRACES_SAMPLER_ARG is blank, defaulting to ${Ar}.`), Ar
+    );
+  }
+  const xr = 1 / 0;
+  class Pr {
+    _exporter;
+    _maxExportBatchSize;
+    _maxQueueSize;
+    _scheduledDelayMillis;
+    _exportTimeoutMillis;
+    _isExporting = !1;
+    _finishedSpans = [];
+    _timer;
+    _shutdownOnce;
+    _droppedSpansCount = 0;
+    constructor(t, e) {
+      (this._exporter = t),
+        (this._maxExportBatchSize =
+          "number" == typeof e?.maxExportBatchSize
+            ? e.maxExportBatchSize
+            : 512),
+        (this._maxQueueSize =
+          "number" == typeof e?.maxQueueSize ? e.maxQueueSize : 2048),
+        (this._scheduledDelayMillis =
+          "number" == typeof e?.scheduledDelayMillis
+            ? e.scheduledDelayMillis
+            : 5e3),
+        (this._exportTimeoutMillis =
+          "number" == typeof e?.exportTimeoutMillis
+            ? e.exportTimeoutMillis
+            : 3e4),
+        (this._shutdownOnce = new Rn(this._shutdown, this)),
+        this._maxExportBatchSize > this._maxQueueSize &&
+          (Lt.warn(
+            "BatchSpanProcessor: maxExportBatchSize must be smaller or equal to maxQueueSize, setting maxExportBatchSize to match maxQueueSize"
+          ),
+          (this._maxExportBatchSize = this._maxQueueSize));
+    }
+    forceFlush() {
+      return this._shutdownOnce.isCalled
+        ? this._shutdownOnce.promise
+        : this._flushAll();
+    }
+    onStart(t, e) {}
+    onEnd(t) {
+      this._shutdownOnce.isCalled ||
+        (t.spanContext().traceFlags & R.SAMPLED && this._addToBuffer(t));
+    }
+    shutdown() {
+      return this._shutdownOnce.call();
+    }
+    _shutdown() {
+      return Promise.resolve()
+        .then(() => this.onShutdown())
+        .then(() => this._flushAll())
+        .then(() => this._exporter.shutdown());
+    }
+    _addToBuffer(t) {
+      if (this._finishedSpans.length >= this._maxQueueSize)
+        return (
+          0 === this._droppedSpansCount &&
+            Lt.debug("maxQueueSize reached, dropping spans"),
+          void this._droppedSpansCount++
+        );
+      this._droppedSpansCount > 0 &&
+        (Lt.warn(
+          `Dropped ${this._droppedSpansCount} spans because maxQueueSize reached`
+        ),
+        (this._droppedSpansCount = 0)),
+        this._finishedSpans.push(t),
+        this._maybeStartTimer();
+    }
+    _flushAll() {
+      return new Promise((t, e) => {
+        const n = [];
+        for (
+          let t = 0,
+            e = Math.ceil(
+              this._finishedSpans.length / this._maxExportBatchSize
+            );
+          t < e;
+          t++
+        )
+          n.push(this._flushOneBatch());
+        Promise.all(n)
+          .then(() => {
+            t();
+          })
+          .catch(e);
+      });
+    }
+    _flushOneBatch() {
+      return (
+        this._clearTimer(),
+        0 === this._finishedSpans.length
+          ? Promise.resolve()
+          : new Promise((t, e) => {
+              const n = setTimeout(() => {
+                e(new Error("Timeout"));
+              }, this._exportTimeoutMillis);
+              Pt.with(Xt(Pt.active()), () => {
+                let r;
+                this._finishedSpans.length <= this._maxExportBatchSize
+                  ? ((r = this._finishedSpans), (this._finishedSpans = []))
+                  : (r = this._finishedSpans.splice(
+                      0,
+                      this._maxExportBatchSize
+                    ));
+                const o = () =>
+                  this._exporter.export(r, (r) => {
+                    clearTimeout(n),
+                      r.code === $e.SUCCESS
+                        ? t()
+                        : e(
+                            r.error ??
+                              new Error(
+                                "BatchSpanProcessor: span export failed"
+                              )
+                          );
+                  });
+                let i = null;
+                for (let t = 0, e = r.length; t < e; t++) {
+                  const e = r[t];
+                  e.resource.asyncAttributesPending &&
+                    e.resource.waitForAsyncAttributes &&
+                    ((i ??= []), i.push(e.resource.waitForAsyncAttributes()));
+                }
+                null === i
+                  ? o()
+                  : Promise.all(i).then(o, (t) => {
+                      ce(t), e(t);
+                    });
+              });
+            })
+      );
+    }
+    _maybeStartTimer() {
+      if (this._isExporting) return;
+      const t = () => {
+        (this._isExporting = !0),
+          this._flushOneBatch()
+            .finally(() => {
+              (this._isExporting = !1),
+                this._finishedSpans.length > 0 &&
+                  (this._clearTimer(), this._maybeStartTimer());
+            })
+            .catch((t) => {
+              (this._isExporting = !1), ce(t);
+            });
+      };
+      if (this._finishedSpans.length >= this._maxExportBatchSize) return t();
+      void 0 === this._timer &&
+        ((this._timer = setTimeout(() => t(), this._scheduledDelayMillis)),
+        this._timer);
+    }
+    _clearTimer() {
+      void 0 !== this._timer &&
+        (clearTimeout(this._timer), (this._timer = void 0));
+    }
+  }
+  class Lr extends Pr {
+    _visibilityChangeListener;
+    _pageHideListener;
+    constructor(t, e) {
+      super(t, e), this.onInit(e);
+    }
+    onInit(t) {
+      !0 !== t?.disableAutoFlushOnDocumentHide &&
+        "undefined" != typeof document &&
+        ((this._visibilityChangeListener = () => {
+          "hidden" === document.visibilityState &&
+            this.forceFlush().catch((t) => {
+              ce(t);
+            });
+        }),
+        (this._pageHideListener = () => {
+          this.forceFlush().catch((t) => {
+            ce(t);
+          });
+        }),
+        document.addEventListener(
+          "visibilitychange",
+          this._visibilityChangeListener
+        ),
+        document.addEventListener("pagehide", this._pageHideListener));
+    }
+    onShutdown() {
+      "undefined" != typeof document &&
+        (this._visibilityChangeListener &&
+          document.removeEventListener(
+            "visibilitychange",
+            this._visibilityChangeListener
+          ),
+        this._pageHideListener &&
+          document.removeEventListener("pagehide", this._pageHideListener));
+    }
+  }
+  class Dr {
+    generateTraceId = Mr(16);
+    generateSpanId = Mr(8);
+  }
+  const Ir = Array(32);
+  function Mr(t) {
+    return function () {
+      for (let e = 0; e < 2 * t; e++)
+        (Ir[e] = Math.floor(16 * Math.random()) + 48),
+          Ir[e] >= 58 && (Ir[e] += 39);
+      return String.fromCharCode.apply(null, Ir.slice(0, 2 * t));
+    };
+  }
+  class kr {
+    _sampler;
+    _generalLimits;
+    _spanLimits;
+    _idGenerator;
+    instrumentationScope;
+    _resource;
+    _spanProcessor;
+    constructor(t, e, n, r) {
+      const o = (function (t) {
+        const e = { sampler: Rr() },
+          n = Or(),
+          r = Object.assign({}, n, e, t);
+        return (
+          (r.generalLimits = Object.assign(
+            {},
+            n.generalLimits,
+            t.generalLimits || {}
+          )),
+          (r.spanLimits = Object.assign({}, n.spanLimits, t.spanLimits || {})),
+          r
+        );
+      })(e);
+      (this._sampler = o.sampler),
+        (this._generalLimits = o.generalLimits),
+        (this._spanLimits = o.spanLimits),
+        (this._idGenerator = e.idGenerator || new Dr()),
+        (this._resource = n),
+        (this._spanProcessor = r),
+        (this.instrumentationScope = t);
+    }
+    startSpan(t, e = {}, n = Pt.active()) {
+      e.root && (n = Kt.deleteSpan(n));
+      const r = Kt.getSpan(n);
+      if (Qt(n)) {
+        Lt.debug("Instrumentation suppressed, returning Noop Span");
+        return Kt.wrapSpanContext(ut);
+      }
+      const o = r?.spanContext(),
+        i = this._idGenerator.generateSpanId();
+      let s, a, u;
+      o && Kt.isSpanContextValid(o)
+        ? ((a = o.traceId), (u = o.traceState), (s = o))
+        : (a = this._idGenerator.generateTraceId());
+      const c = e.kind ?? Ct.INTERNAL,
+        l = (e.links ?? []).map((t) => ({
+          context: t.context,
+          attributes: re(t.attributes),
+        })),
+        p = re(e.attributes),
+        d = this._sampler.shouldSample(n, a, t, c, p, l);
+      u = d.traceState ?? u;
+      const h = {
+        traceId: a,
+        spanId: i,
+        traceFlags: d.decision === wt.RECORD_AND_SAMPLED ? R.SAMPLED : R.NONE,
+        traceState: u,
+      };
+      if (d.decision === wt.NOT_RECORD) {
+        Lt.debug(
+          "Recording is off, propagating context in a non-recording span"
+        );
+        return Kt.wrapSpanContext(h);
+      }
+      const f = re(Object.assign(p, d.attributes));
+      return new Sr({
+        resource: this._resource,
+        scope: this.instrumentationScope,
+        context: n,
+        spanContext: h,
+        name: t,
+        kind: c,
+        links: l,
+        parentSpanContext: s,
+        attributes: f,
+        startTime: e.startTime,
+        spanProcessor: this._spanProcessor,
+        spanLimits: this._spanLimits,
+      });
+    }
+    startActiveSpan(t, e, n, r) {
+      let o, i, s;
+      if (arguments.length < 2) return;
+      2 === arguments.length
+        ? (s = e)
+        : 3 === arguments.length
+        ? ((o = e), (s = n))
+        : ((o = e), (i = n), (s = r));
+      const a = i ?? Pt.active(),
+        u = this.startSpan(t, o, a),
+        c = Kt.setSpan(a, u);
+      return Pt.with(c, s, void 0, u);
+    }
+    getGeneralLimits() {
+      return this._generalLimits;
+    }
+    getSpanLimits() {
+      return this._spanLimits;
+    }
+  }
+  class jr {
+    _spanProcessors;
+    constructor(t) {
+      this._spanProcessors = t;
+    }
+    forceFlush() {
+      const t = [];
+      for (const e of this._spanProcessors) t.push(e.forceFlush());
+      return new Promise((e) => {
+        Promise.all(t)
+          .then(() => {
+            e();
+          })
+          .catch((t) => {
+            ce(t || new Error("MultiSpanProcessor: forceFlush failed")), e();
+          });
+      });
+    }
+    onStart(t, e) {
+      for (const n of this._spanProcessors) n.onStart(t, e);
+    }
+    onEnd(t) {
+      for (const e of this._spanProcessors) e.onEnd(t);
+    }
+    shutdown() {
+      const t = [];
+      for (const e of this._spanProcessors) t.push(e.shutdown());
+      return new Promise((e, n) => {
+        Promise.all(t).then(() => {
+          e();
+        }, n);
+      });
+    }
+  }
+  var Ur, Br;
+  !(function (t) {
+    (t[(t.resolved = 0)] = "resolved"),
+      (t[(t.timeout = 1)] = "timeout"),
+      (t[(t.error = 2)] = "error"),
+      (t[(t.unresolved = 3)] = "unresolved");
+  })(Ur || (Ur = {}));
+  class Fr {
+    _config;
+    _tracers = new Map();
+    _resource;
+    _activeSpanProcessor;
+    constructor(t = {}) {
+      const e = mn(
+        {},
+        Or(),
+        (function (t) {
+          const e = Object.assign({}, t.spanLimits);
+          return (
+            (e.attributeCountLimit =
+              t.spanLimits?.attributeCountLimit ??
+              t.generalLimits?.attributeCountLimit ??
+              void 0 ??
+              void 0 ??
+              128),
+            (e.attributeValueLengthLimit =
+              t.spanLimits?.attributeValueLengthLimit ??
+              t.generalLimits?.attributeValueLengthLimit ??
+              void 0 ??
+              void 0 ??
+              xr),
+            Object.assign({}, t, { spanLimits: e })
+          );
+        })(t)
+      );
+      (this._resource = e.resource ?? yr()),
+        (this._config = Object.assign({}, e, { resource: this._resource }));
+      const n = [];
+      t.spanProcessors?.length && n.push(...t.spanProcessors),
+        (this._activeSpanProcessor = new jr(n));
+    }
+    getTracer(t, e, n) {
+      const r = `${t}@${e || ""}:${n?.schemaUrl || ""}`;
+      return (
+        this._tracers.has(r) ||
+          this._tracers.set(
+            r,
+            new kr(
+              { name: t, version: e, schemaUrl: n?.schemaUrl },
+              this._config,
+              this._resource,
+              this._activeSpanProcessor
+            )
+          ),
+        this._tracers.get(r)
+      );
+    }
+    forceFlush() {
+      const t = this._config.forceFlushTimeoutMillis,
+        e = this._activeSpanProcessor._spanProcessors.map(
+          (e) =>
+            new Promise((n) => {
+              let r;
+              const o = setTimeout(() => {
+                n(
+                  new Error(
+                    `Span processor did not completed within timeout period of ${t} ms`
+                  )
+                ),
+                  (r = Ur.timeout);
+              }, t);
+              e.forceFlush()
+                .then(() => {
+                  clearTimeout(o),
+                    r !== Ur.timeout && ((r = Ur.resolved), n(r));
+                })
+                .catch((t) => {
+                  clearTimeout(o), (r = Ur.error), n(t);
+                });
+            })
+        );
+      return new Promise((t, n) => {
+        Promise.all(e)
+          .then((e) => {
+            const r = e.filter((t) => t !== Ur.resolved);
+            r.length > 0 ? n(r) : t();
+          })
+          .catch((t) => n([t]));
+      });
+    }
+    shutdown() {
+      return this._activeSpanProcessor.shutdown();
+    }
+  }
+  class Hr {
+    _enabled = !1;
+    _currentContext = x;
+    _bindFunction(t = x, e) {
+      const n = this,
+        r = function (...r) {
+          return n.with(t, () => e.apply(this, r));
+        };
+      return (
+        Object.defineProperty(r, "length", {
+          enumerable: !1,
+          configurable: !0,
+          writable: !1,
+          value: e.length,
+        }),
+        r
+      );
+    }
+    active() {
+      return this._currentContext;
+    }
+    bind(t, e) {
+      return (
+        void 0 === t && (t = this.active()),
+        "function" == typeof e ? this._bindFunction(t, e) : e
+      );
+    }
+    disable() {
+      return (this._currentContext = x), (this._enabled = !1), this;
+    }
+    enable() {
+      return (
+        this._enabled || ((this._enabled = !0), (this._currentContext = x)),
+        this
+      );
+    }
+    with(t, e, n, ...r) {
+      const o = this._currentContext;
+      this._currentContext = t || x;
+      try {
+        return e.call(n, ...r);
+      } finally {
+        this._currentContext = o;
+      }
+    }
+  }
+  class Vr extends Fr {
+    constructor(t = {}) {
+      super(t);
+    }
+    register(t = {}) {
+      var e;
+      Kt.setGlobalTracerProvider(this),
+        null !== (e = t.propagator) &&
+          (void 0 !== e
+            ? qt.setGlobalPropagator(e)
+            : qt.setGlobalPropagator(
+                new ze({ propagators: [new tn(), new ne()] })
+              )),
+        (function (t) {
+          if (null !== t) {
+            if (void 0 === t) {
+              const t = new Hr();
+              return t.enable(), void Pt.setGlobalContextManager(t);
+            }
+            t.enable(), Pt.setGlobalContextManager(t);
+          }
+        })(t.contextManager);
+    }
+  }
+  let $r;
+  function zr(t, e, n, r = !0) {
+    if (
+      !((o = n),
+      (i = e),
+      !(i in o) || "number" != typeof n[e] || (r && 0 === n[e]))
+    )
+      return t.addEvent(e, n[e]);
+    var o, i;
+  }
+  function qr(t, e, n = !1, r) {
+    void 0 === r && (r = 0 !== e[Br.START_TIME]),
+      n ||
+        (zr(t, Br.FETCH_START, e, r),
+        zr(t, Br.DOMAIN_LOOKUP_START, e, r),
+        zr(t, Br.DOMAIN_LOOKUP_END, e, r),
+        zr(t, Br.CONNECT_START, e, r),
+        zr(t, Br.SECURE_CONNECTION_START, e, r),
+        zr(t, Br.CONNECT_END, e, r),
+        zr(t, Br.REQUEST_START, e, r),
+        zr(t, Br.RESPONSE_START, e, r),
+        zr(t, Br.RESPONSE_END, e, r));
+    const o = e[Br.ENCODED_BODY_SIZE];
+    void 0 !== o && t.setAttribute("http.response_content_length", o);
+    const i = e[Br.DECODED_BODY_SIZE];
+    void 0 !== i &&
+      o !== i &&
+      t.setAttribute("http.response_content_length_uncompressed", i);
+  }
+  function Gr() {
+    return "undefined" != typeof location ? location.origin : void 0;
+  }
+  function Kr(t, e, n, r, o = new WeakSet(), i) {
+    const s = Wr(t),
+      a = (function (t, e, n, r, o, i) {
+        const s = Be(e),
+          a = Be(n);
+        let u = r.filter((e) => {
+          const n = Be(je(e[Br.FETCH_START])),
+            r = Be(je(e[Br.RESPONSE_END]));
+          return (
+            e.initiatorType.toLowerCase() === (i || "xmlhttprequest") &&
+            e.name === t &&
+            n >= s &&
+            r <= a
+          );
+        });
+        u.length > 0 && (u = u.filter((t) => !o.has(t)));
+        return u;
+      })((t = s.toString()), e, n, r, o, i);
+    if (0 === a.length) return { mainRequest: void 0 };
+    if (1 === a.length) return { mainRequest: a[0] };
+    const u = (function (t) {
+      return t.slice().sort((t, e) => {
+        const n = t[Br.FETCH_START],
+          r = e[Br.FETCH_START];
+        return n > r ? 1 : n < r ? -1 : 0;
+      });
+    })(a);
+    if (s.origin !== Gr() && u.length > 1) {
+      let t = u[0],
+        e = (function (t, e, n) {
+          const r = Be(n),
+            o = Be(je(e));
+          let i,
+            s = t[1];
+          const a = t.length;
+          for (let e = 1; e < a; e++) {
+            const n = t[e],
+              a = Be(je(n[Br.FETCH_START])),
+              u = r - Be(je(n[Br.RESPONSE_END]));
+            a >= o && (!i || u < i) && ((i = u), (s = n));
+          }
+          return s;
+        })(u, t[Br.RESPONSE_END], n);
+      const r = t[Br.RESPONSE_END];
+      return (
+        e[Br.FETCH_START] < r && ((e = t), (t = void 0)),
+        { corsPreFlightRequest: t, mainRequest: e }
+      );
+    }
+    return { mainRequest: a[0] };
+  }
+  function Wr(t) {
+    if ("function" == typeof URL)
+      return new URL(
+        t,
+        "undefined" != typeof document
+          ? document.baseURI
+          : "undefined" != typeof location
+          ? location.href
+          : void 0
+      );
+    const e = ($r || ($r = document.createElement("a")), $r);
+    return (e.href = t), e;
+  }
+  function Xr(t, e) {
+    let n = e || [];
+    ("string" == typeof n || n instanceof RegExp) && (n = [n]);
+    return Wr(t).origin === Gr() || n.some((e) => Cn(t, e));
+  }
+  var Qr;
+  !(function (t) {
+    (t.CONNECT_END = "connectEnd"),
+      (t.CONNECT_START = "connectStart"),
+      (t.DECODED_BODY_SIZE = "decodedBodySize"),
+      (t.DOM_COMPLETE = "domComplete"),
+      (t.DOM_CONTENT_LOADED_EVENT_END = "domContentLoadedEventEnd"),
+      (t.DOM_CONTENT_LOADED_EVENT_START = "domContentLoadedEventStart"),
+      (t.DOM_INTERACTIVE = "domInteractive"),
+      (t.DOMAIN_LOOKUP_END = "domainLookupEnd"),
+      (t.DOMAIN_LOOKUP_START = "domainLookupStart"),
+      (t.ENCODED_BODY_SIZE = "encodedBodySize"),
+      (t.FETCH_START = "fetchStart"),
+      (t.LOAD_EVENT_END = "loadEventEnd"),
+      (t.LOAD_EVENT_START = "loadEventStart"),
+      (t.NAVIGATION_START = "navigationStart"),
+      (t.REDIRECT_END = "redirectEnd"),
+      (t.REDIRECT_START = "redirectStart"),
+      (t.REQUEST_START = "requestStart"),
+      (t.RESPONSE_END = "responseEnd"),
+      (t.RESPONSE_START = "responseStart"),
+      (t.SECURE_CONNECTION_START = "secureConnectionStart"),
+      (t.START_TIME = "startTime"),
+      (t.UNLOAD_EVENT_END = "unloadEventEnd"),
+      (t.UNLOAD_EVENT_START = "unloadEventStart");
+  })(Br || (Br = {})),
+    (function (t) {
+      (t.COMPONENT = "component"),
+        (t.HTTP_ERROR_NAME = "http.error_name"),
+        (t.HTTP_STATUS_TEXT = "http.status_text");
+    })(Qr || (Qr = {}));
+  const Yr = Lt.createComponentLogger({
+    namespace: "@opentelemetry/opentelemetry-instrumentation-fetch/utils",
+  });
+  function Zr(...t) {
+    if (t[0] instanceof URL || "string" == typeof t[0]) {
+      const e = t[1];
+      if (!e?.body) return Promise.resolve();
+      if (e.body instanceof ReadableStream) {
+        const { body: t, length: n } = (function (t) {
+          if (!t.pipeThrough)
+            return (
+              Yr.warn("Platform has ReadableStream but not pipeThrough!"),
+              { body: t, length: Promise.resolve(void 0) }
+            );
+          let e,
+            n = 0;
+          const r = new Promise((t) => {
+              e = t;
+            }),
+            o = new TransformStream({
+              start() {},
+              async transform(t, e) {
+                const r = await t;
+                (n += r.byteLength), e.enqueue(t);
+              },
+              flush() {
+                e(n);
+              },
+            });
+          return { body: t.pipeThrough(o), length: r };
+        })(e.body);
+        return (e.body = t), n;
+      }
+      return Promise.resolve(
+        (function (t) {
+          if (
+            ((e = t), "undefined" != typeof Document && e instanceof Document)
+          )
+            return new XMLSerializer().serializeToString(document).length;
+          var e;
+          if ("string" == typeof t) return to(t);
+          if (t instanceof Blob) return t.size;
+          if (t instanceof FormData)
+            return (function (t) {
+              let e = 0;
+              for (const [n, r] of t.entries())
+                (e += n.length),
+                  r instanceof Blob ? (e += r.size) : (e += r.length);
+              return e;
+            })(t);
+          if (t instanceof URLSearchParams) return to(t.toString());
+          if (void 0 !== t.byteLength) return t.byteLength;
+          return void Yr.warn("unknown body type");
+        })(e.body)
+      );
+    }
+    {
+      const e = t[0];
+      return e?.body
+        ? e
+            .clone()
+            .text()
+            .then((t) => to(t))
+        : Promise.resolve();
+    }
+  }
+  const Jr = new TextEncoder();
+  function to(t) {
+    return Jr.encode(t).byteLength;
+  }
+  const eo = "0.200.0",
+    no = "object" == typeof process && "node" === process.release?.name;
+  class ro extends hr {
+    component = "fetch";
+    version = eo;
+    moduleName = this.component;
+    _usedResources = new WeakSet();
+    _tasksCount = 0;
+    constructor(t = {}) {
+      super("@opentelemetry/instrumentation-fetch", eo, t);
+    }
+    init() {}
+    _addChildSpan(t, e) {
+      const n = this.tracer.startSpan(
+        "CORS Preflight",
+        { startTime: e[Br.FETCH_START] },
+        Kt.setSpan(Pt.active(), t)
+      );
+      qr(n, e, this.getConfig().ignoreNetworkEvents), n.end(e[Br.RESPONSE_END]);
+    }
+    _addFinalSpanAttributes(t, e) {
+      const n = Wr(e.url);
+      t.setAttribute(ye, e.status),
+        null != e.statusText &&
+          t.setAttribute(Qr.HTTP_STATUS_TEXT, e.statusText),
+        t.setAttribute(_e, n.host),
+        t.setAttribute(ve, n.protocol.replace(":", "")),
+        "undefined" != typeof navigator &&
+          t.setAttribute(Se, navigator.userAgent);
+    }
+    _addHeaders(t, e) {
+      if (!Xr(e, this.getConfig().propagateTraceHeaderCorsUrls)) {
+        const t = {};
+        return (
+          qt.inject(Pt.active(), t),
+          void (
+            Object.keys(t).length > 0 &&
+            this._diag.debug("headers inject skipped due to CORS policy")
+          )
+        );
+      }
+      if (t instanceof Request)
+        qt.inject(Pt.active(), t.headers, {
+          set: (t, e, n) => t.set(e, "string" == typeof n ? n : String(n)),
+        });
+      else if (t.headers instanceof Headers)
+        qt.inject(Pt.active(), t.headers, {
+          set: (t, e, n) => t.set(e, "string" == typeof n ? n : String(n)),
+        });
+      else if (t.headers instanceof Map)
+        qt.inject(Pt.active(), t.headers, {
+          set: (t, e, n) => t.set(e, "string" == typeof n ? n : String(n)),
+        });
+      else {
+        const e = {};
+        qt.inject(Pt.active(), e),
+          (t.headers = Object.assign({}, e, t.headers || {}));
+      }
+    }
+    _clearResources() {
+      0 === this._tasksCount &&
+        this.getConfig().clearTimingResources &&
+        (performance.clearResourceTimings(),
+        (this._usedResources = new WeakSet()));
+    }
+    _createSpan(t, e = {}) {
+      if (An(t, this.getConfig().ignoreUrls))
+        return void this._diag.debug(
+          "ignoring span as url matches ignored url"
+        );
+      const n = (e.method || "GET").toUpperCase(),
+        r = `HTTP ${n}`;
+      return this.tracer.startSpan(r, {
+        kind: Ct.CLIENT,
+        attributes: { [Qr.COMPONENT]: this.moduleName, [ge]: n, [me]: t },
+      });
+    }
+    _findResourceAndAddNetworkEvents(t, e, n) {
+      let r = e.entries;
+      if (!r.length) {
+        if (!performance.getEntriesByType) return;
+        r = performance.getEntriesByType("resource");
+      }
+      const o = Kr(e.spanUrl, e.startTime, n, r, this._usedResources, "fetch");
+      if (o.mainRequest) {
+        const e = o.mainRequest;
+        this._markResourceAsUsed(e);
+        const n = o.corsPreFlightRequest;
+        n && (this._addChildSpan(t, n), this._markResourceAsUsed(n)),
+          qr(t, e, this.getConfig().ignoreNetworkEvents);
+      }
+    }
+    _markResourceAsUsed(t) {
+      this._usedResources.add(t);
+    }
+    _endSpan(t, e, n) {
+      const r = Ie(Date.now()),
+        o = ke();
+      this._addFinalSpanAttributes(t, n),
+        setTimeout(() => {
+          e.observer?.disconnect(),
+            this._findResourceAndAddNetworkEvents(t, e, o),
+            this._tasksCount--,
+            this._clearResources(),
+            t.end(r);
+        }, 300);
+    }
+    _patchConstructor() {
+      return (t) => {
+        const e = this;
+        return function (...n) {
+          const r = this,
+            o = Wr(n[0] instanceof Request ? n[0].url : String(n[0])).href,
+            i = n[0] instanceof Request ? n[0] : n[1] || {},
+            s = e._createSpan(o, i);
+          if (!s) return t.apply(this, n);
+          const a = e._prepareSpanData(o);
+          function u(t, n) {
+            e._applyAttributesAfterFetch(t, i, n),
+              e._endSpan(t, a, {
+                status: n.status || 0,
+                statusText: n.message,
+                url: o,
+              });
+          }
+          function c(t, n) {
+            e._applyAttributesAfterFetch(t, i, n),
+              n.status >= 200 && n.status < 400
+                ? e._endSpan(t, a, n)
+                : e._endSpan(t, a, {
+                    status: n.status,
+                    statusText: n.statusText,
+                    url: o,
+                  });
+          }
+          function l(t, e, n) {
+            try {
+              const e = n.clone().body;
+              if (e) {
+                const r = e.getReader(),
+                  o = () => {
+                    r.read().then(
+                      ({ done: e }) => {
+                        e ? c(t, n) : o();
+                      },
+                      (e) => {
+                        u(t, e);
+                      }
+                    );
+                  };
+                o();
+              } else c(t, n);
+            } finally {
+              e(n);
+            }
+          }
+          function p(t, e, n) {
+            try {
+              u(t, n);
+            } finally {
+              e(n);
+            }
+          }
+          return (
+            e.getConfig().measureRequestSize &&
+              Zr(...n)
+                .then((t) => {
+                  t && s.setAttribute(be, t);
+                })
+                .catch((t) => {
+                  e._diag.warn("getFetchBodyLength", t);
+                }),
+            new Promise((n, a) =>
+              Pt.with(
+                Kt.setSpan(Pt.active(), s),
+                () => (
+                  e._addHeaders(i, o),
+                  e._callRequestHook(s, i),
+                  e._tasksCount++,
+                  t
+                    .apply(r, i instanceof Request ? [i] : [o, i])
+                    .then(l.bind(r, s, n), p.bind(r, s, a))
+                )
+              )
+            )
+          );
+        };
+      };
+    }
+    _applyAttributesAfterFetch(t, e, n) {
+      const r = this.getConfig().applyCustomAttributesOnSpan;
+      r &&
+        fr(
+          () => r(t, e, n),
+          (t) => {
+            t && this._diag.error("applyCustomAttributesOnSpan", t);
+          }
+        );
+    }
+    _callRequestHook(t, e) {
+      const n = this.getConfig().requestHook;
+      n &&
+        fr(
+          () => n(t, e),
+          (t) => {
+            t && this._diag.error("requestHook", t);
+          }
+        );
+    }
+    _prepareSpanData(t) {
+      const e = ke(),
+        n = [];
+      if ("function" != typeof PerformanceObserver)
+        return { entries: n, startTime: e, spanUrl: t };
+      const r = new PerformanceObserver((e) => {
+        e.getEntries().forEach((e) => {
+          "fetch" === e.initiatorType && e.name === t && n.push(e);
+        });
+      });
+      return (
+        r.observe({ entryTypes: ["resource"] }),
+        { entries: n, observer: r, startTime: e, spanUrl: t }
+      );
+    }
+    enable() {
+      no
+        ? this._diag.warn(
+            "this instrumentation is intended for web usage only, it does not instrument Node.js's fetch()"
+          )
+        : (gr(fetch) &&
+            (this._unwrap(pe, "fetch"),
+            this._diag.debug("removing previous patch for constructor")),
+          this._wrap(pe, "fetch", this._patchConstructor()));
+    }
+    disable() {
+      no || (this._unwrap(pe, "fetch"), (this._usedResources = new WeakSet()));
+    }
+  }
+  var oo;
+  !(function (t) {
+    (t.METHOD_OPEN = "open"),
+      (t.METHOD_SEND = "send"),
+      (t.EVENT_ABORT = "abort"),
+      (t.EVENT_ERROR = "error"),
+      (t.EVENT_LOAD = "loaded"),
+      (t.EVENT_TIMEOUT = "timeout");
+  })(oo || (oo = {}));
+  const io = Lt.createComponentLogger({
+    namespace:
+      "@opentelemetry/opentelemetry-instrumentation-xml-http-request/utils",
+  });
+  function so(t) {
+    return (
+      (e = t),
+      "undefined" != typeof Document && e instanceof Document
+        ? new XMLSerializer().serializeToString(document).length
+        : "string" == typeof t
+        ? uo(t)
+        : t instanceof Blob
+        ? t.size
+        : t instanceof FormData
+        ? (function (t) {
+            let e = 0;
+            for (const [n, r] of t.entries())
+              (e += n.length),
+                r instanceof Blob ? (e += r.size) : (e += r.length);
+            return e;
+          })(t)
+        : t instanceof URLSearchParams
+        ? uo(t.toString())
+        : void 0 !== t.byteLength
+        ? t.byteLength
+        : void io.warn("unknown body type")
+    );
+    var e;
+  }
+  const ao = new TextEncoder();
+  function uo(t) {
+    return ao.encode(t).byteLength;
+  }
+  const co = "0.200.0";
+  var lo;
+  !(function (t) {
+    t.HTTP_STATUS_TEXT = "http.status_text";
+  })(lo || (lo = {}));
+  class po extends hr {
+    component = "xml-http-request";
+    version = co;
+    moduleName = this.component;
+    _tasksCount = 0;
+    _xhrMem = new WeakMap();
+    _usedResources = new WeakSet();
+    constructor(t = {}) {
+      super("@opentelemetry/instrumentation-xml-http-request", co, t);
+    }
+    init() {}
+    _addHeaders(t, e) {
+      if (!Xr(Wr(e).href, this.getConfig().propagateTraceHeaderCorsUrls)) {
+        const t = {};
+        return (
+          qt.inject(Pt.active(), t),
+          void (
+            Object.keys(t).length > 0 &&
+            this._diag.debug("headers inject skipped due to CORS policy")
+          )
+        );
+      }
+      const n = {};
+      qt.inject(Pt.active(), n),
+        Object.keys(n).forEach((e) => {
+          t.setRequestHeader(e, String(n[e]));
+        });
+    }
+    _addChildSpan(t, e) {
+      Pt.with(Kt.setSpan(Pt.active(), t), () => {
+        const t = this.tracer.startSpan("CORS Preflight", {
+          startTime: e[Br.FETCH_START],
+        });
+        qr(t, e, this.getConfig().ignoreNetworkEvents),
+          t.end(e[Br.RESPONSE_END]);
+      });
+    }
+    _addFinalSpanAttributes(t, e, n) {
+      if ("string" == typeof n) {
+        const r = Wr(n);
+        void 0 !== e.status && t.setAttribute(ye, e.status),
+          void 0 !== e.statusText &&
+            t.setAttribute(lo.HTTP_STATUS_TEXT, e.statusText),
+          t.setAttribute(_e, r.host),
+          t.setAttribute(ve, r.protocol.replace(":", "")),
+          t.setAttribute(Se, navigator.userAgent);
+      }
+    }
+    _applyAttributesAfterXHR(t, e) {
+      const n = this.getConfig().applyCustomAttributesOnSpan;
+      "function" == typeof n &&
+        fr(
+          () => n(t, e),
+          (t) => {
+            t && this._diag.error("applyCustomAttributesOnSpan", t);
+          }
+        );
+    }
+    _addResourceObserver(t, e) {
+      const n = this._xhrMem.get(t);
+      n &&
+        "function" == typeof PerformanceObserver &&
+        "function" == typeof PerformanceResourceTiming &&
+        ((n.createdResources = {
+          observer: new PerformanceObserver((t) => {
+            const r = t.getEntries(),
+              o = Wr(e);
+            r.forEach((t) => {
+              "xmlhttprequest" === t.initiatorType &&
+                t.name === o.href &&
+                n.createdResources &&
+                n.createdResources.entries.push(t);
+            });
+          }),
+          entries: [],
+        }),
+        n.createdResources.observer.observe({ entryTypes: ["resource"] }));
+    }
+    _clearResources() {
+      0 === this._tasksCount &&
+        this.getConfig().clearTimingResources &&
+        (de.clearResourceTimings(),
+        (this._xhrMem = new WeakMap()),
+        (this._usedResources = new WeakSet()));
+    }
+    _findResourceAndAddNetworkEvents(t, e, n, r, o) {
+      if (!(n && r && o && t.createdResources)) return;
+      let i = t.createdResources.entries;
+      (i && i.length) || (i = de.getEntriesByType("resource"));
+      const s = Kr(Wr(n).href, r, o, i, this._usedResources);
+      if (s.mainRequest) {
+        const t = s.mainRequest;
+        this._markResourceAsUsed(t);
+        const n = s.corsPreFlightRequest;
+        n && (this._addChildSpan(e, n), this._markResourceAsUsed(n)),
+          qr(e, t, this.getConfig().ignoreNetworkEvents);
+      }
+    }
+    _cleanPreviousSpanInformation(t) {
+      const e = this._xhrMem.get(t);
+      if (e) {
+        const n = e.callbackToRemoveEvents;
+        n && n(), this._xhrMem.delete(t);
+      }
+    }
+    _createSpan(t, e, n) {
+      if (An(e, this.getConfig().ignoreUrls))
+        return void this._diag.debug(
+          "ignoring span as url matches ignored url"
+        );
+      const r = n.toUpperCase(),
+        o = this.tracer.startSpan(r, {
+          kind: Ct.CLIENT,
+          attributes: { [ge]: n, [me]: Wr(e).toString() },
+        });
+      return (
+        o.addEvent(oo.METHOD_OPEN),
+        this._cleanPreviousSpanInformation(t),
+        this._xhrMem.set(t, { span: o, spanUrl: e }),
+        o
+      );
+    }
+    _markResourceAsUsed(t) {
+      this._usedResources.add(t);
+    }
+    _patchOpen() {
+      return (t) => {
+        const e = this;
+        return function (...n) {
+          const r = n[0],
+            o = n[1];
+          return e._createSpan(this, o, r), t.apply(this, n);
+        };
+      };
+    }
+    _patchSend() {
+      const t = this;
+      function e(e, n) {
+        const r = t._xhrMem.get(n);
+        if (!r) return;
+        (r.status = n.status),
+          (r.statusText = n.statusText),
+          t._xhrMem.delete(n),
+          r.span && t._applyAttributesAfterXHR(r.span, n);
+        const o = ke(),
+          i = Date.now();
+        setTimeout(() => {
+          !(function (e, n, r, o) {
+            const i = n.callbackToRemoveEvents;
+            "function" == typeof i && i();
+            const { span: s, spanUrl: a, sendStartTime: u } = n;
+            s &&
+              (t._findResourceAndAddNetworkEvents(n, s, a, u, r),
+              s.addEvent(e, o),
+              t._addFinalSpanAttributes(s, n, a),
+              s.end(o),
+              t._tasksCount--),
+              t._clearResources();
+          })(e, r, o, i);
+        }, 300);
+      }
+      function n() {
+        e(oo.EVENT_ERROR, this);
+      }
+      function r() {
+        e(oo.EVENT_ABORT, this);
+      }
+      function o() {
+        e(oo.EVENT_TIMEOUT, this);
+      }
+      function i() {
+        this.status < 299 ? e(oo.EVENT_LOAD, this) : e(oo.EVENT_ERROR, this);
+      }
+      return (e) =>
+        function (...s) {
+          const a = t._xhrMem.get(this);
+          if (!a) return e.apply(this, s);
+          const u = a.span,
+            c = a.spanUrl;
+          if (u && c) {
+            if (t.getConfig().measureRequestSize && s?.[0]) {
+              const t = so(s[0]);
+              void 0 !== t && u.setAttribute(be, t);
+            }
+            Pt.with(Kt.setSpan(Pt.active(), u), () => {
+              t._tasksCount++,
+                (a.sendStartTime = ke()),
+                u.addEvent(oo.METHOD_SEND),
+                this.addEventListener("abort", r),
+                this.addEventListener("error", n),
+                this.addEventListener("load", i),
+                this.addEventListener("timeout", o),
+                (a.callbackToRemoveEvents = () => {
+                  !(function (e) {
+                    e.removeEventListener("abort", r),
+                      e.removeEventListener("error", n),
+                      e.removeEventListener("load", i),
+                      e.removeEventListener("timeout", o);
+                    const s = t._xhrMem.get(e);
+                    s && (s.callbackToRemoveEvents = void 0);
+                  })(this),
+                    a.createdResources &&
+                      a.createdResources.observer.disconnect();
+                }),
+                t._addHeaders(this, c),
+                t._addResourceObserver(this, c);
+            });
+          }
+          return e.apply(this, s);
+        };
+    }
+    enable() {
+      this._diag.debug("applying patch to", this.moduleName, this.version),
+        gr(XMLHttpRequest.prototype.open) &&
+          (this._unwrap(XMLHttpRequest.prototype, "open"),
+          this._diag.debug("removing previous patch from method open")),
+        gr(XMLHttpRequest.prototype.send) &&
+          (this._unwrap(XMLHttpRequest.prototype, "send"),
+          this._diag.debug("removing previous patch from method send")),
+        this._wrap(XMLHttpRequest.prototype, "open", this._patchOpen()),
+        this._wrap(XMLHttpRequest.prototype, "send", this._patchSend());
+    }
+    disable() {
+      this._diag.debug("removing patch from", this.moduleName, this.version),
+        this._unwrap(XMLHttpRequest.prototype, "open"),
+        this._unwrap(XMLHttpRequest.prototype, "send"),
+        (this._tasksCount = 0),
+        (this._xhrMem = new WeakMap()),
+        (this._usedResources = new WeakSet());
+    }
+  }
+  class ho extends po {
+    constructor(t = {}) {
+      super(t);
+      this.parentCreateSpan = this._createSpan.bind(this);
+    }
+    _patchOpen() {
+      return (t) => {
+        const n = this;
+        return function (...r) {
+          try {
+            const t = r[0];
+            let o = e.getUrlFromResource(r[1]);
+            n.parentCreateSpan(this, o, t);
+          } catch (t) {
+            e.faro.internalLogger.error(t);
+          }
+          return t.apply(this, r);
+        };
+      };
+    }
+  }
+  function fo(t, e, n) {
+    go(t, n instanceof Error ? 0 : n.status);
+  }
+  function go(t, e) {
+    if (null == e) return;
+    (0 === e || (e >= 400 && e < 600)) && t.setStatus({ code: At.ERROR });
+  }
+  function mo(t) {
+    return (e, n, r) => {
+      fo(e, 0, r), null == t || t(e, n, r);
+    };
+  }
+  function _o(t) {
+    return (e, n) => {
+      !(function (t, e) {
+        go(t, e.status);
+      })(e, n),
+        null == t || t(e, n);
+    };
+  }
+  function vo(t = {}) {
+    const { fetchInstrumentationOptions: e, xhrInstrumentationOptions: n } = t,
+      r = (function (t, e) {
+        var n = {};
+        for (var r in t)
+          Object.prototype.hasOwnProperty.call(t, r) &&
+            e.indexOf(r) < 0 &&
+            (n[r] = t[r]);
+        if (null != t && "function" == typeof Object.getOwnPropertySymbols) {
+          var o = 0;
+          for (r = Object.getOwnPropertySymbols(t); o < r.length; o++)
+            e.indexOf(r[o]) < 0 &&
+              Object.prototype.propertyIsEnumerable.call(t, r[o]) &&
+              (n[r[o]] = t[r[o]]);
+        }
+        return n;
+      })(t, ["fetchInstrumentationOptions", "xhrInstrumentationOptions"]),
+      o = (function (t, e) {
+        return Object.assign(
+          Object.assign(
+            Object.assign(Object.assign({}, e), { ignoreNetworkEvents: !0 }),
+            t
+          ),
+          {
+            applyCustomAttributesOnSpan: mo(
+              null == t ? void 0 : t.applyCustomAttributesOnSpan
+            ),
+          }
+        );
+      })(e, r),
+      i = (function (t, e) {
+        return Object.assign(
+          Object.assign(
+            Object.assign(Object.assign({}, e), { ignoreNetworkEvents: !0 }),
+            t
+          ),
+          {
+            applyCustomAttributesOnSpan: _o(
+              null == t ? void 0 : t.applyCustomAttributesOnSpan
+            ),
+          }
+        );
+      })(n, r);
+    return [new ro(o), new ho(i)];
+  }
+  class yo {
+    constructor(t, e) {
+      (this.processor = t), (this.metas = e);
+    }
+    forceFlush() {
+      return this.processor.forceFlush();
+    }
+    onStart(t, e) {
+      var n;
+      const r = this.metas.value.session;
+      (null == r ? void 0 : r.id) &&
+        ((t.attributes[Zn] = r.id), (t.attributes.session_id = r.id));
+      const o = null !== (n = this.metas.value.user) && void 0 !== n ? n : {};
+      o.email && (t.attributes["user.email"] = o.email),
+        o.id && (t.attributes["user.id"] = o.id),
+        o.username && (t.attributes["user.name"] = o.username),
+        o.fullName && (t.attributes["user.full_name"] = o.fullName),
+        o.roles &&
+          (t.attributes["user.roles"] = o.roles
+            .split(",")
+            .map((t) => t.trim())),
+        o.hash && (t.attributes["user.hash"] = o.hash),
+        this.processor.onStart(t, e);
+    }
+    onEnd(t) {
+      this.processor.onEnd(t);
+    }
+    shutdown() {
+      return this.processor.shutdown();
+    }
+  }
+  class So {
+    constructor(t) {
+      (this.processor = t),
+        e.apiMessageBus.subscribe((t) => {
+          t.type !== e.USER_ACTION_START
+            ? [e.USER_ACTION_END, e.USER_ACTION_CANCEL].includes(t.type) &&
+              (this.message = void 0)
+            : (this.message = t);
+        });
+    }
+    forceFlush() {
+      return this.processor.forceFlush();
+    }
+    onStart(t, e) {
+      var n, r;
+      t.kind === Ct.CLIENT &&
+        this.message &&
+        ((t.attributes["faro.action.user.name"] =
+          null === (n = this.message) || void 0 === n ? void 0 : n.name),
+        (t.attributes["faro.action.user.parentId"] =
+          null === (r = this.message) || void 0 === r ? void 0 : r.parentId)),
+        this.processor.onStart(t, e);
+    }
+    onEnd(t) {
+      this.processor.onEnd(t);
+    }
+    shutdown() {
+      return this.processor.shutdown();
+    }
+  }
+  function bo(t = {}) {
+    var e;
+    return "true" ===
+      (null === (e = t.attributes) || void 0 === e ? void 0 : e.isSampled)
+      ? br.RECORD_AND_SAMPLED
+      : br.NOT_RECORD;
+  }
+  class Eo extends e.BaseInstrumentation {
+    constructor(t = {}) {
+      super(),
+        (this.options = t),
+        (this.name = "@grafana/faro-web-tracing"),
+        (this.version = e.VERSION);
+    }
+    initialize() {
+      var t, e, n, r;
+      const o = this.options,
+        i = {};
+      this.config.app.name && (i[Ae] = this.config.app.name),
+        this.config.app.namespace &&
+          (i["service.namespace"] = this.config.app.namespace),
+        this.config.app.version &&
+          (i["service.version"] = this.config.app.version),
+        this.config.app.environment &&
+          ((i["deployment.environment.name"] = this.config.app.environment),
+          (i["deployment.environment"] = this.config.app.environment)),
+        Object.assign(i, o.resourceAttributes);
+      const s = yr().merge(vr(i));
+      new Vr({
+        resource: s,
+        sampler: {
+          shouldSample: () => ({ decision: bo(this.api.getSession()) }),
+        },
+        spanProcessors: [
+          null !== (t = o.spanProcessor) && void 0 !== t
+            ? t
+            : new So(
+                new yo(
+                  new Lr(new Yn({ api: this.api }), {
+                    scheduledDelayMillis: Eo.SCHEDULED_BATCH_DELAY_MS,
+                    maxExportBatchSize: 30,
+                  }),
+                  this.metas
+                )
+              ),
+        ],
+      }).register({
+        propagator: null !== (e = o.propagator) && void 0 !== e ? e : new tn(),
+        contextManager: o.contextManager,
+      });
+      const {
+        propagateTraceHeaderCorsUrls: a,
+        fetchInstrumentationOptions: u,
+        xhrInstrumentationOptions: c,
+      } = null !== (n = this.options.instrumentationOptions) && void 0 !== n
+        ? n
+        : {};
+      !(function (t) {
+        const e = t.tracerProvider || Kt.getTracerProvider(),
+          n = t.meterProvider || Mt.getMeterProvider(),
+          r = t.loggerProvider || ur.getLoggerProvider(),
+          o = t.instrumentations?.flat() ?? [];
+        (function (t, e, n, r) {
+          for (let o = 0, i = t.length; o < i; o++) {
+            const i = t[o];
+            e && i.setTracerProvider(e),
+              n && i.setMeterProvider(n),
+              r && i.setLoggerProvider && i.setLoggerProvider(r),
+              i.getConfig().enabled || i.enable();
+          }
+        })(o, e, n, r);
+      })({
+        instrumentations:
+          null !== (r = o.instrumentations) && void 0 !== r
+            ? r
+            : vo({
+                ignoreUrls: this.getIgnoreUrls(),
+                propagateTraceHeaderCorsUrls: a,
+                fetchInstrumentationOptions: u,
+                xhrInstrumentationOptions: c,
+              }),
+      }),
+        this.api.initOTEL(Kt, Pt);
+    }
+    getIgnoreUrls() {
+      return this.transports.transports.flatMap((t) => t.getIgnoreUrls());
+    }
+  }
+  return (
+    (Eo.SCHEDULED_BATCH_DELAY_MS = 1e3),
+    (t.FaroSessionSpanProcessor = class {
+      constructor(t, e) {
+        (this.processor = t), (this.metas = e);
+      }
+      forceFlush() {
+        return this.processor.forceFlush();
+      }
+      onStart(t, e) {
+        const n = this.metas.value.session;
+        (null == n ? void 0 : n.id) &&
+          ((t.attributes[Zn] = n.id), (t.attributes.session_id = n.id)),
+          this.processor.onStart(t, e);
+      }
+      onEnd(t) {
+        this.processor.onEnd(t);
+      }
+      shutdown() {
+        return this.processor.shutdown();
+      }
+    }),
+    (t.FaroTraceExporter = Yn),
+    (t.TracingInstrumentation = Eo),
+    (t.fetchCustomAttributeFunctionWithDefaults = mo),
+    (t.getDefaultOTELInstrumentations = vo),
+    (t.getSamplingDecision = bo),
+    (t.setSpanStatusOnFetchError = fo),
+    t
+  );
+};
+
+export default GrafanaFaroWebTracing;

--- a/export/index.template.html
+++ b/export/index.template.html
@@ -75,6 +75,33 @@
         display: none;
       }
     </style>
+    <script type="module">
+      import GrafanaFaroWebSdk from "./grafana-faro-web-sdk.js";
+      import GrafanaFaroWebTracing from "./grafana-faro-web-tracing.js";
+
+      // set environment based on the host
+      let environment = "development";
+      const host = window.location.host;
+      if (host === "export.turnkey.com") {
+        environment = "production";
+      } else if (host === "export.preprod.turnkey.engineering") {
+        environment = "preprod";
+      }
+
+      const faro = GrafanaFaroWebSdk.initializeFaro({
+        url: "https://faro-collector-prod-us-central-0.grafana.net/collect/bf8d63dd821600ed07d42e3329d88d0c",
+        app: {
+          name: "wallet-export",
+          version: "1.0.0",
+          environment: environment,
+        },
+        trackGeolocation: false,
+      });
+
+      const grafanaTracing = GrafanaFaroWebTracing({}, GrafanaFaroWebSdk);
+
+      faro.instrumentations.add(new grafanaTracing.TracingInstrumentation());
+    </script>
   </head>
 
   <body>
@@ -324,7 +351,9 @@
             hexString.length % 2 != 0 ||
             !hexRegex.test(hexString)
           ) {
-            throw new Error("cannot create uint8array from invalid hex string");
+            const errorMessage = `cannot create uint8array from invalid hex string: ${hexString}`;
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
           return new Uint8Array(
             hexString.match(/../g).map((h) => parseInt(h, 16))
@@ -369,9 +398,9 @@
             }
             // Check if the number of zeros found equals the number of zeroes expected
             if (zeroCount !== expectedZeroCount) {
-              throw new Error(
-                `invalid number of starting zeroes. Expected number of zeroes: ${expectedZeroCount}. Found: ${zeroCount}.`
-              );
+              const errorMessage = `invalid number of starting zeroes. Expected number of zeroes: ${expectedZeroCount}. Found: ${zeroCount}.`;
+              reportError(errorMessage);
+              throw new Error(errorMessage);
             }
             return byteArray.slice(
               expectedZeroCount,
@@ -401,9 +430,10 @@
 
           // Parse 'r' and check for integer tag (0x02)
           if (derSignatureBuf[index] !== 0x02) {
-            throw new Error(
-              "failed to convert DER-encoded signature: invalid tag for r"
-            );
+            const errorMessage =
+              "failed to convert DER-encoded signature: invalid tag for r";
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
           index++; // Move past the INTEGER tag
           const rLength = derSignatureBuf[index];
@@ -413,9 +443,10 @@
 
           // Parse 's' and check for integer tag (0x02)
           if (derSignatureBuf[index] !== 0x02) {
-            throw new Error(
-              "failed to convert DER-encoded signature: invalid tag for s"
-            );
+            const errorMessage =
+              "failed to convert DER-encoded signature: invalid tag for s";
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
           index++; // Move past the INTEGER tag
           const sLength = derSignatureBuf[index];
@@ -450,9 +481,10 @@
           const TURNKEY_SIGNER_ENCLAVE_QUORUM_PUBLIC_KEY =
             TURNKEY_SIGNERS_ENCLAVES["${TURNKEY_SIGNER_ENVIRONMENT}"];
           if (TURNKEY_SIGNER_ENCLAVE_QUORUM_PUBLIC_KEY === undefined) {
-            throw new Error(
-              "Configuration error: TURNKEY_SIGNER_ENCLAVE_QUORUM_PUBLIC_KEY is undefined"
-            );
+            const errorMessage =
+              "failed to verify enclave signature: TURNKEY_SIGNER_ENCLAVE_QUORUM_PUBLIC_KEY is undefined";
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
 
           // todo(olivia): throw error if enclave quorum public is null once server changes are deployed
@@ -460,9 +492,9 @@
             if (
               enclaveQuorumPublic !== TURNKEY_SIGNER_ENCLAVE_QUORUM_PUBLIC_KEY
             ) {
-              throw new Error(
-                `enclave quorum public keys from client and bundle do not match. Client: ${TURNKEY_SIGNER_ENCLAVE_QUORUM_PUBLIC_KEY}. Bundle: ${enclaveQuorumPublic}.`
-              );
+              const errorMessage = `enclave quorum public keys from client and bundle do not match. Client: ${TURNKEY_SIGNER_ENCLAVE_QUORUM_PUBLIC_KEY}. Bundle: ${enclaveQuorumPublic}.`;
+              reportError(errorMessage);
+              throw new Error(errorMessage);
             }
           }
 
@@ -471,7 +503,9 @@
           );
           const quorumKey = await loadQuorumKey(encryptionQuorumPublicBuf);
           if (!quorumKey) {
-            throw new Error("failed to load quorum key");
+            const errorMessage = `failed to load quorum key: ${TURNKEY_SIGNER_ENCLAVE_QUORUM_PUBLIC_KEY}`;
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
 
           // The ECDSA signature is ASN.1 DER encoded but WebCrypto uses raw format
@@ -499,6 +533,14 @@
          * @param requestId serves as an idempotency key to match incoming requests. Backwards compatible: if not provided, it isn't passed in.
          */
         function sendMessageUp(type, value, requestId) {
+          if (type === "ERROR") {
+            window.faro?.api?.pushError([value], {
+              context: {
+                requestId: requestId,
+              },
+              level: "error",
+            });
+          }
           const message = {
             type: type,
             value: value,
@@ -532,6 +574,15 @@
           message.innerText = content;
           messageLog.appendChild(message);
         }
+
+        /**
+         * Function to report errors to Grafana Faro.
+         */
+        var reportError = function (errorMessage) {
+          window.faro?.api?.pushError([errorMessage], {
+            level: "error",
+          });
+        };
 
         /**
          * Convert a JSON Web Key private key to a public key and export the public
@@ -607,9 +658,9 @@
           var leadingZeros = [];
           for (var i = 0; i < s.length; i++) {
             if (alphabet.indexOf(s[i]) === -1) {
-              throw new Error(
-                `cannot base58-decode: ${s[i]} isn't a valid character`
-              );
+              const errorMessage = `cannot base58-decode: ${s[i]} isn't a valid character`;
+              reportError(errorMessage);
+              throw new Error(errorMessage);
             }
             var carry = alphabet.indexOf(s[i]);
 
@@ -655,19 +706,20 @@
           switch (keyFormat) {
             case "SOLANA":
               if (!publicKeyBytes) {
-                throw new Error(
-                  "public key must be specified for SOLANA key format"
-                );
+                const errorMessage =
+                  "public key must be specified for SOLANA key format";
+                reportError(errorMessage);
+                throw new Error(errorMessage);
               }
               if (privateKeyBytes.length !== 32) {
-                throw new Error(
-                  `invalid private key length. Expected 32 bytes. Got ${privateKeyBytes.length}.`
-                );
+                const errorMessage = `invalid private key length. Expected 32 bytes. Got ${privateKeyBytes.length}.`;
+                reportError(errorMessage);
+                throw new Error(errorMessage);
               }
               if (publicKeyBytes.length !== 32) {
-                throw new Error(
-                  `invalid public key length. Expected 32 bytes. Got ${publicKeyBytes.length}.`
-                );
+                const errorMessage = `invalid public key length. Expected 32 bytes. Got ${publicKeyBytes.length}.`;
+                reportError(errorMessage);
+                throw new Error(errorMessage);
               }
               const concatenatedBytes = new Uint8Array(64);
               concatenatedBytes.set(privateKeyBytes, 0);
@@ -765,24 +817,28 @@
           Object.entries(styles).forEach(([property, value]) => {
             const styleProperty = property.trim();
             if (styleProperty.length === 0) {
-              throw new Error("css style property cannot be empty");
+              const errorMessage = "css style property cannot be empty";
+              reportError(errorMessage);
+              throw new Error(errorMessage);
             }
             const styleRegexStr = cssValidationRegex[styleProperty];
             if (!styleRegexStr) {
-              throw new Error(
-                `invalid or unsupported css style property: "${styleProperty}"`
-              );
+              const errorMessage = `invalid or unsupported css style property: "${styleProperty}"`;
+              reportError(errorMessage);
+              throw new Error(errorMessage);
             }
             const styleRegex = new RegExp(styleRegexStr);
             const styleValue = value.trim();
             if (styleValue.length == 0) {
-              throw new Error(`css style for "${styleProperty}" is empty`);
+              const errorMessage = `css style value for "${styleProperty}" is empty`;
+              reportError(errorMessage);
+              throw new Error(errorMessage);
             }
             const isValidStyle = styleRegex.test(styleValue);
             if (!isValidStyle) {
-              throw new Error(
-                `invalid css style value for property "${styleProperty}"`
-              );
+              const errorMessage = `invalid css style value for property "${styleProperty}"`;
+              reportError(errorMessage);
+              throw new Error(errorMessage);
             }
             validStyles[styleProperty] = styleValue;
           });
@@ -806,9 +862,10 @@
             // Valid styles will be applied the "key-div" div HTML element.
             const keyDivTextarea = document.getElementById("key-div");
             if (!keyDivTextarea) {
-              throw new Error(
-                "no key-div HTML element found to apply settings to."
-              );
+              const errorMessage =
+                "no key-div HTML element found to apply settings to.";
+              reportError(errorMessage);
+              throw new Error(errorMessage);
             }
 
             // Validate, sanitize, and apply the styles to the "key-div" div element.
@@ -1070,82 +1127,94 @@
        * @param {string} organizationId
        */
       async function decryptBundle(bundle, organizationId) {
-        let encappedKeyBuf;
-        let ciphertextBuf;
-        let verified;
+        try {
+          let encappedKeyBuf;
+          let ciphertextBuf;
+          let verified;
 
-        // Parse the import bundle
-        const bundleObj = JSON.parse(bundle);
-        switch (bundleObj.version) {
-          case "v1.0.0":
-            // Validate fields exist
-            if (!bundleObj.data) {
-              throw new Error('missing "data" in bundle');
-            }
-            if (!bundleObj.dataSignature) {
-              throw new Error('missing "dataSignature" in bundle');
-            }
-            if (!bundleObj.enclaveQuorumPublic) {
-              throw new Error('missing "enclaveQuorumPublic" in bundle');
-            }
+          // Parse the import bundle
+          const bundleObj = JSON.parse(bundle);
+          switch (bundleObj.version) {
+            case "v1.0.0":
+              // Validate fields exist
+              if (!bundleObj.data) {
+                throw new Error('missing "data" in bundle');
+              }
+              if (!bundleObj.dataSignature) {
+                throw new Error('missing "dataSignature" in bundle');
+              }
+              if (!bundleObj.enclaveQuorumPublic) {
+                throw new Error('missing "enclaveQuorumPublic" in bundle');
+              }
 
-            // Verify enclave signature
-            if (!TKHQ.verifyEnclaveSignature) {
-              throw new Error("method not loaded");
-            }
-            verified = await TKHQ.verifyEnclaveSignature(
-              bundleObj.enclaveQuorumPublic,
-              bundleObj.dataSignature,
-              bundleObj.data
-            );
-            if (!verified) {
-              throw new Error(`failed to verify enclave signature: ${bundle}`);
-            }
-
-            // Parse the signed data. The data is produced by JSON encoding followed by hex encoding. We reverse this here.
-            const signedData = JSON.parse(
-              new TextDecoder().decode(
-                TKHQ.uint8arrayFromHexString(bundleObj.data)
-              )
-            );
-
-            // Validate fields match
-            if (!organizationId) {
-              // todo: throw error if organization id is undefined once we've fully transitioned to v1.0.0 server messages and v2.0.0 iframe-stamper
-              console.warn(
-                'we highly recommend a version of @turnkey/iframe-stamper >= v2.0.0 to pass "organizationId" for security purposes.'
+              // Verify enclave signature
+              if (!TKHQ.verifyEnclaveSignature) {
+                throw new Error("method not loaded");
+              }
+              verified = await TKHQ.verifyEnclaveSignature(
+                bundleObj.enclaveQuorumPublic,
+                bundleObj.dataSignature,
+                bundleObj.data
               );
-            } else if (
-              !signedData.organizationId ||
-              signedData.organizationId !== organizationId
-            ) {
-              throw new Error(
-                `organization id does not match expected value. Expected: ${organizationId}. Found: ${signedData.organizationId}.`
-              );
-            }
+              if (!verified) {
+                throw new Error(
+                  `failed to verify enclave signature: ${bundle}`
+                );
+              }
 
-            if (!signedData.encappedPublic) {
-              throw new Error('missing "encappedPublic" in bundle signed data');
-            }
-            if (!signedData.ciphertext) {
-              throw new Error('missing "ciphertext" in bundle signed data');
-            }
-            encappedKeyBuf = TKHQ.uint8arrayFromHexString(
-              signedData.encappedPublic
-            );
-            ciphertextBuf = TKHQ.uint8arrayFromHexString(signedData.ciphertext);
-            break;
-          default:
-            throw new Error(`unsupported version: ${bundleObj.version}`);
+              // Parse the signed data. The data is produced by JSON encoding followed by hex encoding. We reverse this here.
+              const signedData = JSON.parse(
+                new TextDecoder().decode(
+                  TKHQ.uint8arrayFromHexString(bundleObj.data)
+                )
+              );
+
+              // Validate fields match
+              if (!organizationId) {
+                // todo: throw error if organization id is undefined once we've fully transitioned to v1.0.0 server messages and v2.0.0 iframe-stamper
+                console.warn(
+                  'we highly recommend a version of @turnkey/iframe-stamper >= v2.0.0 to pass "organizationId" for security purposes.'
+                );
+              } else if (
+                !signedData.organizationId ||
+                signedData.organizationId !== organizationId
+              ) {
+                throw new Error(
+                  `organization id does not match expected value. Expected: ${organizationId}. Found: ${signedData.organizationId}.`
+                );
+              }
+
+              if (!signedData.encappedPublic) {
+                throw new Error(
+                  'missing "encappedPublic" in bundle signed data'
+                );
+              }
+              if (!signedData.ciphertext) {
+                throw new Error('missing "ciphertext" in bundle signed data');
+              }
+              encappedKeyBuf = TKHQ.uint8arrayFromHexString(
+                signedData.encappedPublic
+              );
+              ciphertextBuf = TKHQ.uint8arrayFromHexString(
+                signedData.ciphertext
+              );
+              break;
+            default:
+              throw new Error(`unsupported version: ${bundleObj.version}`);
+          }
+
+          // Decrypt the ciphertext
+          const embeddedKeyJwk = await TKHQ.getEmbeddedKey();
+          return await HpkeDecrypt({
+            ciphertextBuf,
+            encappedKeyBuf,
+            receiverPrivJwk: embeddedKeyJwk,
+          });
+        } catch (e) {
+          const errorMessage = `failed to decrypt bundle: ${e.toString()}`;
+          reportError(e?.message || errorMessage);
+          throw new Error(e?.message || errorMessage);
         }
-
-        // Decrypt the ciphertext
-        const embeddedKeyJwk = await TKHQ.getEmbeddedKey();
-        return await HpkeDecrypt({
-          ciphertextBuf,
-          encappedKeyBuf,
-          receiverPrivJwk: embeddedKeyJwk,
-        });
       }
 
       /**
@@ -1267,10 +1336,9 @@
         try {
           res = await recipientCtx.open(ciphertextBuf, aad);
         } catch (e) {
-          throw new Error(
-            "unable to decrypt bundle using embedded key. the bundle may be incorrect. failed with error: " +
-              e.toString()
-          );
+          const errorMessage = `unable to decrypt bundle using embedded key. the bundle may be incorrect. failed with error: ${e.toString()}`;
+          reportError(errorMessage);
+          throw new Error(errorMessage);
         }
         return res;
       }

--- a/import/grafana-faro-web-sdk.js
+++ b/import/grafana-faro-web-sdk.js
@@ -1,0 +1,5329 @@
+// vendored @grafana/faro-web-sdk v1.18.1 https://unpkg.com/@grafana/faro-web-sdk@1.18.1/dist/bundle/faro-web-sdk.iife.js
+
+var GrafanaFaroWebSdk = (function (e) {
+  "use strict";
+  function t(e, t) {
+    return typeof e === t;
+  }
+  function n(e, t) {
+    return Object.prototype.toString.call(e) === `[object ${t}]`;
+  }
+  function i(e, t) {
+    try {
+      return e instanceof t;
+    } catch (e) {
+      return !1;
+    }
+  }
+  const r = (e) => t(e, "null"),
+    o = (e) => t(e, "string"),
+    s = (e) => (t(e, "number") && !isNaN(e)) || t(e, "bigint"),
+    a = (e) => t(e, "boolean"),
+    u = (e) => !r(e) && t(e, "object"),
+    c = (e) => t(e, "function"),
+    l = (e) => n(e, "Array"),
+    d = (e) => !u(e) && !c(e),
+    f = "undefined" != typeof Event,
+    p = (e) => f && i(e, Event),
+    g = "undefined" != typeof Error,
+    m = (e) => g && i(e, Error),
+    v = (e) => n(e, "ErrorEvent"),
+    h = (e) => n(e, "DOMError"),
+    b = (e) => n(e, "DOMException"),
+    w = "undefined" != typeof Element,
+    y = "undefined" != typeof Map;
+  function S(e) {
+    return (
+      null == e ||
+      (l(e) || o(e) ? 0 === e.length : !!u(e) && 0 === Object.keys(e).length)
+    );
+  }
+  function T(e, n) {
+    if (e === n) return !0;
+    if (t(e, "number") && isNaN(e)) return t(n, "number") && isNaN(n);
+    const i = l(e),
+      r = l(n);
+    if (i !== r) return !1;
+    if (i && r) {
+      const t = e.length;
+      if (t !== n.length) return !1;
+      for (let i = t; 0 != i--; ) if (!T(e[i], n[i])) return !1;
+      return !0;
+    }
+    const o = u(e),
+      s = u(n);
+    if (o !== s) return !1;
+    if (e && n && o && s) {
+      const t = Object.keys(e),
+        i = Object.keys(n);
+      if (t.length !== i.length) return !1;
+      for (let e of t) if (!i.includes(e)) return !1;
+      for (let i of t) if (!T(e[i], n[i])) return !1;
+      return !0;
+    }
+    return !1;
+  }
+  function E() {
+    return Date.now();
+  }
+  function I() {
+    return new Date().toISOString();
+  }
+  function k(e) {
+    return new Date(e).toISOString();
+  }
+  var O;
+  (e.LogLevel = void 0),
+    ((O = e.LogLevel || (e.LogLevel = {})).TRACE = "trace"),
+    (O.DEBUG = "debug"),
+    (O.INFO = "info"),
+    (O.LOG = "log"),
+    (O.WARN = "warn"),
+    (O.ERROR = "error");
+  const x = e.LogLevel.LOG,
+    L = [
+      e.LogLevel.TRACE,
+      e.LogLevel.DEBUG,
+      e.LogLevel.INFO,
+      e.LogLevel.LOG,
+      e.LogLevel.WARN,
+      e.LogLevel.ERROR,
+    ];
+  function C() {}
+  function A(e) {
+    const { size: t, concurrency: n } = e,
+      i = [];
+    let r = 0;
+    const o = () => {
+      if (r < n && i.length) {
+        const { producer: e, resolve: t, reject: n } = i.shift();
+        r++,
+          e().then(
+            (e) => {
+              r--, o(), t(e);
+            },
+            (e) => {
+              r--, o(), n(e);
+            }
+          );
+      }
+    };
+    return {
+      add: (e) => {
+        if (i.length + r >= t) throw new Error("Task buffer full");
+        return new Promise((t, n) => {
+          i.push({ producer: e, resolve: t, reject: n }), o();
+        });
+      },
+    };
+  }
+  const P = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ0123456789";
+  function M(e = 10) {
+    return Array.from(Array(e))
+      .map(() => P[Math.floor(Math.random() * P.length)])
+      .join("");
+  }
+  const j =
+    "undefined" != typeof globalThis
+      ? globalThis
+      : "undefined" != typeof global
+      ? global
+      : "undefined" != typeof self
+      ? self
+      : void 0;
+  function N(e = {}) {
+    return JSON.stringify(
+      null != e ? e : {},
+      (function () {
+        const e = new WeakSet();
+        return function (t, n) {
+          if (u(n) && null !== n) {
+            if (e.has(n)) return null;
+            e.add(n);
+          }
+          return n;
+        };
+      })()
+    );
+  }
+  function _(e = {}) {
+    const t = {};
+    for (const [n, i] of Object.entries(e))
+      t[n] = u(i) && null !== i ? N(i) : String(i);
+    return t;
+  }
+  class D {
+    constructor() {
+      this.subscribers = [];
+    }
+    subscribe(e) {
+      return (
+        this.subscribers.push(e), { unsubscribe: () => this.unsubscribe(e) }
+      );
+    }
+    unsubscribe(e) {
+      this.subscribers = this.subscribers.filter((t) => t !== e);
+    }
+    notify(e) {
+      this.subscribers.forEach((t) => t(e));
+    }
+    first() {
+      const e = new D(),
+        t = (t) => {
+          e.notify(t), n.unsubscribe();
+        },
+        n = this.subscribe(t),
+        i = e.unsubscribe.bind(e);
+      return this.withUnsubscribeOverride(e, i, t);
+    }
+    takeWhile(e) {
+      const t = new D(),
+        n = (i) => {
+          e(i) ? t.notify(i) : t.unsubscribe(n);
+        };
+      this.subscribe(n);
+      const i = t.unsubscribe.bind(t);
+      return this.withUnsubscribeOverride(t, i, n);
+    }
+    filter(e) {
+      const t = new D(),
+        n = (n) => {
+          e(n) && t.notify(n);
+        };
+      this.subscribe(n);
+      const i = t.unsubscribe.bind(t);
+      return this.withUnsubscribeOverride(t, i, n);
+    }
+    merge(...e) {
+      const t = new D(),
+        n = [];
+      e.forEach((e) => {
+        const i = e.subscribe((e) => {
+          t.notify(e);
+        });
+        n.push(i);
+      });
+      const i = t.unsubscribeAll.bind(t);
+      return (
+        (t.unsubscribe = () => {
+          n.forEach((e) => e.unsubscribe()), i();
+        }),
+        t
+      );
+    }
+    withUnsubscribeOverride(e, t, n) {
+      return (
+        (e.unsubscribe = (e) => {
+          t(e), this.unsubscribe(n);
+        }),
+        e
+      );
+    }
+    unsubscribeAll() {
+      this.subscribers = [];
+    }
+  }
+  class R {
+    constructor(e, t) {
+      var n, i;
+      (this.signalBuffer = []),
+        (this.itemLimit =
+          null !== (n = null == t ? void 0 : t.itemLimit) && void 0 !== n
+            ? n
+            : 50),
+        (this.sendTimeout =
+          null !== (i = null == t ? void 0 : t.sendTimeout) && void 0 !== i
+            ? i
+            : 250),
+        (this.paused = (null == t ? void 0 : t.paused) || !1),
+        (this.sendFn = e),
+        (this.flushInterval = -1),
+        this.paused || this.start(),
+        document.addEventListener("visibilitychange", () => {
+          "hidden" === document.visibilityState && this.flush();
+        });
+    }
+    addItem(e) {
+      this.paused ||
+        (this.signalBuffer.push(e),
+        this.signalBuffer.length >= this.itemLimit && this.flush());
+    }
+    start() {
+      (this.paused = !1),
+        this.sendTimeout > 0 &&
+          (this.flushInterval = window.setInterval(
+            () => this.flush(),
+            this.sendTimeout
+          ));
+    }
+    pause() {
+      (this.paused = !0), clearInterval(this.flushInterval);
+    }
+    groupItems(e) {
+      const t = new Map();
+      return (
+        e.forEach((e) => {
+          const n = JSON.stringify(e.meta);
+          let i = t.get(n);
+          (i = void 0 === i ? [e] : [...i, e]), t.set(n, i);
+        }),
+        Array.from(t.values())
+      );
+    }
+    flush() {
+      if (this.paused || 0 === this.signalBuffer.length) return;
+      this.groupItems(this.signalBuffer).forEach(this.sendFn),
+        (this.signalBuffer = []);
+    }
+  }
+  var U;
+  (e.TransportItemType = void 0),
+    ((U = e.TransportItemType || (e.TransportItemType = {})).EXCEPTION =
+      "exception"),
+    (U.LOG = "log"),
+    (U.MEASUREMENT = "measurement"),
+    (U.TRACE = "trace"),
+    (U.EVENT = "event");
+  const B = {
+    [e.TransportItemType.EXCEPTION]: "exceptions",
+    [e.TransportItemType.LOG]: "logs",
+    [e.TransportItemType.MEASUREMENT]: "measurements",
+    [e.TransportItemType.TRACE]: "traces",
+    [e.TransportItemType.EVENT]: "events",
+  };
+  function F(e, t, n, i) {
+    var r;
+    t.debug("Initializing transports");
+    const o = [];
+    let s = n.paused,
+      a = [];
+    const u = (e) => {
+        let t = e;
+        for (const e of a) {
+          const i = t.map(e).filter(Boolean);
+          if (0 === i.length) return [];
+          t = z(i, n);
+        }
+        return t;
+      },
+      c = (e) => {
+        const n = u(e);
+        if (0 !== n.length)
+          for (const e of o)
+            t.debug(`Transporting item using ${e.name}\n`, n),
+              e.isBatched() && e.send(n);
+      };
+    let l;
+    (null === (r = n.batching) || void 0 === r ? void 0 : r.enabled) &&
+      (l = new R(c, {
+        sendTimeout: n.batching.sendTimeout,
+        itemLimit: n.batching.itemLimit,
+        paused: s,
+      }));
+    return {
+      add: (...r) => {
+        t.debug("Adding transports"),
+          r.forEach((r) => {
+            t.debug(`Adding "${r.name}" transport`);
+            o.some((e) => e === r)
+              ? t.warn(`Transport ${r.name} is already added`)
+              : ((r.unpatchedConsole = e),
+                (r.internalLogger = t),
+                (r.config = n),
+                (r.metas = i),
+                o.push(r));
+          });
+      },
+      addBeforeSendHooks: (...e) => {
+        t.debug("Adding beforeSendHooks\n", a),
+          e.forEach((e) => {
+            e && a.push(e);
+          });
+      },
+      getBeforeSendHooks: () => [...a],
+      execute: (e) => {
+        var i;
+        s ||
+          ((null === (i = n.batching) || void 0 === i ? void 0 : i.enabled) &&
+            (null == l || l.addItem(e)),
+          ((e) => {
+            var i, r;
+            if (
+              (null === (i = n.batching) || void 0 === i
+                ? void 0
+                : i.enabled) &&
+              o.every((e) => e.isBatched())
+            )
+              return;
+            const [s] = u([e]);
+            if (void 0 !== s)
+              for (const e of o)
+                t.debug(`Transporting item using ${e.name}\n`, s),
+                  e.isBatched()
+                    ? (null === (r = n.batching) || void 0 === r
+                        ? void 0
+                        : r.enabled) || e.send([s])
+                    : e.send(s);
+          })(e));
+      },
+      isPaused: () => s,
+      pause: () => {
+        t.debug("Pausing transports"), null == l || l.pause(), (s = !0);
+      },
+      remove: (...e) => {
+        t.debug("Removing transports"),
+          e.forEach((e) => {
+            t.debug(`Removing "${e.name}" transport`);
+            const n = o.indexOf(e);
+            -1 !== n
+              ? o.splice(n, 1)
+              : t.warn(`Transport "${e.name}" is not added`);
+          });
+      },
+      removeBeforeSendHooks: (...e) => {
+        a.filter((t) => !e.includes(t));
+      },
+      get transports() {
+        return [...o];
+      },
+      unpause: () => {
+        t.debug("Unpausing transports"), null == l || l.start(), (s = !1);
+      },
+    };
+  }
+  function z(t, n) {
+    if (n.preserveOriginalError)
+      for (const n of t)
+        n.type === e.TransportItemType.EXCEPTION &&
+          delete n.payload.originalError;
+    return t;
+  }
+  var q;
+  (e.InternalLoggerLevel = void 0),
+    ((q = e.InternalLoggerLevel || (e.InternalLoggerLevel = {}))[(q.OFF = 0)] =
+      "OFF"),
+    (q[(q.ERROR = 1)] = "ERROR"),
+    (q[(q.WARN = 2)] = "WARN"),
+    (q[(q.INFO = 3)] = "INFO"),
+    (q[(q.VERBOSE = 4)] = "VERBOSE");
+  const V = { debug: C, error: C, info: C, prefix: "Faro", warn: C },
+    $ = e.InternalLoggerLevel.ERROR,
+    G = Object.assign({}, console);
+  let H = G;
+  function W(e) {
+    var t;
+    return (H = null !== (t = e.unpatchedConsole) && void 0 !== t ? t : H), H;
+  }
+  function K(t = G, n = $) {
+    const i = V;
+    return (
+      n > e.InternalLoggerLevel.OFF &&
+        ((i.error =
+          n >= e.InternalLoggerLevel.ERROR
+            ? function (...e) {
+                t.error(`${i.prefix}\n`, ...e);
+              }
+            : C),
+        (i.warn =
+          n >= e.InternalLoggerLevel.WARN
+            ? function (...e) {
+                t.warn(`${i.prefix}\n`, ...e);
+              }
+            : C),
+        (i.info =
+          n >= e.InternalLoggerLevel.INFO
+            ? function (...e) {
+                t.info(`${i.prefix}\n`, ...e);
+              }
+            : C),
+        (i.debug =
+          n >= e.InternalLoggerLevel.VERBOSE
+            ? function (...e) {
+                t.debug(`${i.prefix}\n`, ...e);
+              }
+            : C)),
+      i
+    );
+  }
+  let X = V;
+  function J(e, t) {
+    return (X = K(e, t.internalLoggerLevel)), X;
+  }
+  class Z {
+    constructor() {
+      (this.unpatchedConsole = G),
+        (this.internalLogger = V),
+        (this.config = {}),
+        (this.metas = {});
+    }
+    logDebug(...e) {
+      this.internalLogger.debug(`${this.name}\n`, ...e);
+    }
+    logInfo(...e) {
+      this.internalLogger.info(`${this.name}\n`, ...e);
+    }
+    logWarn(...e) {
+      this.internalLogger.warn(`${this.name}\n`, ...e);
+    }
+    logError(...e) {
+      this.internalLogger.error(`${this.name}\n`, ...e);
+    }
+  }
+  class Y extends Z {
+    isBatched() {
+      return !1;
+    }
+    getIgnoreUrls() {
+      return [];
+    }
+  }
+  function Q(e, t) {
+    var n, i;
+    if (void 0 === t) return e;
+    if (void 0 === e) return { resourceSpans: t };
+    const r = null === (n = e.resourceSpans) || void 0 === n ? void 0 : n[0];
+    if (void 0 === r) return e;
+    const o = (null == r ? void 0 : r.scopeSpans) || [],
+      s =
+        (null === (i = null == t ? void 0 : t[0]) || void 0 === i
+          ? void 0
+          : i.scopeSpans) || [];
+    return Object.assign(Object.assign({}, e), {
+      resourceSpans: [
+        Object.assign(Object.assign({}, r), { scopeSpans: [...o, ...s] }),
+      ],
+    });
+  }
+  function ee(t) {
+    let n = { meta: {} };
+    return (
+      void 0 !== t[0] && (n.meta = t[0].meta),
+      t.forEach((t) => {
+        switch (t.type) {
+          case e.TransportItemType.LOG:
+          case e.TransportItemType.EVENT:
+          case e.TransportItemType.EXCEPTION:
+          case e.TransportItemType.MEASUREMENT:
+            const i = B[t.type],
+              r = n[i];
+            n = Object.assign(Object.assign({}, n), {
+              [i]: void 0 === r ? [t.payload] : [...r, t.payload],
+            });
+            break;
+          case e.TransportItemType.TRACE:
+            n = Object.assign(Object.assign({}, n), {
+              traces: Q(n.traces, t.payload.resourceSpans),
+            });
+        }
+      }),
+      n
+    );
+  }
+  const te = "user-action-start",
+    ne = "user-action-end",
+    ie = "user-action-cancel",
+    re = "user-action-halt";
+  const oe = "Error",
+    se = (e) => e.map((e) => (u(e) ? N(e) : String(e))).join(" ");
+  let ae;
+  function ue({
+    internalLogger: t,
+    config: n,
+    metas: i,
+    transports: s,
+    tracesApi: a,
+    actionBuffer: c,
+    getMessage: d,
+  }) {
+    var f;
+    t.debug("Initializing exceptions API");
+    let p = null;
+    ae = null !== (f = n.parseStacktrace) && void 0 !== f ? f : ae;
+    const g = (e) => {
+        t.debug("Changing stacktrace parser"), (ae = null != e ? e : ae);
+      },
+      { ignoreErrors: v = [], preserveOriginalError: h } = n;
+    return (
+      g(n.parseStacktrace),
+      {
+        changeStacktraceParser: g,
+        getStacktraceParser: () => ae,
+        pushError: (
+          f,
+          {
+            skipDedupe: g,
+            stackFrames: b,
+            type: w,
+            context: y,
+            spanContext: E,
+            timestampOverwriteMs: O,
+            originalError: x,
+          } = {}
+        ) => {
+          if (
+            !(function (e, t) {
+              const { message: n, name: i, stack: r } = t;
+              return (
+                (s = e),
+                (a = n + " " + i + " " + r),
+                s.some((e) => (o(e) ? a.includes(e) : !!a.match(e)))
+              );
+              var s, a;
+            })(v, null != x ? x : f)
+          )
+            try {
+              const o = _(
+                  Object.assign(
+                    Object.assign(
+                      {},
+                      (function (e) {
+                        let t = e.cause;
+                        m(t)
+                          ? (t = e.cause.toString())
+                          : null !== t && (u(e.cause) || l(e.cause))
+                          ? (t = N(e.cause))
+                          : null != t && (t = e.cause.toString());
+                        return null == t ? {} : { cause: t };
+                      })(null != x ? x : f)
+                    ),
+                    null != y ? y : {}
+                  )
+                ),
+                v = {
+                  meta: i.value,
+                  payload: Object.assign(
+                    Object.assign(
+                      {
+                        type: w || f.name || oe,
+                        value: f.message,
+                        timestamp: O ? k(O) : I(),
+                        trace: E
+                          ? { trace_id: E.traceId, span_id: E.spanId }
+                          : a.getTraceContext(),
+                      },
+                      S(o) ? {} : { context: o }
+                    ),
+                    h ? { originalError: x } : {}
+                  ),
+                  type: e.TransportItemType.EXCEPTION,
+                };
+              (null ==
+              (b =
+                null != b
+                  ? b
+                  : f.stack
+                  ? null == ae
+                    ? void 0
+                    : ae(f).frames
+                  : void 0)
+                ? void 0
+                : b.length) && (v.payload.stacktrace = { frames: b });
+              const L = {
+                type: v.payload.type,
+                value: v.payload.value,
+                stackTrace: v.payload.stacktrace,
+                context: v.payload.context,
+              };
+              if (!g && n.dedupe && !r(p) && T(L, p))
+                return void t.debug(
+                  "Skipping error push because it is the same as the last one\n",
+                  v.payload
+                );
+              (p = L), t.debug("Pushing exception\n", v);
+              const C = d();
+              C && C.type === te ? c.addItem(v) : s.execute(v);
+            } catch (e) {
+              t.error("Error pushing event", e);
+            }
+        },
+      }
+    );
+  }
+  const ce = (e) =>
+    e
+      .map((e) => {
+        try {
+          return String(e);
+        } catch (e) {
+          return "";
+        }
+      })
+      .join(" ");
+  class le {
+    constructor() {
+      this.buffer = [];
+    }
+    addItem(e) {
+      this.buffer.push(e);
+    }
+    flushBuffer(e) {
+      if (c(e)) for (const t of this.buffer) e(t);
+      this.buffer.length = 0;
+    }
+    size() {
+      return this.buffer.length;
+    }
+  }
+  function de({ apiMessageBus: t, transports: n, config: i }) {
+    const r = new le(),
+      o = i.trackUserActionsExcludeItem;
+    let s;
+    t.subscribe((t) => {
+      if (te !== t.type && re !== t.type) {
+        if (t.type === ne) {
+          const { id: i, name: a } = t;
+          return (
+            r.flushBuffer((t) => {
+              if (
+                (function (t, n) {
+                  return (
+                    (null == n ? void 0 : n(t)) ||
+                    (t.type === e.TransportItemType.MEASUREMENT &&
+                      "web-vitals" === t.payload.type)
+                  );
+                })(t, o)
+              )
+                return void n.execute(t);
+              const r = Object.assign(Object.assign({}, t), {
+                payload: Object.assign(Object.assign({}, t.payload), {
+                  action: { parentId: i, name: a },
+                }),
+              });
+              n.execute(r);
+            }),
+            void (s = void 0)
+          );
+        }
+        t.type === ie &&
+          ((s = void 0),
+          r.flushBuffer((e) => {
+            n.execute(e);
+          }));
+      } else s = t;
+    });
+    return { actionBuffer: r, getMessage: () => s };
+  }
+  const fe = new D();
+  function pe(t, n, i, s, a) {
+    n.debug("Initializing API");
+    const { actionBuffer: u, getMessage: c } = de({
+        apiMessageBus: fe,
+        transports: a,
+        config: i,
+      }),
+      l = (function (t, n, i, r, o) {
+        let s;
+        return (
+          n.debug("Initializing traces API"),
+          {
+            getOTEL: () => s,
+            getTraceContext: () => {
+              const e =
+                null == s ? void 0 : s.trace.getSpanContext(s.context.active());
+              return e ? { trace_id: e.traceId, span_id: e.spanId } : void 0;
+            },
+            initOTEL: (e, t) => {
+              n.debug("Initializing OpenTelemetry"),
+                (s = { trace: e, context: t });
+            },
+            isOTELInitialized: () => !!s,
+            pushTraces: (t) => {
+              try {
+                const i = {
+                  type: e.TransportItemType.TRACE,
+                  payload: t,
+                  meta: r.value,
+                };
+                n.debug("Pushing trace\n", i), o.execute(i);
+              } catch (e) {
+                n.error("Error pushing trace\n", e);
+              }
+            },
+          }
+        );
+      })(0, n, 0, s, a),
+      d = {
+        unpatchedConsole: t,
+        internalLogger: n,
+        config: i,
+        metas: s,
+        transports: a,
+        tracesApi: l,
+        actionBuffer: u,
+        getMessage: c,
+      };
+    return Object.assign(
+      Object.assign(
+        Object.assign(
+          Object.assign(
+            Object.assign(Object.assign({}, l), ue(d)),
+            (function ({ internalLogger: e, metas: t }) {
+              let n, i, r, s;
+              e.debug("Initializing meta API");
+              const a = (e) => {
+                  i && t.remove(i), (i = { user: e }), t.add(i);
+                },
+                u = (e, i) => {
+                  var r;
+                  const o = null == i ? void 0 : i.overrides,
+                    s = o
+                      ? {
+                          overrides: Object.assign(
+                            Object.assign(
+                              {},
+                              null === (r = null == n ? void 0 : n.session) ||
+                                void 0 === r
+                                ? void 0
+                                : r.overrides
+                            ),
+                            o
+                          ),
+                        }
+                      : {};
+                  n && t.remove(n),
+                    (n = {
+                      session: Object.assign(
+                        Object.assign({}, S(e) ? void 0 : e),
+                        s
+                      ),
+                    }),
+                    t.add(n);
+                },
+                c = () => t.value.session,
+                l = () => t.value.page;
+              return {
+                setUser: a,
+                resetUser: a,
+                setSession: u,
+                resetSession: u,
+                getSession: c,
+                setView: (e, n) => {
+                  var i;
+                  if (
+                    ((null == n ? void 0 : n.overrides) &&
+                      u(c(), { overrides: n.overrides }),
+                    (null === (i = null == r ? void 0 : r.view) || void 0 === i
+                      ? void 0
+                      : i.name) === (null == e ? void 0 : e.name))
+                  )
+                    return;
+                  const o = r;
+                  (r = { view: e }), t.add(r), o && t.remove(o);
+                },
+                getView: () => t.value.view,
+                setPage: (e) => {
+                  var n;
+                  const i = o(e)
+                    ? Object.assign(
+                        Object.assign(
+                          {},
+                          null !== (n = null == s ? void 0 : s.page) &&
+                            void 0 !== n
+                            ? n
+                            : l()
+                        ),
+                        { id: e }
+                      )
+                    : e;
+                  s && t.remove(s), (s = { page: i }), t.add(s);
+                },
+                getPage: l,
+              };
+            })(d)
+          ),
+          (function ({
+            internalLogger: t,
+            config: n,
+            metas: i,
+            transports: o,
+            tracesApi: s,
+            actionBuffer: a,
+            getMessage: u,
+          }) {
+            var c;
+            t.debug("Initializing logs API");
+            let l = null;
+            const d =
+              null !== (c = n.logArgsSerializer) && void 0 !== c ? c : ce;
+            return {
+              pushLog: (
+                c,
+                {
+                  context: f,
+                  level: p,
+                  skipDedupe: g,
+                  spanContext: m,
+                  timestampOverwriteMs: v,
+                } = {}
+              ) => {
+                try {
+                  const h = _(f),
+                    b = {
+                      type: e.TransportItemType.LOG,
+                      payload: {
+                        message: d(c),
+                        level: null != p ? p : x,
+                        context: S(h) ? void 0 : h,
+                        timestamp: v ? k(v) : I(),
+                        trace: m
+                          ? { trace_id: m.traceId, span_id: m.spanId }
+                          : s.getTraceContext(),
+                      },
+                      meta: i.value,
+                    },
+                    w = {
+                      message: b.payload.message,
+                      level: b.payload.level,
+                      context: b.payload.context,
+                    };
+                  if (!g && n.dedupe && !r(l) && T(w, l))
+                    return void t.debug(
+                      "Skipping log push because it is the same as the last one\n",
+                      b.payload
+                    );
+                  (l = w), t.debug("Pushing log\n", b);
+                  const y = u();
+                  y && y.type === te ? a.addItem(b) : o.execute(b);
+                } catch (e) {
+                  t.error("Error pushing log\n", e);
+                }
+              },
+            };
+          })(d)
+        ),
+        (function ({
+          internalLogger: t,
+          config: n,
+          metas: i,
+          transports: o,
+          tracesApi: s,
+          actionBuffer: a,
+          getMessage: u,
+        }) {
+          t.debug("Initializing measurements API");
+          let c = null;
+          return {
+            pushMeasurement: (
+              l,
+              {
+                skipDedupe: d,
+                context: f,
+                spanContext: p,
+                timestampOverwriteMs: g,
+              } = {}
+            ) => {
+              try {
+                const m = _(f),
+                  v = {
+                    type: e.TransportItemType.MEASUREMENT,
+                    payload: Object.assign(Object.assign({}, l), {
+                      trace: p
+                        ? { trace_id: p.traceId, span_id: p.spanId }
+                        : s.getTraceContext(),
+                      timestamp: g ? k(g) : I(),
+                      context: S(m) ? void 0 : m,
+                    }),
+                    meta: i.value,
+                  },
+                  h = {
+                    type: v.payload.type,
+                    values: v.payload.values,
+                    context: v.payload.context,
+                  };
+                if (!d && n.dedupe && !r(c) && T(h, c))
+                  return void t.debug(
+                    "Skipping measurement push because it is the same as the last one\n",
+                    v.payload
+                  );
+                (c = h), t.debug("Pushing measurement\n", v);
+                const b = u();
+                b && b.type === te ? a.addItem(v) : o.execute(v);
+              } catch (e) {
+                t.error("Error pushing measurement\n", e);
+              }
+            },
+          };
+        })(d)
+      ),
+      (function ({
+        internalLogger: t,
+        config: n,
+        metas: i,
+        transports: o,
+        tracesApi: s,
+        actionBuffer: a,
+        getMessage: u,
+      }) {
+        let c = null;
+        return {
+          pushEvent: (
+            l,
+            d,
+            f,
+            {
+              skipDedupe: p,
+              spanContext: g,
+              timestampOverwriteMs: m,
+              customPayloadTransformer: v = (e) => e,
+            } = {}
+          ) => {
+            try {
+              const h = _(d),
+                b = {
+                  meta: i.value,
+                  payload: v({
+                    name: l,
+                    domain: null != f ? f : n.eventDomain,
+                    attributes: S(h) ? void 0 : h,
+                    timestamp: m ? k(m) : I(),
+                    trace: g
+                      ? { trace_id: g.traceId, span_id: g.spanId }
+                      : s.getTraceContext(),
+                  }),
+                  type: e.TransportItemType.EVENT,
+                },
+                w = {
+                  name: b.payload.name,
+                  attributes: b.payload.attributes,
+                  domain: b.payload.domain,
+                };
+              if (!p && n.dedupe && !r(c) && T(w, c))
+                return void t.debug(
+                  "Skipping event push because it is the same as the last one\n",
+                  b.payload
+                );
+              (c = w), t.debug("Pushing event\n", b);
+              const y = u();
+              y && y.type === te ? a.addItem(b) : o.execute(b);
+            } catch (e) {
+              t.error("Error pushing event", e);
+            }
+          },
+        };
+      })(d)
+    );
+  }
+  class ge extends Z {
+    constructor() {
+      super(...arguments), (this.api = {}), (this.transports = {});
+    }
+  }
+  const me = "1.18.1";
+  const ve = "_faroInternal";
+  function he(e) {
+    e.config.isolate
+      ? e.internalLogger.debug(
+          "Skipping registering internal Faro instance on global object"
+        )
+      : (e.internalLogger.debug(
+          "Registering internal Faro instance on global object"
+        ),
+        Object.defineProperty(j, ve, {
+          configurable: !1,
+          enumerable: !1,
+          writable: !1,
+          value: e,
+        }));
+  }
+  function be() {
+    return ve in j;
+  }
+  function we(t, n, i, r, o, s, a) {
+    return (
+      n.debug("Initializing Faro"),
+      (e.faro = {
+        api: s,
+        config: i,
+        instrumentations: a,
+        internalLogger: n,
+        metas: r,
+        pause: o.pause,
+        transports: o,
+        unpatchedConsole: t,
+        unpause: o.unpause,
+      }),
+      he(e.faro),
+      (function (e) {
+        if (e.config.preventGlobalExposure)
+          e.internalLogger.debug(
+            "Skipping registering public Faro instance in the global scope"
+          );
+        else {
+          if (
+            (e.internalLogger.debug(
+              `Registering public faro reference in the global scope using "${e.config.globalObjectKey}" key`
+            ),
+            e.config.globalObjectKey in j)
+          )
+            return void e.internalLogger.warn(
+              `Skipping global registration due to key "${e.config.globalObjectKey}" being used already. Please set "globalObjectKey" to something else or set "preventGlobalExposure" to "true"`
+            );
+          Object.defineProperty(j, e.config.globalObjectKey, {
+            configurable: !1,
+            writable: !1,
+            value: e,
+          });
+        }
+      })(e.faro),
+      e.faro
+    );
+  }
+  function ye(e) {
+    const t = W(e),
+      n = J(t, e);
+    if (be() && !e.isolate)
+      return void n.error(
+        'Faro is already registered. Either add instrumentations, transports etc. to the global faro instance or use the "isolate" property'
+      );
+    n.debug("Initializing");
+    const i = (function (e, t) {
+        let n = [],
+          i = [];
+        const r = () =>
+            n.reduce((e, t) => Object.assign(e, c(t) ? t() : t), {}),
+          o = () => {
+            if (i.length) {
+              const e = r();
+              i.forEach((t) => t(e));
+            }
+          };
+        return {
+          add: (...e) => {
+            t.debug("Adding metas\n", e), n.push(...e), o();
+          },
+          remove: (...e) => {
+            t.debug("Removing metas\n", e),
+              (n = n.filter((t) => !e.includes(t))),
+              o();
+          },
+          addListener: (e) => {
+            t.debug("Adding metas listener\n", e), i.push(e);
+          },
+          removeListener: (e) => {
+            t.debug("Removing metas listener\n", e),
+              (i = i.filter((t) => t !== e));
+          },
+          get value() {
+            return r();
+          },
+        };
+      })(0, n),
+      r = F(t, n, e, i),
+      o = pe(t, n, e, i, r),
+      s = (function (e, t, n, i, r, o) {
+        t.debug("Initializing instrumentations");
+        const s = [];
+        return {
+          add: (...a) => {
+            t.debug("Adding instrumentations"),
+              a.forEach((a) => {
+                t.debug(`Adding "${a.name}" instrumentation`),
+                  s.some((e) => e.name === a.name)
+                    ? t.warn(`Instrumentation ${a.name} is already added`)
+                    : ((a.unpatchedConsole = e),
+                      (a.internalLogger = t),
+                      (a.config = n),
+                      (a.metas = i),
+                      (a.transports = r),
+                      (a.api = o),
+                      s.push(a),
+                      a.initialize());
+              });
+          },
+          get instrumentations() {
+            return [...s];
+          },
+          remove: (...e) => {
+            t.debug("Removing instrumentations"),
+              e.forEach((e) => {
+                var n, i;
+                t.debug(`Removing "${e.name}" instrumentation`);
+                const r = s.reduce(
+                  (t, n, i) => (null === t && n.name === e.name ? i : null),
+                  null
+                );
+                r
+                  ? (null === (i = (n = s[r]).destroy) ||
+                      void 0 === i ||
+                      i.call(n),
+                    s.splice(r, 1))
+                  : t.warn(`Instrumentation "${e.name}" is not added`);
+              });
+          },
+        };
+      })(t, n, e, i, r, o),
+      a = we(t, n, e, i, r, o, s);
+    return (
+      (function (e) {
+        var t, n;
+        const i = {
+          sdk: { version: me },
+          app: {
+            bundleId:
+              e.config.app.name &&
+              ((r = e.config.app.name),
+              null == j ? void 0 : j[`__faroBundleId_${r}`]),
+          },
+        };
+        var r;
+        const o =
+          null === (t = e.config.sessionTracking) || void 0 === t
+            ? void 0
+            : t.session;
+        o && e.api.setSession(o),
+          e.config.app &&
+            (i.app = Object.assign(Object.assign({}, e.config.app), i.app)),
+          e.config.user && (i.user = e.config.user),
+          e.config.view && (i.view = e.config.view),
+          e.metas.add(
+            i,
+            ...(null !== (n = e.config.metas) && void 0 !== n ? n : [])
+          );
+      })(a),
+      (function (e) {
+        e.transports.add(...e.config.transports),
+          e.transports.addBeforeSendHooks(e.config.beforeSend);
+      })(a),
+      (function (e) {
+        e.instrumentations.add(...e.config.instrumentations);
+      })(a),
+      a
+    );
+  }
+  e.faro = {};
+  const Se = "faro",
+    Te = { enabled: !0, sendTimeout: 250, itemLimit: 50 },
+    Ee = "view_changed",
+    Ie = "session_start",
+    ke = "session_resume",
+    Oe = "session_extend",
+    xe = "service_name_override",
+    Le = "unknown";
+  var Ce,
+    Ae = { exports: {} },
+    Pe = Ae.exports;
+  var Me =
+    (Ce ||
+      ((Ce = 1),
+      (function (e, t) {
+        !(function (n, i) {
+          var r = "function",
+            o = "undefined",
+            s = "object",
+            a = "string",
+            u = "major",
+            c = "model",
+            l = "name",
+            d = "type",
+            f = "vendor",
+            p = "version",
+            g = "architecture",
+            m = "console",
+            v = "mobile",
+            h = "tablet",
+            b = "smarttv",
+            w = "wearable",
+            y = "embedded",
+            S = "Amazon",
+            T = "Apple",
+            E = "ASUS",
+            I = "BlackBerry",
+            k = "Browser",
+            O = "Chrome",
+            x = "Firefox",
+            L = "Google",
+            C = "Huawei",
+            A = "LG",
+            P = "Microsoft",
+            M = "Motorola",
+            j = "Opera",
+            N = "Samsung",
+            _ = "Sharp",
+            D = "Sony",
+            R = "Xiaomi",
+            U = "Zebra",
+            B = "Facebook",
+            F = "Chromium OS",
+            z = "Mac OS",
+            q = " Browser",
+            V = function (e) {
+              for (var t = {}, n = 0; n < e.length; n++)
+                t[e[n].toUpperCase()] = e[n];
+              return t;
+            },
+            $ = function (e, t) {
+              return typeof e === a && -1 !== G(t).indexOf(G(e));
+            },
+            G = function (e) {
+              return e.toLowerCase();
+            },
+            H = function (e, t) {
+              if (typeof e === a)
+                return (
+                  (e = e.replace(/^\s\s*/, "")),
+                  typeof t === o ? e : e.substring(0, 500)
+                );
+            },
+            W = function (e, t) {
+              for (var n, o, a, u, c, l, d = 0; d < t.length && !c; ) {
+                var f = t[d],
+                  p = t[d + 1];
+                for (n = o = 0; n < f.length && !c && f[n]; )
+                  if ((c = f[n++].exec(e)))
+                    for (a = 0; a < p.length; a++)
+                      (l = c[++o]),
+                        typeof (u = p[a]) === s && u.length > 0
+                          ? 2 === u.length
+                            ? typeof u[1] == r
+                              ? (this[u[0]] = u[1].call(this, l))
+                              : (this[u[0]] = u[1])
+                            : 3 === u.length
+                            ? typeof u[1] !== r || (u[1].exec && u[1].test)
+                              ? (this[u[0]] = l ? l.replace(u[1], u[2]) : i)
+                              : (this[u[0]] = l ? u[1].call(this, l, u[2]) : i)
+                            : 4 === u.length &&
+                              (this[u[0]] = l
+                                ? u[3].call(this, l.replace(u[1], u[2]))
+                                : i)
+                          : (this[u] = l || i);
+                d += 2;
+              }
+            },
+            K = function (e, t) {
+              for (var n in t)
+                if (typeof t[n] === s && t[n].length > 0) {
+                  for (var r = 0; r < t[n].length; r++)
+                    if ($(t[n][r], e)) return "?" === n ? i : n;
+                } else if ($(t[n], e)) return "?" === n ? i : n;
+              return t.hasOwnProperty("*") ? t["*"] : e;
+            },
+            X = {
+              ME: "4.90",
+              "NT 3.11": "NT3.51",
+              "NT 4.0": "NT4.0",
+              2e3: "NT 5.0",
+              XP: ["NT 5.1", "NT 5.2"],
+              Vista: "NT 6.0",
+              7: "NT 6.1",
+              8: "NT 6.2",
+              8.1: "NT 6.3",
+              10: ["NT 6.4", "NT 10.0"],
+              RT: "ARM",
+            },
+            J = {
+              browser: [
+                [/\b(?:crmo|crios)\/([\w\.]+)/i],
+                [p, [l, "Chrome"]],
+                [/edg(?:e|ios|a)?\/([\w\.]+)/i],
+                [p, [l, "Edge"]],
+                [
+                  /(opera mini)\/([-\w\.]+)/i,
+                  /(opera [mobiletab]{3,6})\b.+version\/([-\w\.]+)/i,
+                  /(opera)(?:.+version\/|[\/ ]+)([\w\.]+)/i,
+                ],
+                [l, p],
+                [/opios[\/ ]+([\w\.]+)/i],
+                [p, [l, j + " Mini"]],
+                [/\bop(?:rg)?x\/([\w\.]+)/i],
+                [p, [l, j + " GX"]],
+                [/\bopr\/([\w\.]+)/i],
+                [p, [l, j]],
+                [/\bb[ai]*d(?:uhd|[ub]*[aekoprswx]{5,6})[\/ ]?([\w\.]+)/i],
+                [p, [l, "Baidu"]],
+                [/\b(?:mxbrowser|mxios|myie2)\/?([-\w\.]*)\b/i],
+                [p, [l, "Maxthon"]],
+                [
+                  /(kindle)\/([\w\.]+)/i,
+                  /(lunascape|maxthon|netfront|jasmine|blazer|sleipnir)[\/ ]?([\w\.]*)/i,
+                  /(avant|iemobile|slim(?:browser|boat|jet))[\/ ]?([\d\.]*)/i,
+                  /(?:ms|\()(ie) ([\w\.]+)/i,
+                  /(flock|rockmelt|midori|epiphany|silk|skyfire|ovibrowser|bolt|iron|vivaldi|iridium|phantomjs|bowser|qupzilla|falkon|rekonq|puffin|brave|whale(?!.+naver)|qqbrowserlite|duckduckgo|klar|helio|(?=comodo_)?dragon)\/([-\w\.]+)/i,
+                  /(heytap|ovi|115)browser\/([\d\.]+)/i,
+                  /(weibo)__([\d\.]+)/i,
+                ],
+                [l, p],
+                [/quark(?:pc)?\/([-\w\.]+)/i],
+                [p, [l, "Quark"]],
+                [/\bddg\/([\w\.]+)/i],
+                [p, [l, "DuckDuckGo"]],
+                [/(?:\buc? ?browser|(?:juc.+)ucweb)[\/ ]?([\w\.]+)/i],
+                [p, [l, "UC" + k]],
+                [
+                  /microm.+\bqbcore\/([\w\.]+)/i,
+                  /\bqbcore\/([\w\.]+).+microm/i,
+                  /micromessenger\/([\w\.]+)/i,
+                ],
+                [p, [l, "WeChat"]],
+                [/konqueror\/([\w\.]+)/i],
+                [p, [l, "Konqueror"]],
+                [/trident.+rv[: ]([\w\.]{1,9})\b.+like gecko/i],
+                [p, [l, "IE"]],
+                [/ya(?:search)?browser\/([\w\.]+)/i],
+                [p, [l, "Yandex"]],
+                [/slbrowser\/([\w\.]+)/i],
+                [p, [l, "Smart Lenovo " + k]],
+                [/(avast|avg)\/([\w\.]+)/i],
+                [[l, /(.+)/, "$1 Secure " + k], p],
+                [/\bfocus\/([\w\.]+)/i],
+                [p, [l, x + " Focus"]],
+                [/\bopt\/([\w\.]+)/i],
+                [p, [l, j + " Touch"]],
+                [/coc_coc\w+\/([\w\.]+)/i],
+                [p, [l, "Coc Coc"]],
+                [/dolfin\/([\w\.]+)/i],
+                [p, [l, "Dolphin"]],
+                [/coast\/([\w\.]+)/i],
+                [p, [l, j + " Coast"]],
+                [/miuibrowser\/([\w\.]+)/i],
+                [p, [l, "MIUI" + q]],
+                [/fxios\/([\w\.-]+)/i],
+                [p, [l, x]],
+                [/\bqihoobrowser\/?([\w\.]*)/i],
+                [p, [l, "360"]],
+                [/\b(qq)\/([\w\.]+)/i],
+                [[l, /(.+)/, "$1Browser"], p],
+                [/(oculus|sailfish|huawei|vivo|pico)browser\/([\w\.]+)/i],
+                [[l, /(.+)/, "$1" + q], p],
+                [/samsungbrowser\/([\w\.]+)/i],
+                [p, [l, N + " Internet"]],
+                [/metasr[\/ ]?([\d\.]+)/i],
+                [p, [l, "Sogou Explorer"]],
+                [/(sogou)mo\w+\/([\d\.]+)/i],
+                [[l, "Sogou Mobile"], p],
+                [
+                  /(electron)\/([\w\.]+) safari/i,
+                  /(tesla)(?: qtcarbrowser|\/(20\d\d\.[-\w\.]+))/i,
+                  /m?(qqbrowser|2345(?=browser|chrome|explorer))\w*[\/ ]?v?([\w\.]+)/i,
+                ],
+                [l, p],
+                [/(lbbrowser|rekonq)/i, /\[(linkedin)app\]/i],
+                [l],
+                [
+                  /ome\/([\w\.]+) \w* ?(iron) saf/i,
+                  /ome\/([\w\.]+).+qihu (360)[es]e/i,
+                ],
+                [p, l],
+                [/((?:fban\/fbios|fb_iab\/fb4a)(?!.+fbav)|;fbav\/([\w\.]+);)/i],
+                [[l, B], p],
+                [
+                  /(Klarna)\/([\w\.]+)/i,
+                  /(kakao(?:talk|story))[\/ ]([\w\.]+)/i,
+                  /(naver)\(.*?(\d+\.[\w\.]+).*\)/i,
+                  /safari (line)\/([\w\.]+)/i,
+                  /\b(line)\/([\w\.]+)\/iab/i,
+                  /(alipay)client\/([\w\.]+)/i,
+                  /(twitter)(?:and| f.+e\/([\w\.]+))/i,
+                  /(chromium|instagram|snapchat)[\/ ]([-\w\.]+)/i,
+                ],
+                [l, p],
+                [/\bgsa\/([\w\.]+) .*safari\//i],
+                [p, [l, "GSA"]],
+                [/musical_ly(?:.+app_?version\/|_)([\w\.]+)/i],
+                [p, [l, "TikTok"]],
+                [/headlesschrome(?:\/([\w\.]+)| )/i],
+                [p, [l, O + " Headless"]],
+                [/ wv\).+(chrome)\/([\w\.]+)/i],
+                [[l, O + " WebView"], p],
+                [/droid.+ version\/([\w\.]+)\b.+(?:mobile safari|safari)/i],
+                [p, [l, "Android " + k]],
+                [/(chrome|omniweb|arora|[tizenoka]{5} ?browser)\/v?([\w\.]+)/i],
+                [l, p],
+                [/version\/([\w\.\,]+) .*mobile\/\w+ (safari)/i],
+                [p, [l, "Mobile Safari"]],
+                [/version\/([\w(\.|\,)]+) .*(mobile ?safari|safari)/i],
+                [p, l],
+                [/webkit.+?(mobile ?safari|safari)(\/[\w\.]+)/i],
+                [
+                  l,
+                  [
+                    p,
+                    K,
+                    {
+                      "1.0": "/8",
+                      1.2: "/1",
+                      1.3: "/3",
+                      "2.0": "/412",
+                      "2.0.2": "/416",
+                      "2.0.3": "/417",
+                      "2.0.4": "/419",
+                      "?": "/",
+                    },
+                  ],
+                ],
+                [/(webkit|khtml)\/([\w\.]+)/i],
+                [l, p],
+                [/(navigator|netscape\d?)\/([-\w\.]+)/i],
+                [[l, "Netscape"], p],
+                [/(wolvic|librewolf)\/([\w\.]+)/i],
+                [l, p],
+                [/mobile vr; rv:([\w\.]+)\).+firefox/i],
+                [p, [l, x + " Reality"]],
+                [
+                  /ekiohf.+(flow)\/([\w\.]+)/i,
+                  /(swiftfox)/i,
+                  /(icedragon|iceweasel|camino|chimera|fennec|maemo browser|minimo|conkeror)[\/ ]?([\w\.\+]+)/i,
+                  /(seamonkey|k-meleon|icecat|iceape|firebird|phoenix|palemoon|basilisk|waterfox)\/([-\w\.]+)$/i,
+                  /(firefox)\/([\w\.]+)/i,
+                  /(mozilla)\/([\w\.]+) .+rv\:.+gecko\/\d+/i,
+                  /(polaris|lynx|dillo|icab|doris|amaya|w3m|netsurf|obigo|mosaic|(?:go|ice|up)[\. ]?browser)[-\/ ]?v?([\w\.]+)/i,
+                  /(links) \(([\w\.]+)/i,
+                ],
+                [l, [p, /_/g, "."]],
+                [/(cobalt)\/([\w\.]+)/i],
+                [l, [p, /master.|lts./, ""]],
+              ],
+              cpu: [
+                [/(?:(amd|x(?:(?:86|64)[-_])?|wow|win)64)[;\)]/i],
+                [[g, "amd64"]],
+                [/(ia32(?=;))/i],
+                [[g, G]],
+                [/((?:i[346]|x)86)[;\)]/i],
+                [[g, "ia32"]],
+                [/\b(aarch64|arm(v?8e?l?|_?64))\b/i],
+                [[g, "arm64"]],
+                [/\b(arm(?:v[67])?ht?n?[fl]p?)\b/i],
+                [[g, "armhf"]],
+                [/windows (ce|mobile); ppc;/i],
+                [[g, "arm"]],
+                [/((?:ppc|powerpc)(?:64)?)(?: mac|;|\))/i],
+                [[g, /ower/, "", G]],
+                [/(sun4\w)[;\)]/i],
+                [[g, "sparc"]],
+                [
+                  /((?:avr32|ia64(?=;))|68k(?=\))|\barm(?=v(?:[1-7]|[5-7]1)l?|;|eabi)|(?=atmel )avr|(?:irix|mips|sparc)(?:64)?\b|pa-risc)/i,
+                ],
+                [[g, G]],
+              ],
+              device: [
+                [
+                  /\b(sch-i[89]0\d|shw-m380s|sm-[ptx]\w{2,4}|gt-[pn]\d{2,4}|sgh-t8[56]9|nexus 10)/i,
+                ],
+                [c, [f, N], [d, h]],
+                [
+                  /\b((?:s[cgp]h|gt|sm)-(?![lr])\w+|sc[g-]?[\d]+a?|galaxy nexus)/i,
+                  /samsung[- ]((?!sm-[lr])[-\w]+)/i,
+                  /sec-(sgh\w+)/i,
+                ],
+                [c, [f, N], [d, v]],
+                [/(?:\/|\()(ip(?:hone|od)[\w, ]*)(?:\/|;)/i],
+                [c, [f, T], [d, v]],
+                [
+                  /\((ipad);[-\w\),; ]+apple/i,
+                  /applecoremedia\/[\w\.]+ \((ipad)/i,
+                  /\b(ipad)\d\d?,\d\d?[;\]].+ios/i,
+                ],
+                [c, [f, T], [d, h]],
+                [/(macintosh);/i],
+                [c, [f, T]],
+                [/\b(sh-?[altvz]?\d\d[a-ekm]?)/i],
+                [c, [f, _], [d, v]],
+                [/(?:honor)([-\w ]+)[;\)]/i],
+                [c, [f, "Honor"], [d, v]],
+                [/\b((?:ag[rs][23]?|bah2?|sht?|btv)-a?[lw]\d{2})\b(?!.+d\/s)/i],
+                [c, [f, C], [d, h]],
+                [
+                  /(?:huawei)([-\w ]+)[;\)]/i,
+                  /\b(nexus 6p|\w{2,4}e?-[atu]?[ln][\dx][012359c][adn]?)\b(?!.+d\/s)/i,
+                ],
+                [c, [f, C], [d, v]],
+                [
+                  /\b(poco[\w ]+|m2\d{3}j\d\d[a-z]{2})(?: bui|\))/i,
+                  /\b; (\w+) build\/hm\1/i,
+                  /\b(hm[-_ ]?note?[_ ]?(?:\d\w)?) bui/i,
+                  /\b(redmi[\-_ ]?(?:note|k)?[\w_ ]+)(?: bui|\))/i,
+                  /oid[^\)]+; (m?[12][0-389][01]\w{3,6}[c-y])( bui|; wv|\))/i,
+                  /\b(mi[-_ ]?(?:a\d|one|one[_ ]plus|note lte|max|cc)?[_ ]?(?:\d?\w?)[_ ]?(?:plus|se|lite|pro)?)(?: bui|\))/i,
+                ],
+                [
+                  [c, /_/g, " "],
+                  [f, R],
+                  [d, v],
+                ],
+                [
+                  /oid[^\)]+; (2\d{4}(283|rpbf)[cgl])( bui|\))/i,
+                  /\b(mi[-_ ]?(?:pad)(?:[\w_ ]+))(?: bui|\))/i,
+                ],
+                [
+                  [c, /_/g, " "],
+                  [f, R],
+                  [d, h],
+                ],
+                [
+                  /; (\w+) bui.+ oppo/i,
+                  /\b(cph[12]\d{3}|p(?:af|c[al]|d\w|e[ar])[mt]\d0|x9007|a101op)\b/i,
+                ],
+                [c, [f, "OPPO"], [d, v]],
+                [/\b(opd2\d{3}a?) bui/i],
+                [c, [f, "OPPO"], [d, h]],
+                [/vivo (\w+)(?: bui|\))/i, /\b(v[12]\d{3}\w?[at])(?: bui|;)/i],
+                [c, [f, "Vivo"], [d, v]],
+                [/\b(rmx[1-3]\d{3})(?: bui|;|\))/i],
+                [c, [f, "Realme"], [d, v]],
+                [
+                  /\b(milestone|droid(?:[2-4x]| (?:bionic|x2|pro|razr))?:?( 4g)?)\b[\w ]+build\//i,
+                  /\bmot(?:orola)?[- ](\w*)/i,
+                  /((?:moto[\w\(\) ]+|xt\d{3,4}|nexus 6)(?= bui|\)))/i,
+                ],
+                [c, [f, M], [d, v]],
+                [/\b(mz60\d|xoom[2 ]{0,2}) build\//i],
+                [c, [f, M], [d, h]],
+                [
+                  /((?=lg)?[vl]k\-?\d{3}) bui| 3\.[-\w; ]{10}lg?-([06cv9]{3,4})/i,
+                ],
+                [c, [f, A], [d, h]],
+                [
+                  /(lm(?:-?f100[nv]?|-[\w\.]+)(?= bui|\))|nexus [45])/i,
+                  /\blg[-e;\/ ]+((?!browser|netcast|android tv)\w+)/i,
+                  /\blg-?([\d\w]+) bui/i,
+                ],
+                [c, [f, A], [d, v]],
+                [
+                  /(ideatab[-\w ]+)/i,
+                  /lenovo ?(s[56]000[-\w]+|tab(?:[\w ]+)|yt[-\d\w]{6}|tb[-\d\w]{6})/i,
+                ],
+                [c, [f, "Lenovo"], [d, h]],
+                [
+                  /(?:maemo|nokia).*(n900|lumia \d+)/i,
+                  /nokia[-_ ]?([-\w\.]*)/i,
+                ],
+                [
+                  [c, /_/g, " "],
+                  [f, "Nokia"],
+                  [d, v],
+                ],
+                [/(pixel c)\b/i],
+                [c, [f, L], [d, h]],
+                [/droid.+; (pixel[\daxl ]{0,6})(?: bui|\))/i],
+                [c, [f, L], [d, v]],
+                [
+                  /droid.+; (a?\d[0-2]{2}so|[c-g]\d{4}|so[-gl]\w+|xq-a\w[4-7][12])(?= bui|\).+chrome\/(?![1-6]{0,1}\d\.))/i,
+                ],
+                [c, [f, D], [d, v]],
+                [/sony tablet [ps]/i, /\b(?:sony)?sgp\w+(?: bui|\))/i],
+                [
+                  [c, "Xperia Tablet"],
+                  [f, D],
+                  [d, h],
+                ],
+                [
+                  / (kb2005|in20[12]5|be20[12][59])\b/i,
+                  /(?:one)?(?:plus)? (a\d0\d\d)(?: b|\))/i,
+                ],
+                [c, [f, "OnePlus"], [d, v]],
+                [
+                  /(alexa)webm/i,
+                  /(kf[a-z]{2}wi|aeo(?!bc)\w\w)( bui|\))/i,
+                  /(kf[a-z]+)( bui|\)).+silk\//i,
+                ],
+                [c, [f, S], [d, h]],
+                [/((?:sd|kf)[0349hijorstuw]+)( bui|\)).+silk\//i],
+                [
+                  [c, /(.+)/g, "Fire Phone $1"],
+                  [f, S],
+                  [d, v],
+                ],
+                [/(playbook);[-\w\),; ]+(rim)/i],
+                [c, f, [d, h]],
+                [/\b((?:bb[a-f]|st[hv])100-\d)/i, /\(bb10; (\w+)/i],
+                [c, [f, I], [d, v]],
+                [
+                  /(?:\b|asus_)(transfo[prime ]{4,10} \w+|eeepc|slider \w+|nexus 7|padfone|p00[cj])/i,
+                ],
+                [c, [f, E], [d, h]],
+                [/ (z[bes]6[027][012][km][ls]|zenfone \d\w?)\b/i],
+                [c, [f, E], [d, v]],
+                [/(nexus 9)/i],
+                [c, [f, "HTC"], [d, h]],
+                [
+                  /(htc)[-;_ ]{1,2}([\w ]+(?=\)| bui)|\w+)/i,
+                  /(zte)[- ]([\w ]+?)(?: bui|\/|\))/i,
+                  /(alcatel|geeksphone|nexian|panasonic(?!(?:;|\.))|sony(?!-bra))[-_ ]?([-\w]*)/i,
+                ],
+                [f, [c, /_/g, " "], [d, v]],
+                [
+                  /droid [\w\.]+; ((?:8[14]9[16]|9(?:0(?:48|60|8[01])|1(?:3[27]|66)|2(?:6[69]|9[56])|466))[gqswx])\w*(\)| bui)/i,
+                ],
+                [c, [f, "TCL"], [d, h]],
+                [/(itel) ((\w+))/i],
+                [
+                  [f, G],
+                  c,
+                  [d, K, { tablet: ["p10001l", "w7001"], "*": "mobile" }],
+                ],
+                [/droid.+; ([ab][1-7]-?[0178a]\d\d?)/i],
+                [c, [f, "Acer"], [d, h]],
+                [/droid.+; (m[1-5] note) bui/i, /\bmz-([-\w]{2,})/i],
+                [c, [f, "Meizu"], [d, v]],
+                [/; ((?:power )?armor(?:[\w ]{0,8}))(?: bui|\))/i],
+                [c, [f, "Ulefone"], [d, v]],
+                [
+                  /; (energy ?\w+)(?: bui|\))/i,
+                  /; energizer ([\w ]+)(?: bui|\))/i,
+                ],
+                [c, [f, "Energizer"], [d, v]],
+                [
+                  /; cat (b35);/i,
+                  /; (b15q?|s22 flip|s48c|s62 pro)(?: bui|\))/i,
+                ],
+                [c, [f, "Cat"], [d, v]],
+                [/((?:new )?andromax[\w- ]+)(?: bui|\))/i],
+                [c, [f, "Smartfren"], [d, v]],
+                [/droid.+; (a(?:015|06[35]|142p?))/i],
+                [c, [f, "Nothing"], [d, v]],
+                [
+                  /(blackberry|benq|palm(?=\-)|sonyericsson|acer|asus|dell|meizu|motorola|polytron|infinix|tecno|micromax|advan)[-_ ]?([-\w]*)/i,
+                  /; (imo) ((?!tab)[\w ]+?)(?: bui|\))/i,
+                  /(hp) ([\w ]+\w)/i,
+                  /(asus)-?(\w+)/i,
+                  /(microsoft); (lumia[\w ]+)/i,
+                  /(lenovo)[-_ ]?([-\w]+)/i,
+                  /(jolla)/i,
+                  /(oppo) ?([\w ]+) bui/i,
+                ],
+                [f, c, [d, v]],
+                [
+                  /(imo) (tab \w+)/i,
+                  /(kobo)\s(ereader|touch)/i,
+                  /(archos) (gamepad2?)/i,
+                  /(hp).+(touchpad(?!.+tablet)|tablet)/i,
+                  /(kindle)\/([\w\.]+)/i,
+                  /(nook)[\w ]+build\/(\w+)/i,
+                  /(dell) (strea[kpr\d ]*[\dko])/i,
+                  /(le[- ]+pan)[- ]+(\w{1,9}) bui/i,
+                  /(trinity)[- ]*(t\d{3}) bui/i,
+                  /(gigaset)[- ]+(q\w{1,9}) bui/i,
+                  /(vodafone) ([\w ]+)(?:\)| bui)/i,
+                ],
+                [f, c, [d, h]],
+                [/(surface duo)/i],
+                [c, [f, P], [d, h]],
+                [/droid [\d\.]+; (fp\du?)(?: b|\))/i],
+                [c, [f, "Fairphone"], [d, v]],
+                [/(u304aa)/i],
+                [c, [f, "AT&T"], [d, v]],
+                [/\bsie-(\w*)/i],
+                [c, [f, "Siemens"], [d, v]],
+                [/\b(rct\w+) b/i],
+                [c, [f, "RCA"], [d, h]],
+                [/\b(venue[\d ]{2,7}) b/i],
+                [c, [f, "Dell"], [d, h]],
+                [/\b(q(?:mv|ta)\w+) b/i],
+                [c, [f, "Verizon"], [d, h]],
+                [/\b(?:barnes[& ]+noble |bn[rt])([\w\+ ]*) b/i],
+                [c, [f, "Barnes & Noble"], [d, h]],
+                [/\b(tm\d{3}\w+) b/i],
+                [c, [f, "NuVision"], [d, h]],
+                [/\b(k88) b/i],
+                [c, [f, "ZTE"], [d, h]],
+                [/\b(nx\d{3}j) b/i],
+                [c, [f, "ZTE"], [d, v]],
+                [/\b(gen\d{3}) b.+49h/i],
+                [c, [f, "Swiss"], [d, v]],
+                [/\b(zur\d{3}) b/i],
+                [c, [f, "Swiss"], [d, h]],
+                [/\b((zeki)?tb.*\b) b/i],
+                [c, [f, "Zeki"], [d, h]],
+                [/\b([yr]\d{2}) b/i, /\b(dragon[- ]+touch |dt)(\w{5}) b/i],
+                [[f, "Dragon Touch"], c, [d, h]],
+                [/\b(ns-?\w{0,9}) b/i],
+                [c, [f, "Insignia"], [d, h]],
+                [/\b((nxa|next)-?\w{0,9}) b/i],
+                [c, [f, "NextBook"], [d, h]],
+                [/\b(xtreme\_)?(v(1[045]|2[015]|[3469]0|7[05])) b/i],
+                [[f, "Voice"], c, [d, v]],
+                [/\b(lvtel\-)?(v1[12]) b/i],
+                [[f, "LvTel"], c, [d, v]],
+                [/\b(ph-1) /i],
+                [c, [f, "Essential"], [d, v]],
+                [/\b(v(100md|700na|7011|917g).*\b) b/i],
+                [c, [f, "Envizen"], [d, h]],
+                [/\b(trio[-\w\. ]+) b/i],
+                [c, [f, "MachSpeed"], [d, h]],
+                [/\btu_(1491) b/i],
+                [c, [f, "Rotor"], [d, h]],
+                [/(shield[\w ]+) b/i],
+                [c, [f, "Nvidia"], [d, h]],
+                [/(sprint) (\w+)/i],
+                [f, c, [d, v]],
+                [/(kin\.[onetw]{3})/i],
+                [
+                  [c, /\./g, " "],
+                  [f, P],
+                  [d, v],
+                ],
+                [/droid.+; (cc6666?|et5[16]|mc[239][23]x?|vc8[03]x?)\)/i],
+                [c, [f, U], [d, h]],
+                [/droid.+; (ec30|ps20|tc[2-8]\d[kx])\)/i],
+                [c, [f, U], [d, v]],
+                [/smart-tv.+(samsung)/i],
+                [f, [d, b]],
+                [/hbbtv.+maple;(\d+)/i],
+                [
+                  [c, /^/, "SmartTV"],
+                  [f, N],
+                  [d, b],
+                ],
+                [/(nux; netcast.+smarttv|lg (netcast\.tv-201\d|android tv))/i],
+                [
+                  [f, A],
+                  [d, b],
+                ],
+                [/(apple) ?tv/i],
+                [f, [c, T + " TV"], [d, b]],
+                [/crkey/i],
+                [
+                  [c, O + "cast"],
+                  [f, L],
+                  [d, b],
+                ],
+                [/droid.+aft(\w+)( bui|\))/i],
+                [c, [f, S], [d, b]],
+                [/\(dtv[\);].+(aquos)/i, /(aquos-tv[\w ]+)\)/i],
+                [c, [f, _], [d, b]],
+                [/(bravia[\w ]+)( bui|\))/i],
+                [c, [f, D], [d, b]],
+                [/(mitv-\w{5}) bui/i],
+                [c, [f, R], [d, b]],
+                [/Hbbtv.*(technisat) (.*);/i],
+                [f, c, [d, b]],
+                [
+                  /\b(roku)[\dx]*[\)\/]((?:dvp-)?[\d\.]*)/i,
+                  /hbbtv\/\d+\.\d+\.\d+ +\([\w\+ ]*; *([\w\d][^;]*);([^;]*)/i,
+                ],
+                [
+                  [f, H],
+                  [c, H],
+                  [d, b],
+                ],
+                [/\b(android tv|smart[- ]?tv|opera tv|tv; rv:)\b/i],
+                [[d, b]],
+                [/(ouya)/i, /(nintendo) ([wids3utch]+)/i],
+                [f, c, [d, m]],
+                [/droid.+; (shield) bui/i],
+                [c, [f, "Nvidia"], [d, m]],
+                [/(playstation [345portablevi]+)/i],
+                [c, [f, D], [d, m]],
+                [/\b(xbox(?: one)?(?!; xbox))[\); ]/i],
+                [c, [f, P], [d, m]],
+                [/\b(sm-[lr]\d\d[05][fnuw]?s?)\b/i],
+                [c, [f, N], [d, w]],
+                [/((pebble))app/i],
+                [f, c, [d, w]],
+                [/(watch)(?: ?os[,\/]|\d,\d\/)[\d\.]+/i],
+                [c, [f, T], [d, w]],
+                [/droid.+; (glass) \d/i],
+                [c, [f, L], [d, w]],
+                [/droid.+; (wt63?0{2,3})\)/i],
+                [c, [f, U], [d, w]],
+                [/droid.+; (glass) \d/i],
+                [c, [f, L], [d, w]],
+                [/(pico) (4|neo3(?: link|pro)?)/i],
+                [f, c, [d, w]],
+                [/; (quest( \d| pro)?)/i],
+                [c, [f, B], [d, w]],
+                [/(tesla)(?: qtcarbrowser|\/[-\w\.]+)/i],
+                [f, [d, y]],
+                [/(aeobc)\b/i],
+                [c, [f, S], [d, y]],
+                [
+                  /droid .+?; ([^;]+?)(?: bui|; wv\)|\) applew).+? mobile safari/i,
+                ],
+                [c, [d, v]],
+                [/droid .+?; ([^;]+?)(?: bui|\) applew).+?(?! mobile) safari/i],
+                [c, [d, h]],
+                [/\b((tablet|tab)[;\/]|focus\/\d(?!.+mobile))/i],
+                [[d, h]],
+                [
+                  /(phone|mobile(?:[;\/]| [ \w\/\.]*safari)|pda(?=.+windows ce))/i,
+                ],
+                [[d, v]],
+                [/(android[-\w\. ]{0,9});.+buil/i],
+                [c, [f, "Generic"]],
+              ],
+              engine: [
+                [/windows.+ edge\/([\w\.]+)/i],
+                [p, [l, "EdgeHTML"]],
+                [/(arkweb)\/([\w\.]+)/i],
+                [l, p],
+                [/webkit\/537\.36.+chrome\/(?!27)([\w\.]+)/i],
+                [p, [l, "Blink"]],
+                [
+                  /(presto)\/([\w\.]+)/i,
+                  /(webkit|trident|netfront|netsurf|amaya|lynx|w3m|goanna|servo)\/([\w\.]+)/i,
+                  /ekioh(flow)\/([\w\.]+)/i,
+                  /(khtml|tasman|links)[\/ ]\(?([\w\.]+)/i,
+                  /(icab)[\/ ]([23]\.[\d\.]+)/i,
+                  /\b(libweb)/i,
+                ],
+                [l, p],
+                [/rv\:([\w\.]{1,9})\b.+(gecko)/i],
+                [p, l],
+              ],
+              os: [
+                [/microsoft (windows) (vista|xp)/i],
+                [l, p],
+                [/(windows (?:phone(?: os)?|mobile))[\/ ]?([\d\.\w ]*)/i],
+                [l, [p, K, X]],
+                [
+                  /windows nt 6\.2; (arm)/i,
+                  /windows[\/ ]?([ntce\d\. ]+\w)(?!.+xbox)/i,
+                  /(?:win(?=3|9|n)|win 9x )([nt\d\.]+)/i,
+                ],
+                [
+                  [p, K, X],
+                  [l, "Windows"],
+                ],
+                [
+                  /ip[honead]{2,4}\b(?:.*os ([\w]+) like mac|; opera)/i,
+                  /(?:ios;fbsv\/|iphone.+ios[\/ ])([\d\.]+)/i,
+                  /cfnetwork\/.+darwin/i,
+                ],
+                [
+                  [p, /_/g, "."],
+                  [l, "iOS"],
+                ],
+                [
+                  /(mac os x) ?([\w\. ]*)/i,
+                  /(macintosh|mac_powerpc\b)(?!.+haiku)/i,
+                ],
+                [
+                  [l, z],
+                  [p, /_/g, "."],
+                ],
+                [/droid ([\w\.]+)\b.+(android[- ]x86|harmonyos)/i],
+                [p, l],
+                [
+                  /(android|webos|qnx|bada|rim tablet os|maemo|meego|sailfish|openharmony)[-\/ ]?([\w\.]*)/i,
+                  /(blackberry)\w*\/([\w\.]*)/i,
+                  /(tizen|kaios)[\/ ]([\w\.]+)/i,
+                  /\((series40);/i,
+                ],
+                [l, p],
+                [/\(bb(10);/i],
+                [p, [l, I]],
+                [/(?:symbian ?os|symbos|s60(?=;)|series60)[-\/ ]?([\w\.]*)/i],
+                [p, [l, "Symbian"]],
+                [
+                  /mozilla\/[\d\.]+ \((?:mobile|tablet|tv|mobile; [\w ]+); rv:.+ gecko\/([\w\.]+)/i,
+                ],
+                [p, [l, x + " OS"]],
+                [/web0s;.+rt(tv)/i, /\b(?:hp)?wos(?:browser)?\/([\w\.]+)/i],
+                [p, [l, "webOS"]],
+                [/watch(?: ?os[,\/]|\d,\d\/)([\d\.]+)/i],
+                [p, [l, "watchOS"]],
+                [/crkey\/([\d\.]+)/i],
+                [p, [l, O + "cast"]],
+                [/(cros) [\w]+(?:\)| ([\w\.]+)\b)/i],
+                [[l, F], p],
+                [
+                  /panasonic;(viera)/i,
+                  /(netrange)mmh/i,
+                  /(nettv)\/(\d+\.[\w\.]+)/i,
+                  /(nintendo|playstation) ([wids345portablevuch]+)/i,
+                  /(xbox); +xbox ([^\);]+)/i,
+                  /\b(joli|palm)\b ?(?:os)?\/?([\w\.]*)/i,
+                  /(mint)[\/\(\) ]?(\w*)/i,
+                  /(mageia|vectorlinux)[; ]/i,
+                  /([kxln]?ubuntu|debian|suse|opensuse|gentoo|arch(?= linux)|slackware|fedora|mandriva|centos|pclinuxos|red ?hat|zenwalk|linpus|raspbian|plan 9|minix|risc os|contiki|deepin|manjaro|elementary os|sabayon|linspire)(?: gnu\/linux)?(?: enterprise)?(?:[- ]linux)?(?:-gnu)?[-\/ ]?(?!chrom|package)([-\w\.]*)/i,
+                  /(hurd|linux) ?([\w\.]*)/i,
+                  /(gnu) ?([\w\.]*)/i,
+                  /\b([-frentopcghs]{0,5}bsd|dragonfly)[\/ ]?(?!amd|[ix346]{1,2}86)([\w\.]*)/i,
+                  /(haiku) (\w+)/i,
+                ],
+                [l, p],
+                [/(sunos) ?([\w\.\d]*)/i],
+                [[l, "Solaris"], p],
+                [
+                  /((?:open)?solaris)[-\/ ]?([\w\.]*)/i,
+                  /(aix) ((\d)(?=\.|\)| )[\w\.])*/i,
+                  /\b(beos|os\/2|amigaos|morphos|openvms|fuchsia|hp-ux|serenityos)/i,
+                  /(unix) ?([\w\.]*)/i,
+                ],
+                [l, p],
+              ],
+            },
+            Z = function (e, t) {
+              if ((typeof e === s && ((t = e), (e = i)), !(this instanceof Z)))
+                return new Z(e, t).getResult();
+              var m = typeof n !== o && n.navigator ? n.navigator : i,
+                b = e || (m && m.userAgent ? m.userAgent : ""),
+                w = m && m.userAgentData ? m.userAgentData : i,
+                y = t
+                  ? (function (e, t) {
+                      var n = {};
+                      for (var i in e)
+                        t[i] && t[i].length % 2 == 0
+                          ? (n[i] = t[i].concat(e[i]))
+                          : (n[i] = e[i]);
+                      return n;
+                    })(J, t)
+                  : J,
+                S = m && m.userAgent == b;
+              return (
+                (this.getBrowser = function () {
+                  var e,
+                    t = {};
+                  return (
+                    (t[l] = i),
+                    (t[p] = i),
+                    W.call(t, b, y.browser),
+                    (t[u] =
+                      typeof (e = t[p]) === a
+                        ? e.replace(/[^\d\.]/g, "").split(".")[0]
+                        : i),
+                    S &&
+                      m &&
+                      m.brave &&
+                      typeof m.brave.isBrave == r &&
+                      (t[l] = "Brave"),
+                    t
+                  );
+                }),
+                (this.getCPU = function () {
+                  var e = {};
+                  return (e[g] = i), W.call(e, b, y.cpu), e;
+                }),
+                (this.getDevice = function () {
+                  var e = {};
+                  return (
+                    (e[f] = i),
+                    (e[c] = i),
+                    (e[d] = i),
+                    W.call(e, b, y.device),
+                    S && !e[d] && w && w.mobile && (e[d] = v),
+                    S &&
+                      "Macintosh" == e[c] &&
+                      m &&
+                      typeof m.standalone !== o &&
+                      m.maxTouchPoints &&
+                      m.maxTouchPoints > 2 &&
+                      ((e[c] = "iPad"), (e[d] = h)),
+                    e
+                  );
+                }),
+                (this.getEngine = function () {
+                  var e = {};
+                  return (e[l] = i), (e[p] = i), W.call(e, b, y.engine), e;
+                }),
+                (this.getOS = function () {
+                  var e = {};
+                  return (
+                    (e[l] = i),
+                    (e[p] = i),
+                    W.call(e, b, y.os),
+                    S &&
+                      !e[l] &&
+                      w &&
+                      w.platform &&
+                      "Unknown" != w.platform &&
+                      (e[l] = w.platform
+                        .replace(/chrome os/i, F)
+                        .replace(/macos/i, z)),
+                    e
+                  );
+                }),
+                (this.getResult = function () {
+                  return {
+                    ua: this.getUA(),
+                    browser: this.getBrowser(),
+                    engine: this.getEngine(),
+                    os: this.getOS(),
+                    device: this.getDevice(),
+                    cpu: this.getCPU(),
+                  };
+                }),
+                (this.getUA = function () {
+                  return b;
+                }),
+                (this.setUA = function (e) {
+                  return (
+                    (b = typeof e === a && e.length > 500 ? H(e, 500) : e), this
+                  );
+                }),
+                this.setUA(b),
+                this
+              );
+            };
+          (Z.VERSION = "1.0.40"),
+            (Z.BROWSER = V([l, p, u])),
+            (Z.CPU = V([g])),
+            (Z.DEVICE = V([c, f, d, m, v, b, h, w, y])),
+            (Z.ENGINE = Z.OS = V([l, p])),
+            e.exports && (t = e.exports = Z),
+            (t.UAParser = Z);
+          var Y = typeof n !== o && (n.jQuery || n.Zepto);
+          if (Y && !Y.ua) {
+            var Q = new Z();
+            (Y.ua = Q.getResult()),
+              (Y.ua.get = function () {
+                return Q.getUA();
+              }),
+              (Y.ua.set = function (e) {
+                Q.setUA(e);
+                var t = Q.getResult();
+                for (var n in t) Y.ua[n] = t[n];
+              });
+          }
+        })("object" == typeof window ? window : Pe);
+      })(Ae, Ae.exports)),
+    Ae.exports);
+  const je = () => {
+    const e = new Me.UAParser(),
+      { name: t, version: n } = e.getBrowser(),
+      { name: i, version: r } = e.getOS(),
+      o = e.getUA(),
+      s = navigator.language,
+      a = navigator.userAgent.includes("Mobi"),
+      u = (function () {
+        if (!t || !n) return;
+        if ("userAgentData" in navigator && navigator.userAgentData)
+          return navigator.userAgentData.brands;
+        return;
+      })();
+    return {
+      browser: {
+        name: null != t ? t : Le,
+        version: null != n ? n : Le,
+        os: `${null != i ? i : Le} ${null != r ? r : Le}`,
+        userAgent: null != o ? o : Le,
+        language: null != s ? s : Le,
+        mobile: a,
+        brands: null != u ? u : Le,
+        viewportWidth: `${window.innerWidth}`,
+        viewportHeight: `${window.innerHeight}`,
+      },
+    };
+  };
+  function Ne(t) {
+    var n, i, r, o;
+    return {
+      id:
+        null !==
+          (o =
+            null ===
+              (r =
+                null ===
+                  (i =
+                    null === (n = e.faro.config) || void 0 === n
+                      ? void 0
+                      : n.sessionTracking) || void 0 === i
+                  ? void 0
+                  : i.generateSessionId) || void 0 === r
+              ? void 0
+              : r.call(i)) && void 0 !== o
+          ? o
+          : M(),
+      attributes: t,
+    };
+  }
+  const _e = { session: "sessionStorage", local: "localStorage" };
+  function De(t) {
+    var n;
+    try {
+      let e;
+      e = window[t];
+      const n = "__faro_storage_test__";
+      return e.setItem(n, n), e.removeItem(n), !0;
+    } catch (i) {
+      return (
+        null === (n = e.faro.internalLogger) ||
+          void 0 === n ||
+          n.info(`Web storage of type ${t} is not available. Reason: ${i}`),
+        !1
+      );
+    }
+  }
+  function Re(e, t) {
+    return qe(t) ? window[t].getItem(e) : null;
+  }
+  function Ue(e, t, n) {
+    if (qe(n))
+      try {
+        window[n].setItem(e, t);
+      } catch (e) {}
+  }
+  function Be(e, t) {
+    qe(t) && window[t].removeItem(e);
+  }
+  const Fe = De(_e.local),
+    ze = De(_e.session);
+  function qe(e) {
+    return e === _e.local ? Fe : e === _e.session && ze;
+  }
+  function Ve(e, t) {
+    let n,
+      i = !1;
+    const r = () => {
+      null != n ? (e(...n), (n = null), setTimeout(r, t)) : (i = !1);
+    };
+    return (...o) => {
+      i ? (n = o) : (e(...o), (i = !0), setTimeout(r, t));
+    };
+  }
+  function $e() {
+    return e.faro.transports.transports.flatMap((e) => e.getIgnoreUrls());
+  }
+  function Ge(e = "") {
+    return $e().some((t) => e && null != e.match(t));
+  }
+  function He(e) {
+    return o(e)
+      ? e
+      : e instanceof URL
+      ? e.href
+      : !S(e) && c(null == e ? void 0 : e.toString)
+      ? e.toString()
+      : void 0;
+  }
+  const We = "com.grafana.faro.session",
+    Ke = 144e5,
+    Xe = 9e5,
+    Je = Xe,
+    Ze = { enabled: !0, persistent: !1, maxSessionPersistenceTime: Je };
+  function Ye() {
+    var t, n, i;
+    const r = e.faro.config.sessionTracking;
+    let o =
+      null !==
+        (i =
+          null !==
+            (n =
+              null === (t = null == r ? void 0 : r.sampler) || void 0 === t
+                ? void 0
+                : t.call(r, { metas: e.faro.metas.value })) && void 0 !== n
+            ? n
+            : null == r
+            ? void 0
+            : r.samplingRate) && void 0 !== i
+        ? i
+        : 1;
+    if ("number" != typeof o) {
+      o = 0;
+    }
+    return Math.random() < o;
+  }
+  function Qe({
+    sessionId: t,
+    started: n,
+    lastActivity: i,
+    isSampled: r = !0,
+  } = {}) {
+    var o, s;
+    const a = E(),
+      u =
+        null ===
+          (s =
+            null === (o = e.faro.config) || void 0 === o
+              ? void 0
+              : o.sessionTracking) || void 0 === s
+          ? void 0
+          : s.generateSessionId;
+    return (
+      null == t && (t = "function" == typeof u ? u() : M()),
+      {
+        sessionId: t,
+        lastActivity: null != i ? i : a,
+        started: null != n ? n : a,
+        isSampled: r,
+      }
+    );
+  }
+  function et(e) {
+    if (null == e) return !1;
+    const t = E();
+    if (!(t - e.started < Ke)) return !1;
+    return t - e.lastActivity < Xe;
+  }
+  function tt({ fetchUserSession: t, storeUserSession: n }) {
+    return function ({ forceSessionExtend: i } = { forceSessionExtend: !1 }) {
+      var r, o, s;
+      if (!t || !n) return;
+      const a = e.faro.config.sessionTracking,
+        u = null == a ? void 0 : a.persistent;
+      if ((u && !Fe) || (!u && !ze)) return;
+      const c = t();
+      if (!1 === i && et(c))
+        n(Object.assign(Object.assign({}, c), { lastActivity: E() }));
+      else {
+        let t = nt(Qe({ isSampled: Ye() }), c);
+        n(t),
+          null === (r = e.faro.api) ||
+            void 0 === r ||
+            r.setSession(t.sessionMeta),
+          null === (o = null == a ? void 0 : a.onSessionChange) ||
+            void 0 === o ||
+            o.call(
+              a,
+              null !== (s = null == c ? void 0 : c.sessionMeta) && void 0 !== s
+                ? s
+                : null,
+              t.sessionMeta
+            );
+      }
+    };
+  }
+  function nt(t, n) {
+    var i, r, o, s, a, u, c;
+    const l = Object.assign(Object.assign({}, t), {
+        sessionMeta: {
+          id: t.sessionId,
+          attributes: Object.assign(
+            Object.assign(
+              Object.assign(
+                {},
+                null ===
+                  (r =
+                    null === (i = e.faro.config.sessionTracking) || void 0 === i
+                      ? void 0
+                      : i.session) || void 0 === r
+                  ? void 0
+                  : r.attributes
+              ),
+              null !==
+                (s =
+                  null === (o = e.faro.metas.value.session) || void 0 === o
+                    ? void 0
+                    : o.attributes) && void 0 !== s
+                ? s
+                : {}
+            ),
+            { isSampled: t.isSampled.toString() }
+          ),
+        },
+      }),
+      d =
+        null !==
+          (u =
+            null === (a = e.faro.metas.value.session) || void 0 === a
+              ? void 0
+              : a.overrides) && void 0 !== u
+          ? u
+          : null === (c = null == n ? void 0 : n.sessionMeta) || void 0 === c
+          ? void 0
+          : c.overrides;
+    S(d) || (l.sessionMeta.overrides = d);
+    const f = null == n ? void 0 : n.sessionId;
+    return null != f && (l.sessionMeta.attributes.previousSession = f), l;
+  }
+  function it({ fetchUserSession: t, storeUserSession: n }) {
+    return function (i) {
+      const r = i.session,
+        o = t();
+      let s = null == r ? void 0 : r.id;
+      const a = null == r ? void 0 : r.attributes,
+        u = null == r ? void 0 : r.overrides,
+        c = null == o ? void 0 : o.sessionMeta,
+        l = null == c ? void 0 : c.overrides,
+        d = !!u && !T(u, l),
+        f = !!a && !T(a, null == c ? void 0 : c.attributes);
+      if ((!!r && s !== (null == o ? void 0 : o.sessionId)) || f || d) {
+        const t = nt(Qe({ sessionId: s, isSampled: Ye() }), o);
+        n(t),
+          (function (t, n = {}, i = {}) {
+            var r, o, s;
+            if (!t) return;
+            const a = n.serviceName,
+              u =
+                null !==
+                  (s =
+                    null !== (r = i.serviceName) && void 0 !== r
+                      ? r
+                      : null === (o = e.faro.metas.value.app) || void 0 === o
+                      ? void 0
+                      : o.name) && void 0 !== s
+                  ? s
+                  : "";
+            a &&
+              a !== u &&
+              e.faro.api.pushEvent(xe, {
+                serviceName: a,
+                previousServiceName: u,
+              });
+          })(d, u, l),
+          e.faro.api.setSession(t.sessionMeta);
+      }
+    };
+  }
+  class rt {
+    constructor() {
+      (this.updateSession = Ve(() => this.updateUserSession(), 1e3)),
+        (this.updateUserSession = tt({
+          fetchUserSession: rt.fetchUserSession,
+          storeUserSession: rt.storeUserSession,
+        })),
+        this.init();
+    }
+    static removeUserSession() {
+      Be(We, rt.storageTypeLocal);
+    }
+    static storeUserSession(e) {
+      Ue(We, N(e), rt.storageTypeLocal);
+    }
+    static fetchUserSession() {
+      const e = Re(We, rt.storageTypeLocal);
+      return e ? JSON.parse(e) : null;
+    }
+    init() {
+      document.addEventListener("visibilitychange", () => {
+        "visible" === document.visibilityState && this.updateSession();
+      }),
+        e.faro.metas.addListener(
+          it({
+            fetchUserSession: rt.fetchUserSession,
+            storeUserSession: rt.storeUserSession,
+          })
+        );
+    }
+  }
+  rt.storageTypeLocal = _e.local;
+  class ot {
+    constructor() {
+      (this.updateSession = Ve(() => this.updateUserSession(), 1e3)),
+        (this.updateUserSession = tt({
+          fetchUserSession: ot.fetchUserSession,
+          storeUserSession: ot.storeUserSession,
+        })),
+        this.init();
+    }
+    static removeUserSession() {
+      Be(We, ot.storageTypeSession);
+    }
+    static storeUserSession(e) {
+      Ue(We, N(e), ot.storageTypeSession);
+    }
+    static fetchUserSession() {
+      const e = Re(We, ot.storageTypeSession);
+      return e ? JSON.parse(e) : null;
+    }
+    init() {
+      document.addEventListener("visibilitychange", () => {
+        "visible" === document.visibilityState && this.updateSession();
+      }),
+        e.faro.metas.addListener(
+          it({
+            fetchUserSession: ot.fetchUserSession,
+            storeUserSession: ot.storeUserSession,
+          })
+        );
+    }
+  }
+  function st(e) {
+    return (null == e ? void 0 : e.persistent) ? rt : ot;
+  }
+  ot.storageTypeSession = _e.session;
+  class at extends ge {
+    constructor() {
+      super(...arguments),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-session"),
+        (this.version = me);
+    }
+    sendSessionStartEvent(e) {
+      var t, n;
+      const i = e.session;
+      if (
+        i &&
+        i.id !==
+          (null === (t = this.notifiedSession) || void 0 === t ? void 0 : t.id)
+      ) {
+        if (
+          this.notifiedSession &&
+          this.notifiedSession.id ===
+            (null === (n = i.attributes) || void 0 === n
+              ? void 0
+              : n.previousSession)
+        )
+          return (
+            this.api.pushEvent(Oe, {}, void 0, { skipDedupe: !0 }),
+            void (this.notifiedSession = i)
+          );
+        (this.notifiedSession = i),
+          this.api.pushEvent(Ie, {}, void 0, { skipDedupe: !0 });
+      }
+    }
+    createInitialSession(e, t) {
+      var n, i, r, o, s, a;
+      let u,
+        c,
+        l = e.fetchUserSession();
+      if (t.persistent && t.maxSessionPersistenceTime && l) {
+        const e = E();
+        l.lastActivity < e - t.maxSessionPersistenceTime &&
+          (rt.removeUserSession(), (l = null));
+      }
+      if (et(l)) {
+        const e = null == l ? void 0 : l.sessionId;
+        c = Qe({
+          sessionId: e,
+          isSampled: l.isSampled || !1,
+          started: null == l ? void 0 : l.started,
+        });
+        const r = null == l ? void 0 : l.sessionMeta,
+          o = Object.assign(
+            Object.assign(
+              {},
+              null === (n = t.session) || void 0 === n ? void 0 : n.overrides
+            ),
+            null == r ? void 0 : r.overrides
+          );
+        (c.sessionMeta = Object.assign(Object.assign({}, t.session), {
+          id: e,
+          attributes: Object.assign(
+            Object.assign(
+              Object.assign(
+                {},
+                null === (i = t.session) || void 0 === i ? void 0 : i.attributes
+              ),
+              null == r ? void 0 : r.attributes
+            ),
+            { isSampled: c.isSampled.toString() }
+          ),
+          overrides: o,
+        })),
+          (u = ke);
+      } else {
+        const e =
+          null !==
+            (o = null === (r = t.session) || void 0 === r ? void 0 : r.id) &&
+          void 0 !== o
+            ? o
+            : Ne().id;
+        c = Qe({ sessionId: e, isSampled: Ye() });
+        const n =
+          null === (s = t.session) || void 0 === s ? void 0 : s.overrides;
+        (c.sessionMeta = Object.assign(
+          {
+            id: e,
+            attributes: Object.assign(
+              { isSampled: c.isSampled.toString() },
+              null === (a = t.session) || void 0 === a ? void 0 : a.attributes
+            ),
+          },
+          n ? { overrides: n } : {}
+        )),
+          (u = Ie);
+      }
+      return { initialSession: c, lifecycleType: u };
+    }
+    registerBeforeSendHook(e) {
+      var t;
+      const { updateSession: n } = new e();
+      null === (t = this.transports) ||
+        void 0 === t ||
+        t.addBeforeSendHooks((e) => {
+          var t, i, r;
+          n();
+          const o =
+            null === (t = e.meta.session) || void 0 === t
+              ? void 0
+              : t.attributes;
+          if (o && "true" === (null == o ? void 0 : o.isSampled)) {
+            let t = JSON.parse(JSON.stringify(e));
+            const n =
+              null === (i = t.meta.session) || void 0 === i
+                ? void 0
+                : i.attributes;
+            return (
+              null == n || delete n.isSampled,
+              0 === Object.keys(null != n ? n : {}).length &&
+                (null === (r = t.meta.session) ||
+                  void 0 === r ||
+                  delete r.attributes),
+              t
+            );
+          }
+          return null;
+        });
+    }
+    initialize() {
+      this.logDebug("init session instrumentation");
+      const e = this.config.sessionTracking;
+      if (null == e ? void 0 : e.enabled) {
+        const t = st(e);
+        this.registerBeforeSendHook(t);
+        const { initialSession: n, lifecycleType: i } =
+          this.createInitialSession(t, e);
+        t.storeUserSession(n);
+        const r = n.sessionMeta;
+        (this.notifiedSession = r),
+          this.api.setSession(r),
+          i === Ie && this.api.pushEvent(Ie, {}, void 0, { skipDedupe: !0 }),
+          i === ke && this.api.pushEvent(ke, {}, void 0, { skipDedupe: !0 });
+      }
+      this.metas.addListener(this.sendSessionStartEvent.bind(this));
+    }
+  }
+  const ut = "DOMError",
+    ct = "DOMException",
+    lt = "Non-Error exception captured with keys:",
+    dt = "?",
+    ft =
+      /^(?:[Uu]ncaught (?:exception: )?)?(?:((?:Eval|Internal|Range|Reference|Syntax|Type|URI|)Error): )?(.*)$/i;
+  const pt = "\n",
+    gt = "eval",
+    mt = "?",
+    vt = "@",
+    ht =
+      /^\s*at (?:(.*\).*?|.*?) ?\((?:address at )?)?((?:file|https?|blob|chrome-extension|address|native|eval|webpack|<anonymous>|[-a-z]+:|.*bundle|\/)?.*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i,
+    bt = /\((\S*)(?::(\d+))(?::(\d+))\)/,
+    wt = "eval",
+    yt = "address at ",
+    St = yt.length,
+    Tt =
+      /^\s*(.*?)(?:\((.*?)\))?(?:^|@)?((?:file|https?|blob|chrome|webpack|resource|moz-extension|safari-extension|safari-web-extension|capacitor)?:\/.*?|\[native code]|[^@]*(?:bundle|\d+\.js)|\/[\w\-. /=]+)(?::(\d+))?(?::(\d+))?\s*$/i,
+    Et = /(\S+) line (\d+)(?: > eval line \d+)* > eval/i,
+    It = " > eval",
+    kt = "safari-extension",
+    Ot = "safari-web-extension",
+    xt = /Minified React error #\d+;/i;
+  function Lt(e, t, n, i) {
+    const r = { filename: e || document.location.href, function: t || mt };
+    return void 0 !== n && (r.lineno = n), void 0 !== i && (r.colno = i), r;
+  }
+  function Ct(e, t) {
+    const n = null == e ? void 0 : e.includes(kt),
+      i = !n && (null == e ? void 0 : e.includes(Ot));
+    return n || i
+      ? [
+          (null == e ? void 0 : e.includes(vt)) ? e.split(vt)[0] : e,
+          n ? `${kt}:${t}` : `${Ot}:${t}`,
+        ]
+      : [e, t];
+  }
+  function At(e) {
+    let t = [];
+    e.stacktrace
+      ? (t = e.stacktrace.split(pt).filter((e, t) => t % 2 == 0))
+      : e.stack && (t = e.stack.split(pt));
+    const n = t.reduce((t, n, i) => {
+      let r, o, a, u, c;
+      if ((r = ht.exec(n))) {
+        if (
+          ((o = r[1]),
+          (a = r[2]),
+          (u = r[3]),
+          (c = r[4]),
+          null == a ? void 0 : a.startsWith(wt))
+        ) {
+          const e = bt.exec(a);
+          e && ((a = e[1]), (u = e[2]), (c = e[3]));
+        }
+        (a = (null == a ? void 0 : a.startsWith(yt)) ? a.substring(St) : a),
+          ([o, a] = Ct(o, a));
+      } else if ((r = Tt.exec(n))) {
+        if (
+          ((o = r[1]), (a = r[3]), (u = r[4]), (c = r[5]), a && a.includes(It))
+        ) {
+          const e = Et.exec(a);
+          e && ((o = o || gt), (a = e[1]), (u = e[2]));
+        } else
+          0 === i &&
+            !c &&
+            s(e.columnNumber) &&
+            (c = String(e.columnNumber + 1));
+        [o, a] = Ct(o, a);
+      }
+      return (
+        (a || o) &&
+          t.push(Lt(a, o, u ? Number(u) : void 0, c ? Number(c) : void 0)),
+        t
+      );
+    }, []);
+    return xt.test(e.message) ? n.slice(1) : n;
+  }
+  function Pt(e) {
+    return { frames: At(e) };
+  }
+  function Mt(e) {
+    let t,
+      n,
+      i,
+      r,
+      o = [];
+    if (v(e) && e.error)
+      (t = e.error.message), (n = e.error.name), (o = At(e.error));
+    else if ((i = h(e)) || b(e)) {
+      const { name: r, message: o } = e;
+      (n = null != r ? r : i ? ut : ct), (t = o ? `${n}: ${o}` : n);
+    } else
+      m(e)
+        ? ((t = e.message), (o = At(e)))
+        : (u(e) || (r = p(e))) &&
+          ((n = r ? e.constructor.name : void 0),
+          (t = `${lt} ${Object.keys(e)}`));
+    return [t, n, o];
+  }
+  function jt(e) {
+    const [t, n, i, r, s] = e;
+    let a,
+      u,
+      c = [];
+    const l = o(t),
+      d = Lt(n, dt, i, r);
+    return (
+      s || !l
+        ? (([a, u, c] = Mt(null != s ? s : t)), 0 === c.length && (c = [d]))
+        : l &&
+          (([a, u] = (function (e) {
+            var t, n;
+            const i = e.match(ft),
+              r =
+                null !== (t = null == i ? void 0 : i[1]) && void 0 !== t
+                  ? t
+                  : oe;
+            return [
+              null !== (n = null == i ? void 0 : i[2]) && void 0 !== n ? n : e,
+              r,
+            ];
+          })(t)),
+          (c = [d])),
+      { value: a, type: u, stackFrames: c }
+    );
+  }
+  function Nt(e, t) {
+    return m(e[0]) ? jt(e) : { value: t(e) };
+  }
+  class _t extends ge {
+    constructor(e = {}) {
+      super(),
+        (this.options = e),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-console"),
+        (this.version = me),
+        (this.errorSerializer = ce);
+    }
+    initialize() {
+      var t, n, i, r;
+      this.options = Object.assign(
+        Object.assign({}, this.options),
+        this.config.consoleInstrumentation
+      );
+      const o =
+        (null === (t = this.options) || void 0 === t
+          ? void 0
+          : t.serializeErrors) ||
+        !!(null === (n = this.options) || void 0 === n
+          ? void 0
+          : n.errorSerializer);
+      (this.errorSerializer = o
+        ? null !==
+            (r =
+              null === (i = this.options) || void 0 === i
+                ? void 0
+                : i.errorSerializer) && void 0 !== r
+          ? r
+          : se
+        : ce),
+        L.filter((e) => {
+          var t, n;
+          return !(
+            null !==
+              (n =
+                null === (t = this.options) || void 0 === t
+                  ? void 0
+                  : t.disabledLevels) && void 0 !== n
+              ? n
+              : _t.defaultDisabledLevels
+          ).includes(e);
+        }).forEach((t) => {
+          console[t] = (...n) => {
+            var i, r;
+            try {
+              if (
+                t !== e.LogLevel.ERROR ||
+                (null === (i = this.options) || void 0 === i
+                  ? void 0
+                  : i.consoleErrorAsLog)
+              )
+                if (
+                  t === e.LogLevel.ERROR &&
+                  (null === (r = this.options) || void 0 === r
+                    ? void 0
+                    : r.consoleErrorAsLog)
+                ) {
+                  const {
+                    value: e,
+                    type: i,
+                    stackFrames: r,
+                  } = Nt(n, this.errorSerializer);
+                  this.api.pushLog(e ? [_t.consoleErrorPrefix + e] : n, {
+                    level: t,
+                    context: {
+                      value: null != e ? e : "",
+                      type: null != i ? i : "",
+                      stackFrames: (null == r ? void 0 : r.length) ? se(r) : "",
+                    },
+                  });
+                } else this.api.pushLog(n, { level: t });
+              else {
+                const {
+                  value: e,
+                  type: t,
+                  stackFrames: i,
+                } = Nt(n, this.errorSerializer);
+                if (e && !t && !i)
+                  return void this.api.pushError(
+                    new Error(_t.consoleErrorPrefix + e)
+                  );
+                this.api.pushError(new Error(_t.consoleErrorPrefix + e), {
+                  type: t,
+                  stackFrames: i,
+                });
+              }
+            } catch (e) {
+              this.logError(e);
+            } finally {
+              this.unpatchedConsole[t](...n);
+            }
+          };
+        });
+    }
+  }
+  (_t.defaultDisabledLevels = [
+    e.LogLevel.DEBUG,
+    e.LogLevel.TRACE,
+    e.LogLevel.LOG,
+  ]),
+    (_t.consoleErrorPrefix = "console.error: ");
+  class Dt extends ge {
+    constructor() {
+      super(...arguments),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-errors"),
+        (this.version = me);
+    }
+    initialize() {
+      var e;
+      this.logDebug("Initializing"),
+        (function (e) {
+          const t = window.onerror;
+          window.onerror = (...n) => {
+            try {
+              const { value: t, type: i, stackFrames: r } = jt(n),
+                o = n[4];
+              if (t) {
+                const n = { type: i, stackFrames: r };
+                null != o && (n.originalError = o),
+                  e.pushError(new Error(t), n);
+              }
+            } finally {
+              null == t || t.apply(window, n);
+            }
+          };
+        })(this.api),
+        (e = this.api),
+        window.addEventListener("unhandledrejection", (t) => {
+          var n, i;
+          let r,
+            o,
+            s = t;
+          s.reason
+            ? (s = t.reason)
+            : (null === (n = t.detail) || void 0 === n ? void 0 : n.reason) &&
+              (s = null === (i = t.detail) || void 0 === i ? void 0 : i.reason);
+          let a = [];
+          d(s)
+            ? ((r = `Non-Error promise rejection captured with value: ${String(
+                s
+              )}`),
+              (o = "UnhandledRejection"))
+            : ([r, o, a] = Mt(s)),
+            r && e.pushError(new Error(r), { type: o, stackFrames: a });
+        });
+    }
+  }
+  class Rt extends ge {
+    constructor() {
+      super(...arguments),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-view"),
+        (this.version = me);
+    }
+    sendViewChangedEvent(e) {
+      var t, n, i, r;
+      const o = e.view;
+      o &&
+        o.name !==
+          (null === (t = this.notifiedView) || void 0 === t
+            ? void 0
+            : t.name) &&
+        (this.api.pushEvent(
+          Ee,
+          {
+            fromView:
+              null !==
+                (i =
+                  null === (n = this.notifiedView) || void 0 === n
+                    ? void 0
+                    : n.name) && void 0 !== i
+                ? i
+                : Le,
+            toView: null !== (r = o.name) && void 0 !== r ? r : Le,
+          },
+          void 0,
+          { skipDedupe: !0 }
+        ),
+        (this.notifiedView = o));
+    }
+    initialize() {
+      this.metas.addListener(this.sendViewChangedEvent.bind(this));
+    }
+  }
+  var Ut,
+    Bt,
+    Ft,
+    zt,
+    qt,
+    Vt = -1,
+    $t = function (e) {
+      addEventListener(
+        "pageshow",
+        function (t) {
+          t.persisted && ((Vt = t.timeStamp), e(t));
+        },
+        !0
+      );
+    },
+    Gt = function () {
+      var e =
+        self.performance &&
+        performance.getEntriesByType &&
+        performance.getEntriesByType("navigation")[0];
+      if (e && e.responseStart > 0 && e.responseStart < performance.now())
+        return e;
+    },
+    Ht = function () {
+      var e = Gt();
+      return (e && e.activationStart) || 0;
+    },
+    Wt = function (e, t) {
+      var n = Gt(),
+        i = "navigate";
+      return (
+        Vt >= 0
+          ? (i = "back-forward-cache")
+          : n &&
+            (document.prerendering || Ht() > 0
+              ? (i = "prerender")
+              : document.wasDiscarded
+              ? (i = "restore")
+              : n.type && (i = n.type.replace(/_/g, "-"))),
+        {
+          name: e,
+          value: void 0 === t ? -1 : t,
+          rating: "good",
+          delta: 0,
+          entries: [],
+          id: "v4-"
+            .concat(Date.now(), "-")
+            .concat(Math.floor(8999999999999 * Math.random()) + 1e12),
+          navigationType: i,
+        }
+      );
+    },
+    Kt = function (e, t, n) {
+      try {
+        if (PerformanceObserver.supportedEntryTypes.includes(e)) {
+          var i = new PerformanceObserver(function (e) {
+            Promise.resolve().then(function () {
+              t(e.getEntries());
+            });
+          });
+          return (
+            i.observe(Object.assign({ type: e, buffered: !0 }, n || {})), i
+          );
+        }
+      } catch (e) {}
+    },
+    Xt = function (e, t, n, i) {
+      var r, o;
+      return function (s) {
+        t.value >= 0 &&
+          (s || i) &&
+          ((o = t.value - (r || 0)) || void 0 === r) &&
+          ((r = t.value),
+          (t.delta = o),
+          (t.rating = (function (e, t) {
+            return e > t[1] ? "poor" : e > t[0] ? "needs-improvement" : "good";
+          })(t.value, n)),
+          e(t));
+      };
+    },
+    Jt = function (e) {
+      requestAnimationFrame(function () {
+        return requestAnimationFrame(function () {
+          return e();
+        });
+      });
+    },
+    Zt = function (e) {
+      document.addEventListener("visibilitychange", function () {
+        "hidden" === document.visibilityState && e();
+      });
+    },
+    Yt = function (e) {
+      var t = !1;
+      return function () {
+        t || (e(), (t = !0));
+      };
+    },
+    Qt = -1,
+    en = function () {
+      return "hidden" !== document.visibilityState || document.prerendering
+        ? 1 / 0
+        : 0;
+    },
+    tn = function (e) {
+      "hidden" === document.visibilityState &&
+        Qt > -1 &&
+        ((Qt = "visibilitychange" === e.type ? e.timeStamp : 0), rn());
+    },
+    nn = function () {
+      addEventListener("visibilitychange", tn, !0),
+        addEventListener("prerenderingchange", tn, !0);
+    },
+    rn = function () {
+      removeEventListener("visibilitychange", tn, !0),
+        removeEventListener("prerenderingchange", tn, !0);
+    },
+    on = function () {
+      return (
+        Qt < 0 &&
+          ((Qt = en()),
+          nn(),
+          $t(function () {
+            setTimeout(function () {
+              (Qt = en()), nn();
+            }, 0);
+          })),
+        {
+          get firstHiddenTime() {
+            return Qt;
+          },
+        }
+      );
+    },
+    sn = function (e) {
+      document.prerendering
+        ? addEventListener(
+            "prerenderingchange",
+            function () {
+              return e();
+            },
+            !0
+          )
+        : e();
+    },
+    an = [1800, 3e3],
+    un = function (e, t) {
+      (t = t || {}),
+        sn(function () {
+          var n,
+            i = on(),
+            r = Wt("FCP"),
+            o = Kt("paint", function (e) {
+              e.forEach(function (e) {
+                "first-contentful-paint" === e.name &&
+                  (o.disconnect(),
+                  e.startTime < i.firstHiddenTime &&
+                    ((r.value = Math.max(e.startTime - Ht(), 0)),
+                    r.entries.push(e),
+                    n(!0)));
+              });
+            });
+          o &&
+            ((n = Xt(e, r, an, t.reportAllChanges)),
+            $t(function (i) {
+              (r = Wt("FCP")),
+                (n = Xt(e, r, an, t.reportAllChanges)),
+                Jt(function () {
+                  (r.value = performance.now() - i.timeStamp), n(!0);
+                });
+            }));
+        });
+    },
+    cn = [0.1, 0.25],
+    ln = 0,
+    dn = 1 / 0,
+    fn = 0,
+    pn = function (e) {
+      e.forEach(function (e) {
+        e.interactionId &&
+          ((dn = Math.min(dn, e.interactionId)),
+          (fn = Math.max(fn, e.interactionId)),
+          (ln = fn ? (fn - dn) / 7 + 1 : 0));
+      });
+    },
+    gn = function () {
+      return Ut ? ln : performance.interactionCount || 0;
+    },
+    mn = [],
+    vn = new Map(),
+    hn = 0,
+    bn = [],
+    wn = function (e) {
+      if (
+        (bn.forEach(function (t) {
+          return t(e);
+        }),
+        e.interactionId || "first-input" === e.entryType)
+      ) {
+        var t = mn[mn.length - 1],
+          n = vn.get(e.interactionId);
+        if (n || mn.length < 10 || e.duration > t.latency) {
+          if (n)
+            e.duration > n.latency
+              ? ((n.entries = [e]), (n.latency = e.duration))
+              : e.duration === n.latency &&
+                e.startTime === n.entries[0].startTime &&
+                n.entries.push(e);
+          else {
+            var i = { id: e.interactionId, latency: e.duration, entries: [e] };
+            vn.set(i.id, i), mn.push(i);
+          }
+          mn.sort(function (e, t) {
+            return t.latency - e.latency;
+          }),
+            mn.length > 10 &&
+              mn.splice(10).forEach(function (e) {
+                return vn.delete(e.id);
+              });
+        }
+      }
+    },
+    yn = function (e) {
+      var t = self.requestIdleCallback || self.setTimeout,
+        n = -1;
+      return (
+        (e = Yt(e)),
+        "hidden" === document.visibilityState ? e() : ((n = t(e)), Zt(e)),
+        n
+      );
+    },
+    Sn = [200, 500],
+    Tn = [2500, 4e3],
+    En = {},
+    In = [800, 1800],
+    kn = function e(t) {
+      document.prerendering
+        ? sn(function () {
+            return e(t);
+          })
+        : "complete" !== document.readyState
+        ? addEventListener(
+            "load",
+            function () {
+              return e(t);
+            },
+            !0
+          )
+        : setTimeout(t, 0);
+    },
+    On = { passive: !0, capture: !0 },
+    xn = new Date(),
+    Ln = function (e, t) {
+      Bt ||
+        ((Bt = t), (Ft = e), (zt = new Date()), Pn(removeEventListener), Cn());
+    },
+    Cn = function () {
+      if (Ft >= 0 && Ft < zt - xn) {
+        var e = {
+          entryType: "first-input",
+          name: Bt.type,
+          target: Bt.target,
+          cancelable: Bt.cancelable,
+          startTime: Bt.timeStamp,
+          processingStart: Bt.timeStamp + Ft,
+        };
+        qt.forEach(function (t) {
+          t(e);
+        }),
+          (qt = []);
+      }
+    },
+    An = function (e) {
+      if (e.cancelable) {
+        var t =
+          (e.timeStamp > 1e12 ? new Date() : performance.now()) - e.timeStamp;
+        "pointerdown" == e.type
+          ? (function (e, t) {
+              var n = function () {
+                  Ln(e, t), r();
+                },
+                i = function () {
+                  r();
+                },
+                r = function () {
+                  removeEventListener("pointerup", n, On),
+                    removeEventListener("pointercancel", i, On);
+                };
+              addEventListener("pointerup", n, On),
+                addEventListener("pointercancel", i, On);
+            })(t, e)
+          : Ln(t, e);
+      }
+    },
+    Pn = function (e) {
+      ["mousedown", "keydown", "touchstart", "pointerdown"].forEach(function (
+        t
+      ) {
+        return e(t, An, On);
+      });
+    },
+    Mn = [100, 300];
+  class jn {
+    constructor(e, t) {
+      (this.pushMeasurement = e), (this.webVitalConfig = t);
+    }
+    initialize() {
+      Object.entries(jn.mapping).forEach(([e, t]) => {
+        var n;
+        t(
+          (t) => {
+            this.pushMeasurement({
+              type: "web-vitals",
+              values: { [e]: t.value },
+            });
+          },
+          {
+            reportAllChanges:
+              null === (n = this.webVitalConfig) || void 0 === n
+                ? void 0
+                : n.reportAllChanges,
+          }
+        );
+      });
+    }
+  }
+  jn.mapping = {
+    cls: function (e, t) {
+      (t = t || {}),
+        un(
+          Yt(function () {
+            var n,
+              i = Wt("CLS", 0),
+              r = 0,
+              o = [],
+              s = function (e) {
+                e.forEach(function (e) {
+                  if (!e.hadRecentInput) {
+                    var t = o[0],
+                      n = o[o.length - 1];
+                    r &&
+                    e.startTime - n.startTime < 1e3 &&
+                    e.startTime - t.startTime < 5e3
+                      ? ((r += e.value), o.push(e))
+                      : ((r = e.value), (o = [e]));
+                  }
+                }),
+                  r > i.value && ((i.value = r), (i.entries = o), n());
+              },
+              a = Kt("layout-shift", s);
+            a &&
+              ((n = Xt(e, i, cn, t.reportAllChanges)),
+              Zt(function () {
+                s(a.takeRecords()), n(!0);
+              }),
+              $t(function () {
+                (r = 0),
+                  (i = Wt("CLS", 0)),
+                  (n = Xt(e, i, cn, t.reportAllChanges)),
+                  Jt(function () {
+                    return n();
+                  });
+              }),
+              setTimeout(n, 0));
+          })
+        );
+    },
+    fcp: un,
+    fid: function (e, t) {
+      (t = t || {}),
+        sn(function () {
+          var n,
+            i = on(),
+            r = Wt("FID"),
+            o = function (e) {
+              e.startTime < i.firstHiddenTime &&
+                ((r.value = e.processingStart - e.startTime),
+                r.entries.push(e),
+                n(!0));
+            },
+            s = function (e) {
+              e.forEach(o);
+            },
+            a = Kt("first-input", s);
+          (n = Xt(e, r, Mn, t.reportAllChanges)),
+            a &&
+              (Zt(
+                Yt(function () {
+                  s(a.takeRecords()), a.disconnect();
+                })
+              ),
+              $t(function () {
+                var i;
+                (r = Wt("FID")),
+                  (n = Xt(e, r, Mn, t.reportAllChanges)),
+                  (qt = []),
+                  (Ft = -1),
+                  (Bt = null),
+                  Pn(addEventListener),
+                  (i = o),
+                  qt.push(i),
+                  Cn();
+              }));
+        });
+    },
+    inp: function (e, t) {
+      "PerformanceEventTiming" in self &&
+        "interactionId" in PerformanceEventTiming.prototype &&
+        ((t = t || {}),
+        sn(function () {
+          var n;
+          "interactionCount" in performance ||
+            Ut ||
+            (Ut = Kt("event", pn, {
+              type: "event",
+              buffered: !0,
+              durationThreshold: 0,
+            }));
+          var i,
+            r = Wt("INP"),
+            o = function (e) {
+              yn(function () {
+                e.forEach(wn);
+                var t = (function () {
+                  var e = Math.min(mn.length - 1, Math.floor((gn() - hn) / 50));
+                  return mn[e];
+                })();
+                t &&
+                  t.latency !== r.value &&
+                  ((r.value = t.latency), (r.entries = t.entries), i());
+              });
+            },
+            s = Kt("event", o, {
+              durationThreshold:
+                null !== (n = t.durationThreshold) && void 0 !== n ? n : 40,
+            });
+          (i = Xt(e, r, Sn, t.reportAllChanges)),
+            s &&
+              (s.observe({ type: "first-input", buffered: !0 }),
+              Zt(function () {
+                o(s.takeRecords()), i(!0);
+              }),
+              $t(function () {
+                (hn = gn()),
+                  (mn.length = 0),
+                  vn.clear(),
+                  (r = Wt("INP")),
+                  (i = Xt(e, r, Sn, t.reportAllChanges));
+              }));
+        }));
+    },
+    lcp: function (e, t) {
+      (t = t || {}),
+        sn(function () {
+          var n,
+            i = on(),
+            r = Wt("LCP"),
+            o = function (e) {
+              t.reportAllChanges || (e = e.slice(-1)),
+                e.forEach(function (e) {
+                  e.startTime < i.firstHiddenTime &&
+                    ((r.value = Math.max(e.startTime - Ht(), 0)),
+                    (r.entries = [e]),
+                    n());
+                });
+            },
+            s = Kt("largest-contentful-paint", o);
+          if (s) {
+            n = Xt(e, r, Tn, t.reportAllChanges);
+            var a = Yt(function () {
+              En[r.id] ||
+                (o(s.takeRecords()), s.disconnect(), (En[r.id] = !0), n(!0));
+            });
+            ["keydown", "click"].forEach(function (e) {
+              addEventListener(
+                e,
+                function () {
+                  return yn(a);
+                },
+                { once: !0, capture: !0 }
+              );
+            }),
+              Zt(a),
+              $t(function (i) {
+                (r = Wt("LCP")),
+                  (n = Xt(e, r, Tn, t.reportAllChanges)),
+                  Jt(function () {
+                    (r.value = performance.now() - i.timeStamp),
+                      (En[r.id] = !0),
+                      n(!0);
+                  });
+              });
+          }
+        });
+    },
+    ttfb: function (e, t) {
+      t = t || {};
+      var n = Wt("TTFB"),
+        i = Xt(e, n, In, t.reportAllChanges);
+      kn(function () {
+        var r = Gt();
+        r &&
+          ((n.value = Math.max(r.responseStart - Ht(), 0)),
+          (n.entries = [r]),
+          i(!0),
+          $t(function () {
+            (n = Wt("TTFB", 0)), (i = Xt(e, n, In, t.reportAllChanges))(!0);
+          }));
+      });
+    },
+  };
+  var Nn,
+    _n,
+    Dn = function () {
+      var e =
+        self.performance &&
+        performance.getEntriesByType &&
+        performance.getEntriesByType("navigation")[0];
+      if (e && e.responseStart > 0 && e.responseStart < performance.now())
+        return e;
+    },
+    Rn = function (e) {
+      if ("loading" === document.readyState) return "loading";
+      var t = Dn();
+      if (t) {
+        if (e < t.domInteractive) return "loading";
+        if (
+          0 === t.domContentLoadedEventStart ||
+          e < t.domContentLoadedEventStart
+        )
+          return "dom-interactive";
+        if (0 === t.domComplete || e < t.domComplete)
+          return "dom-content-loaded";
+      }
+      return "complete";
+    },
+    Un = function (e) {
+      var t = e.nodeName;
+      return 1 === e.nodeType
+        ? t.toLowerCase()
+        : t.toUpperCase().replace(/^#/, "");
+    },
+    Bn = function (e, t) {
+      var n = "";
+      try {
+        for (; e && 9 !== e.nodeType; ) {
+          var i = e,
+            r = i.id
+              ? "#" + i.id
+              : Un(i) +
+                (i.classList &&
+                i.classList.value &&
+                i.classList.value.trim() &&
+                i.classList.value.trim().length
+                  ? "." + i.classList.value.trim().replace(/\s+/g, ".")
+                  : "");
+          if (n.length + r.length > (t || 100) - 1) return n || r;
+          if (((n = n ? r + ">" + n : r), i.id)) break;
+          e = i.parentNode;
+        }
+      } catch (e) {}
+      return n;
+    },
+    Fn = -1,
+    zn = function () {
+      return Fn;
+    },
+    qn = function (e) {
+      addEventListener(
+        "pageshow",
+        function (t) {
+          t.persisted && ((Fn = t.timeStamp), e(t));
+        },
+        !0
+      );
+    },
+    Vn = function () {
+      var e = Dn();
+      return (e && e.activationStart) || 0;
+    },
+    $n = function (e, t) {
+      var n = Dn(),
+        i = "navigate";
+      return (
+        zn() >= 0
+          ? (i = "back-forward-cache")
+          : n &&
+            (document.prerendering || Vn() > 0
+              ? (i = "prerender")
+              : document.wasDiscarded
+              ? (i = "restore")
+              : n.type && (i = n.type.replace(/_/g, "-"))),
+        {
+          name: e,
+          value: void 0 === t ? -1 : t,
+          rating: "good",
+          delta: 0,
+          entries: [],
+          id: "v4-"
+            .concat(Date.now(), "-")
+            .concat(Math.floor(8999999999999 * Math.random()) + 1e12),
+          navigationType: i,
+        }
+      );
+    },
+    Gn = function (e, t, n) {
+      try {
+        if (PerformanceObserver.supportedEntryTypes.includes(e)) {
+          var i = new PerformanceObserver(function (e) {
+            Promise.resolve().then(function () {
+              t(e.getEntries());
+            });
+          });
+          return (
+            i.observe(Object.assign({ type: e, buffered: !0 }, n || {})), i
+          );
+        }
+      } catch (e) {}
+    },
+    Hn = function (e, t, n, i) {
+      var r, o;
+      return function (s) {
+        t.value >= 0 &&
+          (s || i) &&
+          ((o = t.value - (r || 0)) || void 0 === r) &&
+          ((r = t.value),
+          (t.delta = o),
+          (t.rating = (function (e, t) {
+            return e > t[1] ? "poor" : e > t[0] ? "needs-improvement" : "good";
+          })(t.value, n)),
+          e(t));
+      };
+    },
+    Wn = function (e) {
+      requestAnimationFrame(function () {
+        return requestAnimationFrame(function () {
+          return e();
+        });
+      });
+    },
+    Kn = function (e) {
+      document.addEventListener("visibilitychange", function () {
+        "hidden" === document.visibilityState && e();
+      });
+    },
+    Xn = function (e) {
+      var t = !1;
+      return function () {
+        t || (e(), (t = !0));
+      };
+    },
+    Jn = -1,
+    Zn = function () {
+      return "hidden" !== document.visibilityState || document.prerendering
+        ? 1 / 0
+        : 0;
+    },
+    Yn = function (e) {
+      "hidden" === document.visibilityState &&
+        Jn > -1 &&
+        ((Jn = "visibilitychange" === e.type ? e.timeStamp : 0), ei());
+    },
+    Qn = function () {
+      addEventListener("visibilitychange", Yn, !0),
+        addEventListener("prerenderingchange", Yn, !0);
+    },
+    ei = function () {
+      removeEventListener("visibilitychange", Yn, !0),
+        removeEventListener("prerenderingchange", Yn, !0);
+    },
+    ti = function () {
+      return (
+        Jn < 0 &&
+          ((Jn = Zn()),
+          Qn(),
+          qn(function () {
+            setTimeout(function () {
+              (Jn = Zn()), Qn();
+            }, 0);
+          })),
+        {
+          get firstHiddenTime() {
+            return Jn;
+          },
+        }
+      );
+    },
+    ni = function (e) {
+      document.prerendering
+        ? addEventListener(
+            "prerenderingchange",
+            function () {
+              return e();
+            },
+            !0
+          )
+        : e();
+    },
+    ii = [1800, 3e3],
+    ri = function (e, t) {
+      (t = t || {}),
+        ni(function () {
+          var n,
+            i = ti(),
+            r = $n("FCP"),
+            o = Gn("paint", function (e) {
+              e.forEach(function (e) {
+                "first-contentful-paint" === e.name &&
+                  (o.disconnect(),
+                  e.startTime < i.firstHiddenTime &&
+                    ((r.value = Math.max(e.startTime - Vn(), 0)),
+                    r.entries.push(e),
+                    n(!0)));
+              });
+            });
+          o &&
+            ((n = Hn(e, r, ii, t.reportAllChanges)),
+            qn(function (i) {
+              (r = $n("FCP")),
+                (n = Hn(e, r, ii, t.reportAllChanges)),
+                Wn(function () {
+                  (r.value = performance.now() - i.timeStamp), n(!0);
+                });
+            }));
+        });
+    },
+    oi = [0.1, 0.25],
+    si = 0,
+    ai = 1 / 0,
+    ui = 0,
+    ci = function (e) {
+      e.forEach(function (e) {
+        e.interactionId &&
+          ((ai = Math.min(ai, e.interactionId)),
+          (ui = Math.max(ui, e.interactionId)),
+          (si = ui ? (ui - ai) / 7 + 1 : 0));
+      });
+    },
+    li = function () {
+      return Nn ? si : performance.interactionCount || 0;
+    },
+    di = function () {
+      "interactionCount" in performance ||
+        Nn ||
+        (Nn = Gn("event", ci, {
+          type: "event",
+          buffered: !0,
+          durationThreshold: 0,
+        }));
+    },
+    fi = [],
+    pi = new Map(),
+    gi = 0,
+    mi = [],
+    vi = function (e) {
+      if (
+        (mi.forEach(function (t) {
+          return t(e);
+        }),
+        e.interactionId || "first-input" === e.entryType)
+      ) {
+        var t = fi[fi.length - 1],
+          n = pi.get(e.interactionId);
+        if (n || fi.length < 10 || e.duration > t.latency) {
+          if (n)
+            e.duration > n.latency
+              ? ((n.entries = [e]), (n.latency = e.duration))
+              : e.duration === n.latency &&
+                e.startTime === n.entries[0].startTime &&
+                n.entries.push(e);
+          else {
+            var i = { id: e.interactionId, latency: e.duration, entries: [e] };
+            pi.set(i.id, i), fi.push(i);
+          }
+          fi.sort(function (e, t) {
+            return t.latency - e.latency;
+          }),
+            fi.length > 10 &&
+              fi.splice(10).forEach(function (e) {
+                return pi.delete(e.id);
+              });
+        }
+      }
+    },
+    hi = function (e) {
+      var t = self.requestIdleCallback || self.setTimeout,
+        n = -1;
+      return (
+        (e = Xn(e)),
+        "hidden" === document.visibilityState ? e() : ((n = t(e)), Kn(e)),
+        n
+      );
+    },
+    bi = [200, 500],
+    wi = function (e, t) {
+      "PerformanceEventTiming" in self &&
+        "interactionId" in PerformanceEventTiming.prototype &&
+        ((t = t || {}),
+        ni(function () {
+          var n;
+          di();
+          var i,
+            r = $n("INP"),
+            o = function (e) {
+              hi(function () {
+                e.forEach(vi);
+                var t = (function () {
+                  var e = Math.min(fi.length - 1, Math.floor((li() - gi) / 50));
+                  return fi[e];
+                })();
+                t &&
+                  t.latency !== r.value &&
+                  ((r.value = t.latency), (r.entries = t.entries), i());
+              });
+            },
+            s = Gn("event", o, {
+              durationThreshold:
+                null !== (n = t.durationThreshold) && void 0 !== n ? n : 40,
+            });
+          (i = Hn(e, r, bi, t.reportAllChanges)),
+            s &&
+              (s.observe({ type: "first-input", buffered: !0 }),
+              Kn(function () {
+                o(s.takeRecords()), i(!0);
+              }),
+              qn(function () {
+                (gi = li()),
+                  (fi.length = 0),
+                  pi.clear(),
+                  (r = $n("INP")),
+                  (i = Hn(e, r, bi, t.reportAllChanges));
+              }));
+        }));
+    },
+    yi = [],
+    Si = [],
+    Ti = 0,
+    Ei = new WeakMap(),
+    Ii = new Map(),
+    ki = -1,
+    Oi = function (e) {
+      (yi = yi.concat(e)), xi();
+    },
+    xi = function () {
+      ki < 0 && (ki = hi(Li));
+    },
+    Li = function () {
+      Ii.size > 10 &&
+        Ii.forEach(function (e, t) {
+          pi.has(t) || Ii.delete(t);
+        });
+      var e = fi.map(function (e) {
+          return Ei.get(e.entries[0]);
+        }),
+        t = Si.length - 50;
+      Si = Si.filter(function (n, i) {
+        return i >= t || e.includes(n);
+      });
+      for (var n = new Set(), i = 0; i < Si.length; i++) {
+        var r = Si[i];
+        ji(r.startTime, r.processingEnd).forEach(function (e) {
+          n.add(e);
+        });
+      }
+      var o = yi.length - 1 - 50;
+      (yi = yi.filter(function (e, t) {
+        return (e.startTime > Ti && t > o) || n.has(e);
+      })),
+        (ki = -1);
+    };
+  mi.push(
+    function (e) {
+      e.interactionId &&
+        e.target &&
+        !Ii.has(e.interactionId) &&
+        Ii.set(e.interactionId, e.target);
+    },
+    function (e) {
+      var t,
+        n = e.startTime + e.duration;
+      Ti = Math.max(Ti, e.processingEnd);
+      for (var i = Si.length - 1; i >= 0; i--) {
+        var r = Si[i];
+        if (Math.abs(n - r.renderTime) <= 8) {
+          ((t = r).startTime = Math.min(e.startTime, t.startTime)),
+            (t.processingStart = Math.min(
+              e.processingStart,
+              t.processingStart
+            )),
+            (t.processingEnd = Math.max(e.processingEnd, t.processingEnd)),
+            t.entries.push(e);
+          break;
+        }
+      }
+      t ||
+        ((t = {
+          startTime: e.startTime,
+          processingStart: e.processingStart,
+          processingEnd: e.processingEnd,
+          renderTime: n,
+          entries: [e],
+        }),
+        Si.push(t)),
+        (e.interactionId || "first-input" === e.entryType) && Ei.set(e, t),
+        xi();
+    }
+  );
+  var Ci,
+    Ai,
+    Pi,
+    Mi,
+    ji = function (e, t) {
+      for (var n, i = [], r = 0; (n = yi[r]); r++)
+        if (!(n.startTime + n.duration < e)) {
+          if (n.startTime > t) break;
+          i.push(n);
+        }
+      return i;
+    },
+    Ni = [2500, 4e3],
+    _i = {},
+    Di = [800, 1800],
+    Ri = function e(t) {
+      document.prerendering
+        ? ni(function () {
+            return e(t);
+          })
+        : "complete" !== document.readyState
+        ? addEventListener(
+            "load",
+            function () {
+              return e(t);
+            },
+            !0
+          )
+        : setTimeout(t, 0);
+    },
+    Ui = function (e, t) {
+      t = t || {};
+      var n = $n("TTFB"),
+        i = Hn(e, n, Di, t.reportAllChanges);
+      Ri(function () {
+        var r = Dn();
+        r &&
+          ((n.value = Math.max(r.responseStart - Vn(), 0)),
+          (n.entries = [r]),
+          i(!0),
+          qn(function () {
+            (n = $n("TTFB", 0)), (i = Hn(e, n, Di, t.reportAllChanges))(!0);
+          }));
+      });
+    },
+    Bi = { passive: !0, capture: !0 },
+    Fi = new Date(),
+    zi = function (e, t) {
+      Ci ||
+        ((Ci = t), (Ai = e), (Pi = new Date()), $i(removeEventListener), qi());
+    },
+    qi = function () {
+      if (Ai >= 0 && Ai < Pi - Fi) {
+        var e = {
+          entryType: "first-input",
+          name: Ci.type,
+          target: Ci.target,
+          cancelable: Ci.cancelable,
+          startTime: Ci.timeStamp,
+          processingStart: Ci.timeStamp + Ai,
+        };
+        Mi.forEach(function (t) {
+          t(e);
+        }),
+          (Mi = []);
+      }
+    },
+    Vi = function (e) {
+      if (e.cancelable) {
+        var t =
+          (e.timeStamp > 1e12 ? new Date() : performance.now()) - e.timeStamp;
+        "pointerdown" == e.type
+          ? (function (e, t) {
+              var n = function () {
+                  zi(e, t), r();
+                },
+                i = function () {
+                  r();
+                },
+                r = function () {
+                  removeEventListener("pointerup", n, Bi),
+                    removeEventListener("pointercancel", i, Bi);
+                };
+              addEventListener("pointerup", n, Bi),
+                addEventListener("pointercancel", i, Bi);
+            })(t, e)
+          : zi(t, e);
+      }
+    },
+    $i = function (e) {
+      ["mousedown", "keydown", "touchstart", "pointerdown"].forEach(function (
+        t
+      ) {
+        return e(t, Vi, Bi);
+      });
+    },
+    Gi = [100, 300],
+    Hi = function (e, t) {
+      !(function (e, t) {
+        (t = t || {}),
+          ni(function () {
+            var n,
+              i = ti(),
+              r = $n("FID"),
+              o = function (e) {
+                e.startTime < i.firstHiddenTime &&
+                  ((r.value = e.processingStart - e.startTime),
+                  r.entries.push(e),
+                  n(!0));
+              },
+              s = function (e) {
+                e.forEach(o);
+              },
+              a = Gn("first-input", s);
+            (n = Hn(e, r, Gi, t.reportAllChanges)),
+              a &&
+                (Kn(
+                  Xn(function () {
+                    s(a.takeRecords()), a.disconnect();
+                  })
+                ),
+                qn(function () {
+                  var i;
+                  (r = $n("FID")),
+                    (n = Hn(e, r, Gi, t.reportAllChanges)),
+                    (Mi = []),
+                    (Ai = -1),
+                    (Ci = null),
+                    $i(addEventListener),
+                    (i = o),
+                    Mi.push(i),
+                    qi();
+                }));
+          });
+      })(function (t) {
+        var n = (function (e) {
+          var t = e.entries[0],
+            n = {
+              eventTarget: Bn(t.target),
+              eventType: t.name,
+              eventTime: t.startTime,
+              eventEntry: t,
+              loadState: Rn(t.startTime),
+            };
+          return Object.assign(e, { attribution: n });
+        })(t);
+        e(n);
+      }, t);
+    };
+  const Wi = "com.grafana.faro.lastNavigationId",
+    Ki = "load_state",
+    Xi = "time_to_first_byte";
+  class Ji {
+    constructor(e, t) {
+      (this.corePushMeasurement = e), (this.webVitalConfig = t);
+    }
+    initialize() {
+      this.measureCLS(),
+        this.measureFCP(),
+        this.measureFID(),
+        this.measureINP(),
+        this.measureLCP(),
+        this.measureTTFB();
+    }
+    measureCLS() {
+      var e;
+      !(function (e, t) {
+        !(function (e, t) {
+          (t = t || {}),
+            ri(
+              Xn(function () {
+                var n,
+                  i = $n("CLS", 0),
+                  r = 0,
+                  o = [],
+                  s = function (e) {
+                    e.forEach(function (e) {
+                      if (!e.hadRecentInput) {
+                        var t = o[0],
+                          n = o[o.length - 1];
+                        r &&
+                        e.startTime - n.startTime < 1e3 &&
+                        e.startTime - t.startTime < 5e3
+                          ? ((r += e.value), o.push(e))
+                          : ((r = e.value), (o = [e]));
+                      }
+                    }),
+                      r > i.value && ((i.value = r), (i.entries = o), n());
+                  },
+                  a = Gn("layout-shift", s);
+                a &&
+                  ((n = Hn(e, i, oi, t.reportAllChanges)),
+                  Kn(function () {
+                    s(a.takeRecords()), n(!0);
+                  }),
+                  qn(function () {
+                    (r = 0),
+                      (i = $n("CLS", 0)),
+                      (n = Hn(e, i, oi, t.reportAllChanges)),
+                      Wn(function () {
+                        return n();
+                      });
+                  }),
+                  setTimeout(n, 0));
+              })
+            );
+        })(function (t) {
+          var n = (function (e) {
+            var t,
+              n = {};
+            if (e.entries.length) {
+              var i = e.entries.reduce(function (e, t) {
+                return e && e.value > t.value ? e : t;
+              });
+              if (i && i.sources && i.sources.length) {
+                var r =
+                  (t = i.sources).find(function (e) {
+                    return e.node && 1 === e.node.nodeType;
+                  }) || t[0];
+                r &&
+                  (n = {
+                    largestShiftTarget: Bn(r.node),
+                    largestShiftTime: i.startTime,
+                    largestShiftValue: i.value,
+                    largestShiftSource: r,
+                    largestShiftEntry: i,
+                    loadState: Rn(i.startTime),
+                  });
+              }
+            }
+            return Object.assign(e, { attribution: n });
+          })(t);
+          e(n);
+        }, t);
+      })(
+        (e) => {
+          const {
+              loadState: t,
+              largestShiftValue: n,
+              largestShiftTime: i,
+              largestShiftTarget: r,
+            } = e.attribution,
+            o = this.buildInitialValues(e);
+          this.addIfPresent(o, "largest_shift_value", n),
+            this.addIfPresent(o, "largest_shift_time", i);
+          const s = this.buildInitialContext(e);
+          this.addIfPresent(s, Ki, t),
+            this.addIfPresent(s, "largest_shift_target", r),
+            this.pushMeasurement(o, s);
+        },
+        {
+          reportAllChanges:
+            null === (e = this.webVitalConfig) || void 0 === e
+              ? void 0
+              : e.reportAllChanges,
+        }
+      );
+    }
+    measureFCP() {
+      var e;
+      !(function (e, t) {
+        ri(function (t) {
+          var n = (function (e) {
+            var t = {
+              timeToFirstByte: 0,
+              firstByteToFCP: e.value,
+              loadState: Rn(zn()),
+            };
+            if (e.entries.length) {
+              var n = Dn(),
+                i = e.entries[e.entries.length - 1];
+              if (n) {
+                var r = n.activationStart || 0,
+                  o = Math.max(0, n.responseStart - r);
+                t = {
+                  timeToFirstByte: o,
+                  firstByteToFCP: e.value - o,
+                  loadState: Rn(e.entries[0].startTime),
+                  navigationEntry: n,
+                  fcpEntry: i,
+                };
+              }
+            }
+            return Object.assign(e, { attribution: t });
+          })(t);
+          e(n);
+        }, t);
+      })(
+        (e) => {
+          const {
+              firstByteToFCP: t,
+              timeToFirstByte: n,
+              loadState: i,
+            } = e.attribution,
+            r = this.buildInitialValues(e);
+          this.addIfPresent(r, "first_byte_to_fcp", t),
+            this.addIfPresent(r, Xi, n);
+          const o = this.buildInitialContext(e);
+          this.addIfPresent(o, Ki, i), this.pushMeasurement(r, o);
+        },
+        {
+          reportAllChanges:
+            null === (e = this.webVitalConfig) || void 0 === e
+              ? void 0
+              : e.reportAllChanges,
+        }
+      );
+    }
+    measureFID() {
+      var e;
+      Hi(
+        (e) => {
+          const {
+              eventTime: t,
+              eventTarget: n,
+              eventType: i,
+              loadState: r,
+            } = e.attribution,
+            o = this.buildInitialValues(e);
+          this.addIfPresent(o, "event_time", t);
+          const s = this.buildInitialContext(e);
+          this.addIfPresent(s, "event_target", n),
+            this.addIfPresent(s, "event_type", i),
+            this.addIfPresent(s, Ki, r),
+            this.pushMeasurement(o, s);
+        },
+        {
+          reportAllChanges:
+            null === (e = this.webVitalConfig) || void 0 === e
+              ? void 0
+              : e.reportAllChanges,
+        }
+      );
+    }
+    measureINP() {
+      var e;
+      !(function (e, t) {
+        _n || (_n = Gn("long-animation-frame", Oi)),
+          wi(function (t) {
+            var n = (function (e) {
+              var t = e.entries[0],
+                n = Ei.get(t),
+                i = t.processingStart,
+                r = n.processingEnd,
+                o = n.entries.sort(function (e, t) {
+                  return e.processingStart - t.processingStart;
+                }),
+                s = ji(t.startTime, r),
+                a = e.entries.find(function (e) {
+                  return e.target;
+                }),
+                u = (a && a.target) || Ii.get(t.interactionId),
+                c = [t.startTime + t.duration, r].concat(
+                  s.map(function (e) {
+                    return e.startTime + e.duration;
+                  })
+                ),
+                l = Math.max.apply(Math, c),
+                d = {
+                  interactionTarget: Bn(u),
+                  interactionTargetElement: u,
+                  interactionType: t.name.startsWith("key")
+                    ? "keyboard"
+                    : "pointer",
+                  interactionTime: t.startTime,
+                  nextPaintTime: l,
+                  processedEventEntries: o,
+                  longAnimationFrameEntries: s,
+                  inputDelay: i - t.startTime,
+                  processingDuration: r - i,
+                  presentationDelay: Math.max(l - r, 0),
+                  loadState: Rn(t.startTime),
+                };
+              return Object.assign(e, { attribution: d });
+            })(t);
+            e(n);
+          }, t);
+      })(
+        (e) => {
+          const {
+              interactionTime: t,
+              presentationDelay: n,
+              inputDelay: i,
+              processingDuration: r,
+              nextPaintTime: o,
+              loadState: s,
+              interactionTarget: a,
+              interactionType: u,
+            } = e.attribution,
+            c = this.buildInitialValues(e);
+          this.addIfPresent(c, "interaction_time", t),
+            this.addIfPresent(c, "presentation_delay", n),
+            this.addIfPresent(c, "input_delay", i),
+            this.addIfPresent(c, "processing_duration", r),
+            this.addIfPresent(c, "next_paint_time", o);
+          const l = this.buildInitialContext(e);
+          this.addIfPresent(l, Ki, s),
+            this.addIfPresent(l, "interaction_target", a),
+            this.addIfPresent(l, "interaction_type", u),
+            this.pushMeasurement(c, l);
+        },
+        {
+          reportAllChanges:
+            null === (e = this.webVitalConfig) || void 0 === e
+              ? void 0
+              : e.reportAllChanges,
+        }
+      );
+    }
+    measureLCP() {
+      var e;
+      !(function (e, t) {
+        !(function (e, t) {
+          (t = t || {}),
+            ni(function () {
+              var n,
+                i = ti(),
+                r = $n("LCP"),
+                o = function (e) {
+                  t.reportAllChanges || (e = e.slice(-1)),
+                    e.forEach(function (e) {
+                      e.startTime < i.firstHiddenTime &&
+                        ((r.value = Math.max(e.startTime - Vn(), 0)),
+                        (r.entries = [e]),
+                        n());
+                    });
+                },
+                s = Gn("largest-contentful-paint", o);
+              if (s) {
+                n = Hn(e, r, Ni, t.reportAllChanges);
+                var a = Xn(function () {
+                  _i[r.id] ||
+                    (o(s.takeRecords()),
+                    s.disconnect(),
+                    (_i[r.id] = !0),
+                    n(!0));
+                });
+                ["keydown", "click"].forEach(function (e) {
+                  addEventListener(
+                    e,
+                    function () {
+                      return hi(a);
+                    },
+                    { once: !0, capture: !0 }
+                  );
+                }),
+                  Kn(a),
+                  qn(function (i) {
+                    (r = $n("LCP")),
+                      (n = Hn(e, r, Ni, t.reportAllChanges)),
+                      Wn(function () {
+                        (r.value = performance.now() - i.timeStamp),
+                          (_i[r.id] = !0),
+                          n(!0);
+                      });
+                  });
+              }
+            });
+        })(function (t) {
+          var n = (function (e) {
+            var t = {
+              timeToFirstByte: 0,
+              resourceLoadDelay: 0,
+              resourceLoadDuration: 0,
+              elementRenderDelay: e.value,
+            };
+            if (e.entries.length) {
+              var n = Dn();
+              if (n) {
+                var i = n.activationStart || 0,
+                  r = e.entries[e.entries.length - 1],
+                  o =
+                    r.url &&
+                    performance
+                      .getEntriesByType("resource")
+                      .filter(function (e) {
+                        return e.name === r.url;
+                      })[0],
+                  s = Math.max(0, n.responseStart - i),
+                  a = Math.max(s, o ? (o.requestStart || o.startTime) - i : 0),
+                  u = Math.max(a, o ? o.responseEnd - i : 0),
+                  c = Math.max(u, r.startTime - i);
+                (t = {
+                  element: Bn(r.element),
+                  timeToFirstByte: s,
+                  resourceLoadDelay: a - s,
+                  resourceLoadDuration: u - a,
+                  elementRenderDelay: c - u,
+                  navigationEntry: n,
+                  lcpEntry: r,
+                }),
+                  r.url && (t.url = r.url),
+                  o && (t.lcpResourceEntry = o);
+              }
+            }
+            return Object.assign(e, { attribution: t });
+          })(t);
+          e(n);
+        }, t);
+      })(
+        (e) => {
+          const {
+              elementRenderDelay: t,
+              resourceLoadDelay: n,
+              resourceLoadDuration: i,
+              timeToFirstByte: r,
+              element: o,
+            } = e.attribution,
+            s = this.buildInitialValues(e);
+          this.addIfPresent(s, "element_render_delay", t),
+            this.addIfPresent(s, "resource_load_delay", n),
+            this.addIfPresent(s, "resource_load_duration", i),
+            this.addIfPresent(s, Xi, r);
+          const a = this.buildInitialContext(e);
+          this.addIfPresent(a, "element", o), this.pushMeasurement(s, a);
+        },
+        {
+          reportAllChanges:
+            null === (e = this.webVitalConfig) || void 0 === e
+              ? void 0
+              : e.reportAllChanges,
+        }
+      );
+    }
+    measureTTFB() {
+      var e;
+      !(function (e, t) {
+        Ui(function (t) {
+          var n = (function (e) {
+            var t = {
+              waitingDuration: 0,
+              cacheDuration: 0,
+              dnsDuration: 0,
+              connectionDuration: 0,
+              requestDuration: 0,
+            };
+            if (e.entries.length) {
+              var n = e.entries[0],
+                i = n.activationStart || 0,
+                r = Math.max((n.workerStart || n.fetchStart) - i, 0),
+                o = Math.max(n.domainLookupStart - i, 0),
+                s = Math.max(n.connectStart - i, 0),
+                a = Math.max(n.connectEnd - i, 0);
+              t = {
+                waitingDuration: r,
+                cacheDuration: o - r,
+                dnsDuration: s - o,
+                connectionDuration: a - s,
+                requestDuration: e.value - a,
+                navigationEntry: n,
+              };
+            }
+            return Object.assign(e, { attribution: t });
+          })(t);
+          e(n);
+        }, t);
+      })(
+        (e) => {
+          const {
+              dnsDuration: t,
+              connectionDuration: n,
+              requestDuration: i,
+              waitingDuration: r,
+              cacheDuration: o,
+            } = e.attribution,
+            s = this.buildInitialValues(e);
+          this.addIfPresent(s, "dns_duration", t),
+            this.addIfPresent(s, "connection_duration", n),
+            this.addIfPresent(s, "request_duration", i),
+            this.addIfPresent(s, "waiting_duration", r),
+            this.addIfPresent(s, "cache_duration", o);
+          const a = this.buildInitialContext(e);
+          this.pushMeasurement(s, a);
+        },
+        {
+          reportAllChanges:
+            null === (e = this.webVitalConfig) || void 0 === e
+              ? void 0
+              : e.reportAllChanges,
+        }
+      );
+    }
+    buildInitialValues(e) {
+      const t = e.name.toLowerCase();
+      return { [t]: e.value, delta: e.delta };
+    }
+    buildInitialContext(e) {
+      var t;
+      const n = null !== (t = Re(Wi, _e.session)) && void 0 !== t ? t : Le;
+      return {
+        id: e.id,
+        rating: e.rating,
+        navigation_type: e.navigationType,
+        navigation_entry_id: n,
+      };
+    }
+    pushMeasurement(e, t) {
+      this.corePushMeasurement(
+        { type: "web-vitals", values: e },
+        { context: t }
+      );
+    }
+    addIfPresent(e, t, n) {
+      n && (e[t] = n);
+    }
+  }
+  class Zi extends ge {
+    constructor() {
+      super(...arguments),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-web-vitals"),
+        (this.version = me);
+    }
+    initialize() {
+      this.logDebug("Initializing");
+      this.intializeWebVitalsInstrumentation().initialize();
+    }
+    intializeWebVitalsInstrumentation() {
+      var e, t, n;
+      return !1 ===
+        (null === (e = this.config) || void 0 === e
+          ? void 0
+          : e.trackWebVitalsAttribution) ||
+        !1 ===
+          (null ===
+            (n =
+              null === (t = this.config) || void 0 === t
+                ? void 0
+                : t.webVitalsInstrumentation) || void 0 === n
+            ? void 0
+            : n.trackAttribution)
+        ? new jn(this.api.pushMeasurement, this.config.webVitalsInstrumentation)
+        : new Ji(
+            this.api.pushMeasurement,
+            this.config.webVitalsInstrumentation
+          );
+    }
+  }
+  function Yi(e, t) {
+    var n = {};
+    for (var i in e)
+      Object.prototype.hasOwnProperty.call(e, i) &&
+        t.indexOf(i) < 0 &&
+        (n[i] = e[i]);
+    if (null != e && "function" == typeof Object.getOwnPropertySymbols) {
+      var r = 0;
+      for (i = Object.getOwnPropertySymbols(e); r < i.length; r++)
+        t.indexOf(i[r]) < 0 &&
+          Object.prototype.propertyIsEnumerable.call(e, i[r]) &&
+          (n[i[r]] = e[i[r]]);
+    }
+    return n;
+  }
+  function Qi(e, t, n, i) {
+    return new (n || (n = Promise))(function (r, o) {
+      function s(e) {
+        try {
+          u(i.next(e));
+        } catch (e) {
+          o(e);
+        }
+      }
+      function a(e) {
+        try {
+          u(i.throw(e));
+        } catch (e) {
+          o(e);
+        }
+      }
+      function u(e) {
+        var t;
+        e.done
+          ? r(e.value)
+          : ((t = e.value),
+            t instanceof n
+              ? t
+              : new n(function (e) {
+                  e(t);
+                })).then(s, a);
+      }
+      u((i = i.apply(e, t || [])).next());
+    });
+  }
+  "function" == typeof SuppressedError && SuppressedError;
+  const er = "resource",
+    tr = /^00-[a-f0-9]{32}-[a-f0-9]{16}-[0-9]{1,2}$/;
+  function nr(e = []) {
+    for (const t of e)
+      if ("traceparent" === t.name) {
+        if (!tr.test(t.description)) continue;
+        const [, e, n] = t.description.split("-");
+        if (null != e && null != n) return { traceId: e, spanId: n };
+        break;
+      }
+  }
+  function ir(e, t = {}) {
+    for (const [n, i] of Object.entries(t)) {
+      const t = e[n];
+      return null != t && (l(i) ? i.includes(t) : t === i);
+    }
+    return !0;
+  }
+  function rr(e) {
+    const {
+      connectEnd: t,
+      connectStart: n,
+      decodedBodySize: i,
+      domainLookupEnd: r,
+      domainLookupStart: o,
+      duration: s,
+      encodedBodySize: a,
+      fetchStart: u,
+      initiatorType: c,
+      name: l,
+      nextHopProtocol: d,
+      redirectEnd: f,
+      redirectStart: p,
+      renderBlockingStatus: g,
+      requestStart: m,
+      responseEnd: v,
+      responseStart: h,
+      responseStatus: b,
+      secureConnectionStart: w,
+      transferSize: y,
+      workerStart: S,
+    } = e;
+    return {
+      name: l,
+      duration: sr(s),
+      tcpHandshakeTime: sr(t - n),
+      dnsLookupTime: sr(r - o),
+      tlsNegotiationTime: sr(t - w),
+      responseStatus: sr(b),
+      redirectTime: sr(f - p),
+      requestTime: sr(h - m),
+      responseTime: sr(v - h),
+      fetchTime: sr(v - u),
+      serviceWorkerTime: sr(u - S),
+      decodedBodySize: sr(i),
+      encodedBodySize: sr(a),
+      cacheHitStatus: (function () {
+        let e = "fullLoad";
+        0 === y
+          ? i > 0 && (e = "cache")
+          : null != b
+          ? 304 === b && (e = "conditionalFetch")
+          : a > 0 && y < a && (e = "conditionalFetch");
+        return e;
+      })(),
+      renderBlockingStatus: sr(g),
+      protocol: d,
+      initiatorType: c,
+      visibilityState: document.visibilityState,
+      ttfb: sr(h - m),
+      transferSize: sr(y),
+    };
+  }
+  function or(e) {
+    const {
+        activationStart: t,
+        domComplete: n,
+        domContentLoadedEventEnd: i,
+        domContentLoadedEventStart: r,
+        domInteractive: o,
+        fetchStart: s,
+        loadEventEnd: a,
+        loadEventStart: u,
+        responseStart: c,
+        type: l,
+      } = e,
+      d = (function () {
+        var e;
+        if (
+          null !=
+          (null === (e = performance.timing) || void 0 === e
+            ? void 0
+            : e.domLoading)
+        )
+          return performance.timing.domLoading - performance.timeOrigin;
+        return null;
+      })();
+    return Object.assign(Object.assign({}, rr(e)), {
+      pageLoadTime: sr(n - s),
+      documentParsingTime: sr(d ? o - d : null),
+      domProcessingTime: sr(n - o),
+      domContentLoadHandlerTime: sr(i - r),
+      onLoadTime: sr(a - u),
+      ttfb: sr(Math.max(c - (null != t ? t : 0), 0)),
+      type: l,
+    });
+  }
+  function sr(e) {
+    return null == e
+      ? Le
+      : "number" == typeof e
+      ? Math.round(e > 0 ? e : 0).toString()
+      : e.toString();
+  }
+  const ar = { initiatorType: ["xmlhttprequest", "fetch"] };
+  const ur = new D();
+  class cr extends ge {
+    constructor() {
+      super(...arguments),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-performance"),
+        (this.version = me);
+    }
+    initialize() {
+      "PerformanceObserver" in window
+        ? (function (e) {
+            if ("complete" === document.readyState) e();
+            else {
+              const t = () => {
+                "complete" === document.readyState &&
+                  (e(), document.removeEventListener("readystatechange", t));
+              };
+              document.addEventListener("readystatechange", t);
+            }
+          })(() =>
+            Qi(this, void 0, void 0, function* () {
+              const t = this.api.pushEvent,
+                { faroNavigationId: n } = yield (function (e) {
+                  let t;
+                  const n = new Promise((e) => {
+                    t = e;
+                  });
+                  return (
+                    new PerformanceObserver((n) => {
+                      var i;
+                      const [r] = n.getEntries();
+                      if (null == r || Ge(r.name)) return;
+                      const o = r.toJSON();
+                      let s = nr(null == o ? void 0 : o.serverTiming);
+                      const a =
+                          null !== (i = Re(Wi, _e.session)) && void 0 !== i
+                            ? i
+                            : Le,
+                        u = Object.assign(Object.assign({}, or(o)), {
+                          faroNavigationId: M(),
+                          faroPreviousNavigationId: a,
+                        });
+                      Ue(Wi, u.faroNavigationId, _e.session),
+                        e("faro.performance.navigation", u, void 0, {
+                          spanContext: s,
+                          timestampOverwriteMs:
+                            performance.timeOrigin + o.startTime,
+                        }),
+                        t(u);
+                    }).observe({ type: "navigation", buffered: !0 }),
+                    n
+                  );
+                })(t);
+              null != n &&
+                (function (t, n, i) {
+                  const r = e.faro.config.trackResources;
+                  new PerformanceObserver((o) => {
+                    const s = o.getEntries();
+                    for (const o of s) {
+                      if (Ge(o.name)) return;
+                      const s = o.toJSON();
+                      let a = nr(null == s ? void 0 : s.serverTiming);
+                      if ((null == r && ir(s, ar)) || r) {
+                        const r = Object.assign(Object.assign({}, rr(s)), {
+                          faroNavigationId: t,
+                          faroResourceId: M(),
+                        });
+                        e.faro.config.trackUserActionsPreview &&
+                          (null == i || i.notify({ type: er })),
+                          n("faro.performance.resource", r, void 0, {
+                            spanContext: a,
+                            timestampOverwriteMs:
+                              performance.timeOrigin + s.startTime,
+                          });
+                      }
+                    }
+                  }).observe({ type: er, buffered: !0 });
+                })(n, t, ur);
+            })
+          )
+        : this.logDebug(
+            "performance observer not supported. Disable performance instrumentation."
+          );
+    }
+  }
+  const lr = "resource-entry",
+    dr = "http-request-start",
+    fr = "http-request-end",
+    pr = "dom-mutation",
+    gr = "data-faro-user-action-name";
+  const mr = "fetch",
+    vr = "xhr";
+  function hr() {
+    const e = new D();
+    function t(t) {
+      e.notify({ type: dr, request: t });
+    }
+    function n(t) {
+      e.notify({ type: fr, request: t });
+    }
+    return (
+      (function ({ onRequestEnd: e, onRequestStart: t }) {
+        const n = window.fetch;
+        window.fetch = function () {
+          var i, r;
+          const o = null !== (i = He(arguments[0])) && void 0 !== i ? i : "",
+            s = Ge(o),
+            a = (null !== (r = arguments[1]) && void 0 !== r ? r : {}).method,
+            u = M();
+          return (
+            s || t({ url: o, method: a, requestId: u, apiType: mr }),
+            n
+              .apply(this, arguments)
+              .then(
+                (t) => (
+                  s || e({ url: o, method: a, requestId: u, apiType: mr }), t
+                )
+              )
+              .catch((t) => {
+                throw (
+                  (s || e({ url: o, method: a, requestId: u, apiType: mr }), t)
+                );
+              })
+          );
+        };
+      })({ onRequestStart: t, onRequestEnd: n }),
+      (function ({ onRequestStart: e, onRequestEnd: t }) {
+        const n = XMLHttpRequest.prototype.open;
+        XMLHttpRequest.prototype.open = function () {
+          const i = arguments[1],
+            r = Ge(i),
+            o = arguments[0],
+            s = M();
+          this.addEventListener("loadstart", function () {
+            r || e({ url: i, method: o, requestId: s, apiType: vr });
+          }),
+            this.addEventListener("load", function () {
+              r || t({ url: i, method: o, requestId: s, apiType: vr });
+            }),
+            this.addEventListener("error", function () {
+              r || t({ url: i, method: o, requestId: s, apiType: vr });
+            }),
+            this.addEventListener("abort", function () {
+              r || t({ url: i, method: o, requestId: s, apiType: vr });
+            }),
+            n.apply(this, arguments);
+        };
+      })({ onRequestStart: t, onRequestEnd: n }),
+      e
+    );
+  }
+  function br(e) {
+    const { api: t, config: n } = e,
+      i = hr(),
+      r = (function () {
+        const e = new D();
+        return (
+          new MutationObserver((t, n) => {
+            e.notify({ type: pr });
+          }).observe(document, {
+            attributes: !0,
+            childList: !0,
+            subtree: !0,
+            characterData: !0,
+          }),
+          e
+        );
+      })(),
+      o = (function () {
+        const e = new D();
+        return (
+          ur.subscribe((t) => {
+            t.type === er && e.notify({ type: lr });
+          }),
+          e
+        );
+      })();
+    let s,
+      a = !1;
+    return function (e) {
+      var u;
+      let c;
+      const l = "apiEvent" === (d = e).type && "string" == typeof d.name;
+      var d;
+      if (
+        ((c = l
+          ? e.name
+          : (function (e, t) {
+              const n = (function (e) {
+                  const t = e.split("data-")[1],
+                    n =
+                      null == t
+                        ? void 0
+                        : t.replace(/-(.)/g, (e, t) => t.toUpperCase());
+                  return null == n ? void 0 : n.replace(/-/g, "");
+                })(t),
+                i = e.dataset;
+              for (const e in i) if (e === n) return i[e];
+              return;
+            })(
+              e.target,
+              null !== (u = n.trackUserActionsDataAttributeName) && void 0 !== u
+                ? u
+                : "faroUserActionName"
+            )),
+        a || null == c)
+      )
+        return;
+      a = !0;
+      const f = E();
+      let p;
+      const g = M();
+      fe.notify({ type: te, name: c, startTime: f, parentId: g }),
+        (s = yr(
+          s,
+          () => {
+            (p = E()),
+              (a = !1),
+              (function (e, t) {
+                fe.notify({ type: ie, name: e, parentId: t });
+              })(c, g);
+          },
+          100
+        ));
+      const m = new Map();
+      let v,
+        h = !1;
+      const b = new D()
+        .merge(i, r, o)
+        .takeWhile(() => a)
+        .filter((e) => !!(!h || (Tr(e) && m.has(e.request.requestId))))
+        .subscribe((n) => {
+          (function (e) {
+            return e.type === dr;
+          })(n) && m.set(n.request.requestId, n.request),
+            Tr(n) && m.delete(n.request.requestId),
+            (s = yr(
+              s,
+              () => {
+                p = E();
+                const n = Object.assign(
+                    {
+                      api: t,
+                      userActionName: c,
+                      startTime: f,
+                      endTime: p,
+                      actionId: g,
+                      event: e,
+                    },
+                    l ? { attributes: e.attributes } : {}
+                  ),
+                  i = m.size > 0;
+                h && !i && (clearTimeout(v), (h = !1)),
+                  i
+                    ? ((h = !0),
+                      fe.notify({
+                        type: re,
+                        name: c,
+                        parentId: g,
+                        reason: "pending-requests",
+                        haltTime: E(),
+                      }),
+                      (v = yr(
+                        void 0,
+                        () => {
+                          Sr(b), wr(n), (a = !1), (h = !1);
+                        },
+                        1e4
+                      )))
+                    : (Sr(b), wr(n), (a = !1), (h = !1));
+              },
+              100
+            ));
+        });
+    };
+  }
+  function wr(e) {
+    const {
+        api: t,
+        userActionName: n,
+        startTime: i,
+        endTime: r,
+        actionId: o,
+        event: s,
+        attributes: a,
+      } = e,
+      u = r - i,
+      c = s.type;
+    fe.notify({
+      type: ne,
+      name: n,
+      id: o,
+      startTime: i,
+      endTime: r,
+      duration: u,
+      eventType: c,
+    }),
+      t.pushEvent(
+        n,
+        Object.assign(
+          {
+            userActionStartTime: i.toString(),
+            userActionEndTime: r.toString(),
+            userActionDuration: u.toString(),
+            userActionEventType: c,
+          },
+          _(a)
+        ),
+        void 0,
+        {
+          timestampOverwriteMs: i,
+          customPayloadTransformer: (e) => ((e.action = { id: o, name: n }), e),
+        }
+      );
+  }
+  function yr(e, t, n) {
+    return (
+      e && clearTimeout(e),
+      (e = setTimeout(() => {
+        t();
+      }, n))
+    );
+  }
+  function Sr(e) {
+    null == e || e.unsubscribe(), (e = void 0);
+  }
+  function Tr(e) {
+    return e.type === fr;
+  }
+  let Er;
+  class Ir extends ge {
+    constructor() {
+      super(...arguments),
+        (this.name = "@grafana/faro-web-sdk:instrumentation-user-action"),
+        (this.version = me);
+    }
+    initialize() {
+      (Er = br(e.faro)),
+        window.addEventListener("pointerdown", Er),
+        window.addEventListener("keydown", Er);
+    }
+  }
+  function kr(e = {}) {
+    const t = [new Ir(), new Dt(), new Zi(), new at(), new Rt()];
+    return (
+      !1 !== e.enablePerformanceInstrumentation && t.unshift(new cr()),
+      !1 !== e.captureConsole &&
+        t.push(new _t({ disabledLevels: e.captureConsoleDisabledLevels })),
+      t
+    );
+  }
+  const Or = "browser",
+    xr = () => {
+      const e = window.k6;
+      return {
+        k6: Object.assign(
+          { isK6Browser: !0 },
+          (null == e ? void 0 : e.testRunId) && {
+            testRunId: null == e ? void 0 : e.testRunId,
+          }
+        ),
+      };
+    };
+  let Lr, Cr;
+  function Ar({ generatePageId: e, initialPageMeta: t } = {}) {
+    return () => {
+      const n = location.href;
+      return (
+        c(e) && Lr !== n && ((Lr = n), (Cr = e(location))),
+        {
+          page: Object.assign(
+            Object.assign({ url: n }, Cr ? { id: Cr } : {}),
+            t
+          ),
+        }
+      );
+    };
+  }
+  class Pr extends Y {
+    constructor(e) {
+      var t, n, i, r;
+      super(),
+        (this.options = e),
+        (this.name = "@grafana/faro-web-sdk:transport-fetch"),
+        (this.version = me),
+        (this.disabledUntil = new Date()),
+        (this.rateLimitBackoffMs =
+          null !== (t = e.defaultRateLimitBackoffMs) && void 0 !== t ? t : 5e3),
+        (this.getNow =
+          null !== (n = e.getNow) && void 0 !== n ? n : () => Date.now()),
+        (this.promiseBuffer = A({
+          size: null !== (i = e.bufferSize) && void 0 !== i ? i : 30,
+          concurrency: null !== (r = e.concurrency) && void 0 !== r ? r : 5,
+        }));
+    }
+    send(e) {
+      return Qi(this, void 0, void 0, function* () {
+        try {
+          if (this.disabledUntil > new Date(this.getNow()))
+            return (
+              this.logWarn(
+                `Dropping transport item due to too many requests. Backoff until ${this.disabledUntil}`
+              ),
+              Promise.resolve()
+            );
+          yield this.promiseBuffer.add(() => {
+            const t = JSON.stringify(ee(e)),
+              { url: n, requestOptions: i, apiKey: r } = this.options,
+              o = null != i ? i : {},
+              { headers: s } = o,
+              a = Yi(o, ["headers"]);
+            let u;
+            const c = this.metas.value.session;
+            return (
+              null != c && (u = c.id),
+              fetch(
+                n,
+                Object.assign(
+                  {
+                    method: "POST",
+                    headers: Object.assign(
+                      Object.assign(
+                        Object.assign(
+                          { "Content-Type": "application/json" },
+                          null != s ? s : {}
+                        ),
+                        r ? { "x-api-key": r } : {}
+                      ),
+                      u ? { "x-faro-session-id": u } : {}
+                    ),
+                    body: t,
+                    keepalive: t.length <= 6e4,
+                  },
+                  null != a ? a : {}
+                )
+              )
+                .then((e) =>
+                  Qi(this, void 0, void 0, function* () {
+                    if (202 === e.status) {
+                      "invalid" === e.headers.get("X-Faro-Session-Status") &&
+                        this.extendFaroSession(this.config, this.logDebug);
+                    }
+                    return (
+                      429 === e.status &&
+                        ((this.disabledUntil = this.getRetryAfterDate(e)),
+                        this.logWarn(
+                          `Too many requests, backing off until ${this.disabledUntil}`
+                        )),
+                      e.text().catch(C),
+                      e
+                    );
+                  })
+                )
+                .catch((e) => {
+                  this.logError(
+                    "Failed sending payload to the receiver\n",
+                    JSON.parse(t),
+                    e
+                  );
+                })
+            );
+          });
+        } catch (e) {
+          this.logError(e);
+        }
+      });
+    }
+    getIgnoreUrls() {
+      var e;
+      return [this.options.url].concat(
+        null !== (e = this.config.ignoreUrls) && void 0 !== e ? e : []
+      );
+    }
+    isBatched() {
+      return !0;
+    }
+    getRetryAfterDate(e) {
+      const t = this.getNow(),
+        n = e.headers.get("Retry-After");
+      if (n) {
+        const e = Number(n);
+        if (!isNaN(e)) return new Date(1e3 * e + t);
+        const i = Date.parse(n);
+        if (!isNaN(i)) return new Date(i);
+      }
+      return new Date(t + this.rateLimitBackoffMs);
+    }
+    extendFaroSession(e, t) {
+      const n = "Session expired",
+        i = e.sessionTracking;
+      if (null == i ? void 0 : i.enabled) {
+        const { fetchUserSession: e, storeUserSession: r } = st(i);
+        tt({ fetchUserSession: e, storeUserSession: r })({
+          forceSessionExtend: !0,
+        }),
+          t(`${n} created new session.`);
+      } else t(`${n}.`);
+    }
+  }
+  function Mr(e) {
+    var t;
+    const n = [],
+      i = K(e.unpatchedConsole, e.internalLoggerLevel);
+    e.transports
+      ? ((e.url || e.apiKey) &&
+          i.error(
+            'if "transports" is defined, "url" and "apiKey" should not be defined'
+          ),
+        n.push(...e.transports))
+      : e.url
+      ? n.push(new Pr({ url: e.url, apiKey: e.apiKey }))
+      : i.error('either "url" or "transports" must be defined');
+    const {
+        dedupe: r = !0,
+        eventDomain: o = Or,
+        globalObjectKey: s = Se,
+        instrumentations: a = kr(),
+        internalLoggerLevel: u = $,
+        isolate: c = !1,
+        logArgsSerializer: l = ce,
+        metas: d = Nr(e),
+        paused: f = !1,
+        preventGlobalExposure: p = !1,
+        unpatchedConsole: g = G,
+        trackUserActionsPreview: m = !1,
+        trackUserActionsDataAttributeName: v = gr,
+      } = e,
+      h = Yi(e, [
+        "dedupe",
+        "eventDomain",
+        "globalObjectKey",
+        "instrumentations",
+        "internalLoggerLevel",
+        "isolate",
+        "logArgsSerializer",
+        "metas",
+        "paused",
+        "preventGlobalExposure",
+        "unpatchedConsole",
+        "trackUserActionsPreview",
+        "trackUserActionsDataAttributeName",
+      ]);
+    return Object.assign(Object.assign({}, h), {
+      batching: Object.assign(Object.assign({}, Te), e.batching),
+      dedupe: r,
+      globalObjectKey: s,
+      instrumentations: jr(a, e),
+      internalLoggerLevel: u,
+      isolate: c,
+      logArgsSerializer: l,
+      metas: d,
+      parseStacktrace: Pt,
+      paused: f,
+      preventGlobalExposure: p,
+      transports: n,
+      unpatchedConsole: g,
+      eventDomain: o,
+      ignoreUrls: (null !== (t = e.ignoreUrls) && void 0 !== t ? t : []).concat(
+        [/\/collect(?:\/[\w]*)?$/]
+      ),
+      sessionTracking: Object.assign(
+        Object.assign(Object.assign({}, Ze), e.sessionTracking),
+        _r({
+          trackGeolocation: e.trackGeolocation,
+          sessionTracking: e.sessionTracking,
+        })
+      ),
+      trackUserActionsPreview: m,
+      trackUserActionsDataAttributeName: v,
+    });
+  }
+  function jr(e, { trackUserActionsPreview: t }) {
+    return e.filter(
+      (e) =>
+        !("@grafana/faro-web-sdk:instrumentation-user-action" === e.name && !t)
+    );
+  }
+  function Nr(e) {
+    var t, n;
+    const { page: i, generatePageId: r } =
+        null !== (t = null == e ? void 0 : e.pageTracking) && void 0 !== t
+          ? t
+          : {},
+      o = [
+        je,
+        Ar({ generatePageId: r, initialPageMeta: i }),
+        ...(null !== (n = e.metas) && void 0 !== n ? n : []),
+      ];
+    return u(window.k6) ? [...o, xr] : o;
+  }
+  function _r({ trackGeolocation: e, sessionTracking: t }) {
+    var n;
+    const i = {};
+    return (
+      a(e) && (i.geoLocationTrackingEnabled = e),
+      S(i)
+        ? {}
+        : {
+            session: Object.assign(
+              Object.assign(
+                {},
+                null !== (n = null == t ? void 0 : t.session) && void 0 !== n
+                  ? n
+                  : {}
+              ),
+              { overrides: i }
+            ),
+          }
+    );
+  }
+  return (
+    (e.BaseExtension = Z),
+    (e.BaseInstrumentation = ge),
+    (e.BaseTransport = Y),
+    (e.ConsoleInstrumentation = _t),
+    (e.ConsoleTransport = class extends Y {
+      constructor(e = {}) {
+        super(),
+          (this.options = e),
+          (this.name = "@grafana/faro-web-sdk:transport-console"),
+          (this.version = me);
+      }
+      send(t) {
+        var n;
+        return this.unpatchedConsole[
+          null !== (n = this.options.level) && void 0 !== n
+            ? n
+            : e.LogLevel.DEBUG
+        ]("New event", ee([t]));
+      }
+    }),
+    (e.Conventions = {
+      EventNames: {
+        CLICK: "click",
+        NAVIGATION: "navigation",
+        SESSION_START: "session_start",
+        VIEW_CHANGED: "view_changed",
+      },
+    }),
+    (e.EVENT_CLICK = "click"),
+    (e.EVENT_NAVIGATION = "navigation"),
+    (e.EVENT_ROUTE_CHANGE = "route_change"),
+    (e.EVENT_SESSION_EXTEND = Oe),
+    (e.EVENT_SESSION_RESUME = ke),
+    (e.EVENT_SESSION_START = Ie),
+    (e.EVENT_VIEW_CHANGED = Ee),
+    (e.ErrorsInstrumentation = Dt),
+    (e.FetchTransport = Pr),
+    (e.MAX_SESSION_PERSISTENCE_TIME = Je),
+    (e.MAX_SESSION_PERSISTENCE_TIME_BUFFER = 6e4),
+    (e.Observable = D),
+    (e.PerformanceInstrumentation = cr),
+    (e.PersistentSessionsManager = rt),
+    (e.SESSION_EXPIRATION_TIME = Ke),
+    (e.SESSION_INACTIVITY_TIME = Xe),
+    (e.STORAGE_KEY = We),
+    (e.SessionInstrumentation = at),
+    (e.USER_ACTION_CANCEL = ie),
+    (e.USER_ACTION_END = ne),
+    (e.USER_ACTION_START = te),
+    (e.UserActionInstrumentation = Ir),
+    (e.VERSION = me),
+    (e.ViewInstrumentation = Rt),
+    (e.VolatileSessionsManager = ot),
+    (e.WebVitalsInstrumentation = Zi),
+    (e.allLogLevels = L),
+    (e.apiMessageBus = fe),
+    (e.browserMeta = je),
+    (e.buildStackFrame = Lt),
+    (e.createInternalLogger = K),
+    (e.createPromiseBuffer = A),
+    (e.createSession = Ne),
+    (e.deepEqual = T),
+    (e.defaultEventDomain = Or),
+    (e.defaultExceptionType = oe),
+    (e.defaultGlobalObjectKey = Se),
+    (e.defaultInternalLoggerLevel = $),
+    (e.defaultLogLevel = x),
+    (e.genShortID = M),
+    (e.getCurrentTimestamp = I),
+    (e.getDataFromSafariExtensions = Ct),
+    (e.getIgnoreUrls = $e),
+    (e.getInternalFaroFromGlobalObject = function () {
+      return j[ve];
+    }),
+    (e.getStackFramesFromError = At),
+    (e.getTransportBody = ee),
+    (e.getUrlFromResource = He),
+    (e.getWebInstrumentations = kr),
+    (e.globalObject = j),
+    (e.initializeFaro = function (e) {
+      const t = Mr(e);
+      if (t) return ye(t);
+    }),
+    (e.internalGlobalObjectKey = ve),
+    (e.isArray = l),
+    (e.isBoolean = a),
+    (e.isDomError = h),
+    (e.isDomException = b),
+    (e.isElement = (e) => w && i(e, Element)),
+    (e.isElementDefined = w),
+    (e.isEmpty = S),
+    (e.isError = m),
+    (e.isErrorDefined = g),
+    (e.isErrorEvent = v),
+    (e.isEvent = p),
+    (e.isEventDefined = f),
+    (e.isFunction = c),
+    (e.isInstanceOf = i),
+    (e.isInt = (e) => s(e) && Number.isInteger(e)),
+    (e.isInternalFaroOnGlobalObject = be),
+    (e.isMap = (e) => y && i(e, Map)),
+    (e.isMapDefined = y),
+    (e.isNull = r),
+    (e.isNumber = s),
+    (e.isObject = u),
+    (e.isPrimitive = d),
+    (e.isRegExp = (e) => n(e, "RegExp")),
+    (e.isString = o),
+    (e.isSymbol = (e) => t(e, "symbol")),
+    (e.isSyntheticEvent = (e) =>
+      u(e) &&
+      "nativeEvent" in e &&
+      "preventDefault" in e &&
+      "stopPropagation" in e),
+    (e.isThenable = (e) => c(null == e ? void 0 : e.then)),
+    (e.isToString = n),
+    (e.isTypeof = t),
+    (e.isUndefined = (e) => t(e, "undefined")),
+    (e.makeCoreConfig = Mr),
+    (e.noop = C),
+    (e.parseStacktrace = Pt),
+    (e.sdkMeta = () => ({
+      sdk: {
+        name: "@grafana/faro-core",
+        version: me,
+        integrations: e.faro.config.instrumentations.map(
+          ({ name: e, version: t }) => ({ name: e, version: t })
+        ),
+      },
+    })),
+    (e.setInternalFaroOnGlobalObject = he),
+    (e.startUserAction = function (e, t) {
+      null == Er ||
+        Er(
+          (function (e, t) {
+            return { name: e, attributes: t, type: "apiEvent" };
+          })(e, t)
+        );
+    }),
+    (e.transportItemTypeToBodyKey = B),
+    (e.unknownString = Le),
+    (e.userActionDataAttribute = gr),
+    e
+  );
+})({});
+
+export default GrafanaFaroWebSdk;

--- a/import/grafana-faro-web-tracing.js
+++ b/import/grafana-faro-web-tracing.js
@@ -1,0 +1,4248 @@
+// vendored @grafana/faro-web-tracing v1.18.1 https://unpkg.com/@grafana/faro-web-tracing@1.18.1/dist/bundle/faro-web-tracing.iife.js
+
+var GrafanaFaroWebTracing = function (t, e) {
+  "use strict";
+  var n =
+      "object" == typeof globalThis
+        ? globalThis
+        : "object" == typeof self
+        ? self
+        : "object" == typeof window
+        ? window
+        : "object" == typeof global
+        ? global
+        : {},
+    r = "1.9.0",
+    o = /^(\d+)\.(\d+)\.(\d+)(-(.+))?$/;
+  var i = (function (t) {
+      var e = new Set([t]),
+        n = new Set(),
+        r = t.match(o);
+      if (!r)
+        return function () {
+          return !1;
+        };
+      var i = +r[1],
+        s = +r[2],
+        a = +r[3];
+      if (null != r[4])
+        return function (e) {
+          return e === t;
+        };
+      function u(t) {
+        return n.add(t), !1;
+      }
+      function c(t) {
+        return e.add(t), !0;
+      }
+      return function (t) {
+        if (e.has(t)) return !0;
+        if (n.has(t)) return !1;
+        var r = t.match(o);
+        if (!r) return u(t);
+        var l = +r[1],
+          p = +r[2],
+          d = +r[3];
+        return null != r[4] || i !== l
+          ? u(t)
+          : 0 === i
+          ? s === p && a <= d
+            ? c(t)
+            : u(t)
+          : s <= p
+          ? c(t)
+          : u(t);
+      };
+    })(r),
+    s = r.split(".")[0],
+    a = Symbol.for("opentelemetry.js.api." + s),
+    u = n;
+  function c(t, e, n, o) {
+    var i;
+    void 0 === o && (o = !1);
+    var s = (u[a] = null !== (i = u[a]) && void 0 !== i ? i : { version: r });
+    if (!o && s[t]) {
+      var c = new Error(
+        "@opentelemetry/api: Attempted duplicate registration of API: " + t
+      );
+      return n.error(c.stack || c.message), !1;
+    }
+    if (s.version !== r) {
+      c = new Error(
+        "@opentelemetry/api: Registration of version v" +
+          s.version +
+          " for " +
+          t +
+          " does not match previously registered API v" +
+          r
+      );
+      return n.error(c.stack || c.message), !1;
+    }
+    return (
+      (s[t] = e),
+      n.debug(
+        "@opentelemetry/api: Registered a global for " + t + " v" + r + "."
+      ),
+      !0
+    );
+  }
+  function l(t) {
+    var e,
+      n,
+      r = null === (e = u[a]) || void 0 === e ? void 0 : e.version;
+    if (r && i(r)) return null === (n = u[a]) || void 0 === n ? void 0 : n[t];
+  }
+  function p(t, e) {
+    e.debug(
+      "@opentelemetry/api: Unregistering a global for " + t + " v" + r + "."
+    );
+    var n = u[a];
+    n && delete n[t];
+  }
+  var d,
+    h = function (t, e) {
+      var n = "function" == typeof Symbol && t[Symbol.iterator];
+      if (!n) return t;
+      var r,
+        o,
+        i = n.call(t),
+        s = [];
+      try {
+        for (; (void 0 === e || e-- > 0) && !(r = i.next()).done; )
+          s.push(r.value);
+      } catch (t) {
+        o = { error: t };
+      } finally {
+        try {
+          r && !r.done && (n = i.return) && n.call(i);
+        } finally {
+          if (o) throw o.error;
+        }
+      }
+      return s;
+    },
+    f = function (t, e, n) {
+      if (n || 2 === arguments.length)
+        for (var r, o = 0, i = e.length; o < i; o++)
+          (!r && o in e) ||
+            (r || (r = Array.prototype.slice.call(e, 0, o)), (r[o] = e[o]));
+      return t.concat(r || Array.prototype.slice.call(e));
+    },
+    g = (function () {
+      function t(t) {
+        this._namespace = t.namespace || "DiagComponentLogger";
+      }
+      return (
+        (t.prototype.debug = function () {
+          for (var t = [], e = 0; e < arguments.length; e++)
+            t[e] = arguments[e];
+          return m("debug", this._namespace, t);
+        }),
+        (t.prototype.error = function () {
+          for (var t = [], e = 0; e < arguments.length; e++)
+            t[e] = arguments[e];
+          return m("error", this._namespace, t);
+        }),
+        (t.prototype.info = function () {
+          for (var t = [], e = 0; e < arguments.length; e++)
+            t[e] = arguments[e];
+          return m("info", this._namespace, t);
+        }),
+        (t.prototype.warn = function () {
+          for (var t = [], e = 0; e < arguments.length; e++)
+            t[e] = arguments[e];
+          return m("warn", this._namespace, t);
+        }),
+        (t.prototype.verbose = function () {
+          for (var t = [], e = 0; e < arguments.length; e++)
+            t[e] = arguments[e];
+          return m("verbose", this._namespace, t);
+        }),
+        t
+      );
+    })();
+  function m(t, e, n) {
+    var r = l("diag");
+    if (r) return n.unshift(e), r[t].apply(r, f([], h(n), !1));
+  }
+  !(function (t) {
+    (t[(t.NONE = 0)] = "NONE"),
+      (t[(t.ERROR = 30)] = "ERROR"),
+      (t[(t.WARN = 50)] = "WARN"),
+      (t[(t.INFO = 60)] = "INFO"),
+      (t[(t.DEBUG = 70)] = "DEBUG"),
+      (t[(t.VERBOSE = 80)] = "VERBOSE"),
+      (t[(t.ALL = 9999)] = "ALL");
+  })(d || (d = {}));
+  var _ = function (t, e) {
+      var n = "function" == typeof Symbol && t[Symbol.iterator];
+      if (!n) return t;
+      var r,
+        o,
+        i = n.call(t),
+        s = [];
+      try {
+        for (; (void 0 === e || e-- > 0) && !(r = i.next()).done; )
+          s.push(r.value);
+      } catch (t) {
+        o = { error: t };
+      } finally {
+        try {
+          r && !r.done && (n = i.return) && n.call(i);
+        } finally {
+          if (o) throw o.error;
+        }
+      }
+      return s;
+    },
+    v = function (t, e, n) {
+      if (n || 2 === arguments.length)
+        for (var r, o = 0, i = e.length; o < i; o++)
+          (!r && o in e) ||
+            (r || (r = Array.prototype.slice.call(e, 0, o)), (r[o] = e[o]));
+      return t.concat(r || Array.prototype.slice.call(e));
+    },
+    y = (function () {
+      function t() {
+        function t(t) {
+          return function () {
+            for (var e = [], n = 0; n < arguments.length; n++)
+              e[n] = arguments[n];
+            var r = l("diag");
+            if (r) return r[t].apply(r, v([], _(e), !1));
+          };
+        }
+        var e = this;
+        (e.setLogger = function (t, n) {
+          var r, o, i;
+          if ((void 0 === n && (n = { logLevel: d.INFO }), t === e)) {
+            var s = new Error(
+              "Cannot use diag as the logger for itself. Please use a DiagLogger implementation like ConsoleDiagLogger or a custom implementation"
+            );
+            return (
+              e.error(null !== (r = s.stack) && void 0 !== r ? r : s.message),
+              !1
+            );
+          }
+          "number" == typeof n && (n = { logLevel: n });
+          var a = l("diag"),
+            u = (function (t, e) {
+              function n(n, r) {
+                var o = e[n];
+                return "function" == typeof o && t >= r
+                  ? o.bind(e)
+                  : function () {};
+              }
+              return (
+                t < d.NONE ? (t = d.NONE) : t > d.ALL && (t = d.ALL),
+                (e = e || {}),
+                {
+                  error: n("error", d.ERROR),
+                  warn: n("warn", d.WARN),
+                  info: n("info", d.INFO),
+                  debug: n("debug", d.DEBUG),
+                  verbose: n("verbose", d.VERBOSE),
+                }
+              );
+            })(null !== (o = n.logLevel) && void 0 !== o ? o : d.INFO, t);
+          if (a && !n.suppressOverrideMessage) {
+            var p =
+              null !== (i = new Error().stack) && void 0 !== i
+                ? i
+                : "<failed to generate stacktrace>";
+            a.warn("Current logger will be overwritten from " + p),
+              u.warn(
+                "Current logger will overwrite one already registered from " + p
+              );
+          }
+          return c("diag", u, e, !0);
+        }),
+          (e.disable = function () {
+            p("diag", e);
+          }),
+          (e.createComponentLogger = function (t) {
+            return new g(t);
+          }),
+          (e.verbose = t("verbose")),
+          (e.debug = t("debug")),
+          (e.info = t("info")),
+          (e.warn = t("warn")),
+          (e.error = t("error"));
+      }
+      return (
+        (t.instance = function () {
+          return this._instance || (this._instance = new t()), this._instance;
+        }),
+        t
+      );
+    })(),
+    S = function (t, e) {
+      var n = "function" == typeof Symbol && t[Symbol.iterator];
+      if (!n) return t;
+      var r,
+        o,
+        i = n.call(t),
+        s = [];
+      try {
+        for (; (void 0 === e || e-- > 0) && !(r = i.next()).done; )
+          s.push(r.value);
+      } catch (t) {
+        o = { error: t };
+      } finally {
+        try {
+          r && !r.done && (n = i.return) && n.call(i);
+        } finally {
+          if (o) throw o.error;
+        }
+      }
+      return s;
+    },
+    b = function (t) {
+      var e = "function" == typeof Symbol && Symbol.iterator,
+        n = e && t[e],
+        r = 0;
+      if (n) return n.call(t);
+      if (t && "number" == typeof t.length)
+        return {
+          next: function () {
+            return (
+              t && r >= t.length && (t = void 0),
+              { value: t && t[r++], done: !t }
+            );
+          },
+        };
+      throw new TypeError(
+        e ? "Object is not iterable." : "Symbol.iterator is not defined."
+      );
+    },
+    E = (function () {
+      function t(t) {
+        this._entries = t ? new Map(t) : new Map();
+      }
+      return (
+        (t.prototype.getEntry = function (t) {
+          var e = this._entries.get(t);
+          if (e) return Object.assign({}, e);
+        }),
+        (t.prototype.getAllEntries = function () {
+          return Array.from(this._entries.entries()).map(function (t) {
+            var e = S(t, 2);
+            return [e[0], e[1]];
+          });
+        }),
+        (t.prototype.setEntry = function (e, n) {
+          var r = new t(this._entries);
+          return r._entries.set(e, n), r;
+        }),
+        (t.prototype.removeEntry = function (e) {
+          var n = new t(this._entries);
+          return n._entries.delete(e), n;
+        }),
+        (t.prototype.removeEntries = function () {
+          for (var e, n, r = [], o = 0; o < arguments.length; o++)
+            r[o] = arguments[o];
+          var i = new t(this._entries);
+          try {
+            for (var s = b(r), a = s.next(); !a.done; a = s.next()) {
+              var u = a.value;
+              i._entries.delete(u);
+            }
+          } catch (t) {
+            e = { error: t };
+          } finally {
+            try {
+              a && !a.done && (n = s.return) && n.call(s);
+            } finally {
+              if (e) throw e.error;
+            }
+          }
+          return i;
+        }),
+        (t.prototype.clear = function () {
+          return new t();
+        }),
+        t
+      );
+    })(),
+    T = Symbol("BaggageEntryMetadata"),
+    w = y.instance();
+  function C(t) {
+    return void 0 === t && (t = {}), new E(new Map(Object.entries(t)));
+  }
+  function A(t) {
+    return Symbol.for(t);
+  }
+  var O,
+    R,
+    N = function t(e) {
+      var n = this;
+      (n._currentContext = e ? new Map(e) : new Map()),
+        (n.getValue = function (t) {
+          return n._currentContext.get(t);
+        }),
+        (n.setValue = function (e, r) {
+          var o = new t(n._currentContext);
+          return o._currentContext.set(e, r), o;
+        }),
+        (n.deleteValue = function (e) {
+          var r = new t(n._currentContext);
+          return r._currentContext.delete(e), r;
+        });
+    },
+    x = new N(),
+    P =
+      ((O = function (t, e) {
+        return (
+          (O =
+            Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array &&
+              function (t, e) {
+                t.__proto__ = e;
+              }) ||
+            function (t, e) {
+              for (var n in e)
+                Object.prototype.hasOwnProperty.call(e, n) && (t[n] = e[n]);
+            }),
+          O(t, e)
+        );
+      }),
+      function (t, e) {
+        if ("function" != typeof e && null !== e)
+          throw new TypeError(
+            "Class extends value " + String(e) + " is not a constructor or null"
+          );
+        function n() {
+          this.constructor = t;
+        }
+        O(t, e),
+          (t.prototype =
+            null === e
+              ? Object.create(e)
+              : ((n.prototype = e.prototype), new n()));
+      }),
+    L = (function () {
+      function t() {}
+      return (
+        (t.prototype.createGauge = function (t, e) {
+          return z;
+        }),
+        (t.prototype.createHistogram = function (t, e) {
+          return q;
+        }),
+        (t.prototype.createCounter = function (t, e) {
+          return $;
+        }),
+        (t.prototype.createUpDownCounter = function (t, e) {
+          return G;
+        }),
+        (t.prototype.createObservableGauge = function (t, e) {
+          return W;
+        }),
+        (t.prototype.createObservableCounter = function (t, e) {
+          return K;
+        }),
+        (t.prototype.createObservableUpDownCounter = function (t, e) {
+          return X;
+        }),
+        (t.prototype.addBatchObservableCallback = function (t, e) {}),
+        (t.prototype.removeBatchObservableCallback = function (t) {}),
+        t
+      );
+    })(),
+    D = function () {},
+    I = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), (e.prototype.add = function (t, e) {}), e;
+    })(D),
+    M = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), (e.prototype.add = function (t, e) {}), e;
+    })(D),
+    k = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), (e.prototype.record = function (t, e) {}), e;
+    })(D),
+    j = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), (e.prototype.record = function (t, e) {}), e;
+    })(D),
+    U = (function () {
+      function t() {}
+      return (
+        (t.prototype.addCallback = function (t) {}),
+        (t.prototype.removeCallback = function (t) {}),
+        t
+      );
+    })(),
+    B = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), e;
+    })(U),
+    F = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), e;
+    })(U),
+    H = (function (t) {
+      function e() {
+        return (null !== t && t.apply(this, arguments)) || this;
+      }
+      return P(e, t), e;
+    })(U),
+    V = new L(),
+    $ = new I(),
+    z = new k(),
+    q = new j(),
+    G = new M(),
+    K = new B(),
+    W = new F(),
+    X = new H(),
+    Q = {
+      get: function (t, e) {
+        if (null != t) return t[e];
+      },
+      keys: function (t) {
+        return null == t ? [] : Object.keys(t);
+      },
+    },
+    Y = {
+      set: function (t, e, n) {
+        null != t && (t[e] = n);
+      },
+    },
+    Z = function (t, e) {
+      var n = "function" == typeof Symbol && t[Symbol.iterator];
+      if (!n) return t;
+      var r,
+        o,
+        i = n.call(t),
+        s = [];
+      try {
+        for (; (void 0 === e || e-- > 0) && !(r = i.next()).done; )
+          s.push(r.value);
+      } catch (t) {
+        o = { error: t };
+      } finally {
+        try {
+          r && !r.done && (n = i.return) && n.call(i);
+        } finally {
+          if (o) throw o.error;
+        }
+      }
+      return s;
+    },
+    J = function (t, e, n) {
+      if (n || 2 === arguments.length)
+        for (var r, o = 0, i = e.length; o < i; o++)
+          (!r && o in e) ||
+            (r || (r = Array.prototype.slice.call(e, 0, o)), (r[o] = e[o]));
+      return t.concat(r || Array.prototype.slice.call(e));
+    },
+    tt = (function () {
+      function t() {}
+      return (
+        (t.prototype.active = function () {
+          return x;
+        }),
+        (t.prototype.with = function (t, e, n) {
+          for (var r = [], o = 3; o < arguments.length; o++)
+            r[o - 3] = arguments[o];
+          return e.call.apply(e, J([n], Z(r), !1));
+        }),
+        (t.prototype.bind = function (t, e) {
+          return e;
+        }),
+        (t.prototype.enable = function () {
+          return this;
+        }),
+        (t.prototype.disable = function () {
+          return this;
+        }),
+        t
+      );
+    })(),
+    et = function (t, e) {
+      var n = "function" == typeof Symbol && t[Symbol.iterator];
+      if (!n) return t;
+      var r,
+        o,
+        i = n.call(t),
+        s = [];
+      try {
+        for (; (void 0 === e || e-- > 0) && !(r = i.next()).done; )
+          s.push(r.value);
+      } catch (t) {
+        o = { error: t };
+      } finally {
+        try {
+          r && !r.done && (n = i.return) && n.call(i);
+        } finally {
+          if (o) throw o.error;
+        }
+      }
+      return s;
+    },
+    nt = function (t, e, n) {
+      if (n || 2 === arguments.length)
+        for (var r, o = 0, i = e.length; o < i; o++)
+          (!r && o in e) ||
+            (r || (r = Array.prototype.slice.call(e, 0, o)), (r[o] = e[o]));
+      return t.concat(r || Array.prototype.slice.call(e));
+    },
+    rt = "context",
+    ot = new tt(),
+    it = (function () {
+      function t() {}
+      return (
+        (t.getInstance = function () {
+          return this._instance || (this._instance = new t()), this._instance;
+        }),
+        (t.prototype.setGlobalContextManager = function (t) {
+          return c(rt, t, y.instance());
+        }),
+        (t.prototype.active = function () {
+          return this._getContextManager().active();
+        }),
+        (t.prototype.with = function (t, e, n) {
+          for (var r, o = [], i = 3; i < arguments.length; i++)
+            o[i - 3] = arguments[i];
+          return (r = this._getContextManager()).with.apply(
+            r,
+            nt([t, e, n], et(o), !1)
+          );
+        }),
+        (t.prototype.bind = function (t, e) {
+          return this._getContextManager().bind(t, e);
+        }),
+        (t.prototype._getContextManager = function () {
+          return l(rt) || ot;
+        }),
+        (t.prototype.disable = function () {
+          this._getContextManager().disable(), p(rt, y.instance());
+        }),
+        t
+      );
+    })();
+  !(function (t) {
+    (t[(t.NONE = 0)] = "NONE"), (t[(t.SAMPLED = 1)] = "SAMPLED");
+  })(R || (R = {}));
+  var st = "0000000000000000",
+    at = "00000000000000000000000000000000",
+    ut = { traceId: at, spanId: st, traceFlags: R.NONE },
+    ct = (function () {
+      function t(t) {
+        void 0 === t && (t = ut), (this._spanContext = t);
+      }
+      return (
+        (t.prototype.spanContext = function () {
+          return this._spanContext;
+        }),
+        (t.prototype.setAttribute = function (t, e) {
+          return this;
+        }),
+        (t.prototype.setAttributes = function (t) {
+          return this;
+        }),
+        (t.prototype.addEvent = function (t, e) {
+          return this;
+        }),
+        (t.prototype.addLink = function (t) {
+          return this;
+        }),
+        (t.prototype.addLinks = function (t) {
+          return this;
+        }),
+        (t.prototype.setStatus = function (t) {
+          return this;
+        }),
+        (t.prototype.updateName = function (t) {
+          return this;
+        }),
+        (t.prototype.end = function (t) {}),
+        (t.prototype.isRecording = function () {
+          return !1;
+        }),
+        (t.prototype.recordException = function (t, e) {}),
+        t
+      );
+    })(),
+    lt = A("OpenTelemetry Context Key SPAN");
+  function pt(t) {
+    return t.getValue(lt) || void 0;
+  }
+  function dt() {
+    return pt(it.getInstance().active());
+  }
+  function ht(t, e) {
+    return t.setValue(lt, e);
+  }
+  function ft(t) {
+    return t.deleteValue(lt);
+  }
+  function gt(t, e) {
+    return ht(t, new ct(e));
+  }
+  function mt(t) {
+    var e;
+    return null === (e = pt(t)) || void 0 === e ? void 0 : e.spanContext();
+  }
+  var _t = /^([0-9a-f]{32})$/i,
+    vt = /^[0-9a-f]{16}$/i;
+  function yt(t) {
+    return _t.test(t) && t !== at;
+  }
+  function St(t) {
+    return yt(t.traceId) && ((e = t.spanId), vt.test(e) && e !== st);
+    var e;
+  }
+  function bt(t) {
+    return new ct(t);
+  }
+  var Et = it.getInstance(),
+    Tt = (function () {
+      function t() {}
+      return (
+        (t.prototype.startSpan = function (t, e, n) {
+          if (
+            (void 0 === n && (n = Et.active()),
+            Boolean(null == e ? void 0 : e.root))
+          )
+            return new ct();
+          var r,
+            o = n && mt(n);
+          return "object" == typeof (r = o) &&
+            "string" == typeof r.spanId &&
+            "string" == typeof r.traceId &&
+            "number" == typeof r.traceFlags &&
+            St(o)
+            ? new ct(o)
+            : new ct();
+        }),
+        (t.prototype.startActiveSpan = function (t, e, n, r) {
+          var o, i, s;
+          if (!(arguments.length < 2)) {
+            2 === arguments.length
+              ? (s = e)
+              : 3 === arguments.length
+              ? ((o = e), (s = n))
+              : ((o = e), (i = n), (s = r));
+            var a = null != i ? i : Et.active(),
+              u = this.startSpan(t, o, a),
+              c = ht(a, u);
+            return Et.with(c, s, void 0, u);
+          }
+        }),
+        t
+      );
+    })();
+  var wt,
+    Ct,
+    At,
+    Ot = new Tt(),
+    Rt = (function () {
+      function t(t, e, n, r) {
+        (this._provider = t),
+          (this.name = e),
+          (this.version = n),
+          (this.options = r);
+      }
+      return (
+        (t.prototype.startSpan = function (t, e, n) {
+          return this._getTracer().startSpan(t, e, n);
+        }),
+        (t.prototype.startActiveSpan = function (t, e, n, r) {
+          var o = this._getTracer();
+          return Reflect.apply(o.startActiveSpan, o, arguments);
+        }),
+        (t.prototype._getTracer = function () {
+          if (this._delegate) return this._delegate;
+          var t = this._provider.getDelegateTracer(
+            this.name,
+            this.version,
+            this.options
+          );
+          return t ? ((this._delegate = t), this._delegate) : Ot;
+        }),
+        t
+      );
+    })(),
+    Nt = new ((function () {
+      function t() {}
+      return (
+        (t.prototype.getTracer = function (t, e, n) {
+          return new Tt();
+        }),
+        t
+      );
+    })())(),
+    xt = (function () {
+      function t() {}
+      return (
+        (t.prototype.getTracer = function (t, e, n) {
+          var r;
+          return null !== (r = this.getDelegateTracer(t, e, n)) && void 0 !== r
+            ? r
+            : new Rt(this, t, e, n);
+        }),
+        (t.prototype.getDelegate = function () {
+          var t;
+          return null !== (t = this._delegate) && void 0 !== t ? t : Nt;
+        }),
+        (t.prototype.setDelegate = function (t) {
+          this._delegate = t;
+        }),
+        (t.prototype.getDelegateTracer = function (t, e, n) {
+          var r;
+          return null === (r = this._delegate) || void 0 === r
+            ? void 0
+            : r.getTracer(t, e, n);
+        }),
+        t
+      );
+    })();
+  !(function (t) {
+    (t[(t.NOT_RECORD = 0)] = "NOT_RECORD"),
+      (t[(t.RECORD = 1)] = "RECORD"),
+      (t[(t.RECORD_AND_SAMPLED = 2)] = "RECORD_AND_SAMPLED");
+  })(wt || (wt = {})),
+    (function (t) {
+      (t[(t.INTERNAL = 0)] = "INTERNAL"),
+        (t[(t.SERVER = 1)] = "SERVER"),
+        (t[(t.CLIENT = 2)] = "CLIENT"),
+        (t[(t.PRODUCER = 3)] = "PRODUCER"),
+        (t[(t.CONSUMER = 4)] = "CONSUMER");
+    })(Ct || (Ct = {})),
+    (function (t) {
+      (t[(t.UNSET = 0)] = "UNSET"),
+        (t[(t.OK = 1)] = "OK"),
+        (t[(t.ERROR = 2)] = "ERROR");
+    })(At || (At = {}));
+  var Pt = it.getInstance(),
+    Lt = y.instance(),
+    Dt = new ((function () {
+      function t() {}
+      return (
+        (t.prototype.getMeter = function (t, e, n) {
+          return V;
+        }),
+        t
+      );
+    })())(),
+    It = "metrics",
+    Mt = (function () {
+      function t() {}
+      return (
+        (t.getInstance = function () {
+          return this._instance || (this._instance = new t()), this._instance;
+        }),
+        (t.prototype.setGlobalMeterProvider = function (t) {
+          return c(It, t, y.instance());
+        }),
+        (t.prototype.getMeterProvider = function () {
+          return l(It) || Dt;
+        }),
+        (t.prototype.getMeter = function (t, e, n) {
+          return this.getMeterProvider().getMeter(t, e, n);
+        }),
+        (t.prototype.disable = function () {
+          p(It, y.instance());
+        }),
+        t
+      );
+    })().getInstance(),
+    kt = (function () {
+      function t() {}
+      return (
+        (t.prototype.inject = function (t, e) {}),
+        (t.prototype.extract = function (t, e) {
+          return t;
+        }),
+        (t.prototype.fields = function () {
+          return [];
+        }),
+        t
+      );
+    })(),
+    jt = A("OpenTelemetry Baggage Key");
+  function Ut(t) {
+    return t.getValue(jt) || void 0;
+  }
+  function Bt() {
+    return Ut(it.getInstance().active());
+  }
+  function Ft(t, e) {
+    return t.setValue(jt, e);
+  }
+  function Ht(t) {
+    return t.deleteValue(jt);
+  }
+  var Vt = "propagation",
+    $t = new kt(),
+    zt = (function () {
+      function t() {
+        (this.createBaggage = C),
+          (this.getBaggage = Ut),
+          (this.getActiveBaggage = Bt),
+          (this.setBaggage = Ft),
+          (this.deleteBaggage = Ht);
+      }
+      return (
+        (t.getInstance = function () {
+          return this._instance || (this._instance = new t()), this._instance;
+        }),
+        (t.prototype.setGlobalPropagator = function (t) {
+          return c(Vt, t, y.instance());
+        }),
+        (t.prototype.inject = function (t, e, n) {
+          return (
+            void 0 === n && (n = Y), this._getGlobalPropagator().inject(t, e, n)
+          );
+        }),
+        (t.prototype.extract = function (t, e, n) {
+          return (
+            void 0 === n && (n = Q),
+            this._getGlobalPropagator().extract(t, e, n)
+          );
+        }),
+        (t.prototype.fields = function () {
+          return this._getGlobalPropagator().fields();
+        }),
+        (t.prototype.disable = function () {
+          p(Vt, y.instance());
+        }),
+        (t.prototype._getGlobalPropagator = function () {
+          return l(Vt) || $t;
+        }),
+        t
+      );
+    })(),
+    qt = zt.getInstance(),
+    Gt = "trace",
+    Kt = (function () {
+      function t() {
+        (this._proxyTracerProvider = new xt()),
+          (this.wrapSpanContext = bt),
+          (this.isSpanContextValid = St),
+          (this.deleteSpan = ft),
+          (this.getSpan = pt),
+          (this.getActiveSpan = dt),
+          (this.getSpanContext = mt),
+          (this.setSpan = ht),
+          (this.setSpanContext = gt);
+      }
+      return (
+        (t.getInstance = function () {
+          return this._instance || (this._instance = new t()), this._instance;
+        }),
+        (t.prototype.setGlobalTracerProvider = function (t) {
+          var e = c(Gt, this._proxyTracerProvider, y.instance());
+          return e && this._proxyTracerProvider.setDelegate(t), e;
+        }),
+        (t.prototype.getTracerProvider = function () {
+          return l(Gt) || this._proxyTracerProvider;
+        }),
+        (t.prototype.getTracer = function (t, e) {
+          return this.getTracerProvider().getTracer(t, e);
+        }),
+        (t.prototype.disable = function () {
+          p(Gt, y.instance()), (this._proxyTracerProvider = new xt());
+        }),
+        t
+      );
+    })().getInstance();
+  const Wt = A("OpenTelemetry SDK Context Key SUPPRESS_TRACING");
+  function Xt(t) {
+    return t.setValue(Wt, !0);
+  }
+  function Qt(t) {
+    return !0 === t.getValue(Wt);
+  }
+  const Yt = "=",
+    Zt = ";",
+    Jt = ",",
+    te = "baggage";
+  function ee(t) {
+    const e = t.split(Zt);
+    if (e.length <= 0) return;
+    const n = e.shift();
+    if (!n) return;
+    const r = n.indexOf(Yt);
+    if (r <= 0) return;
+    const o = decodeURIComponent(n.substring(0, r).trim()),
+      i = decodeURIComponent(n.substring(r + 1).trim());
+    let s;
+    var a;
+    return (
+      e.length > 0 &&
+        ("string" != typeof (a = e.join(Zt)) &&
+          (w.error(
+            "Cannot create baggage metadata from unknown type: " + typeof a
+          ),
+          (a = "")),
+        (s = {
+          __TYPE__: T,
+          toString: function () {
+            return a;
+          },
+        })),
+      { key: o, value: i, metadata: s }
+    );
+  }
+  class ne {
+    inject(t, e, n) {
+      const r = qt.getBaggage(t);
+      if (!r || Qt(t)) return;
+      const o = (function (t) {
+          return t.getAllEntries().map(([t, e]) => {
+            let n = `${encodeURIComponent(t)}=${encodeURIComponent(e.value)}`;
+            return (
+              void 0 !== e.metadata && (n += Zt + e.metadata.toString()), n
+            );
+          });
+        })(r)
+          .filter((t) => t.length <= 4096)
+          .slice(0, 180),
+        i = (function (t) {
+          return t.reduce((t, e) => {
+            const n = `${t}${"" !== t ? Jt : ""}${e}`;
+            return n.length > 8192 ? t : n;
+          }, "");
+        })(o);
+      i.length > 0 && n.set(e, te, i);
+    }
+    extract(t, e, n) {
+      const r = n.get(e, te),
+        o = Array.isArray(r) ? r.join(Jt) : r;
+      if (!o) return t;
+      const i = {};
+      if (0 === o.length) return t;
+      return (
+        o.split(Jt).forEach((t) => {
+          const e = ee(t);
+          if (e) {
+            const t = { value: e.value };
+            e.metadata && (t.metadata = e.metadata), (i[e.key] = t);
+          }
+        }),
+        0 === Object.entries(i).length
+          ? t
+          : qt.setBaggage(t, qt.createBaggage(i))
+      );
+    }
+    fields() {
+      return [te];
+    }
+  }
+  function re(t) {
+    const e = {};
+    if ("object" != typeof t || null == t) return e;
+    for (const [n, r] of Object.entries(t))
+      oe(n)
+        ? ie(r)
+          ? Array.isArray(r)
+            ? (e[n] = r.slice())
+            : (e[n] = r)
+          : Lt.warn(`Invalid attribute value set for key: ${n}`)
+        : Lt.warn(`Invalid attribute key: ${n}`);
+    return e;
+  }
+  function oe(t) {
+    return "string" == typeof t && t.length > 0;
+  }
+  function ie(t) {
+    return (
+      null == t ||
+      (Array.isArray(t)
+        ? (function (t) {
+            let e;
+            for (const n of t)
+              if (null != n) {
+                if (!e) {
+                  if (se(n)) {
+                    e = typeof n;
+                    continue;
+                  }
+                  return !1;
+                }
+                if (typeof n !== e) return !1;
+              }
+            return !0;
+          })(t)
+        : se(t))
+    );
+  }
+  function se(t) {
+    switch (typeof t) {
+      case "number":
+      case "boolean":
+      case "string":
+        return !0;
+    }
+    return !1;
+  }
+  function ae() {
+    return (t) => {
+      Lt.error(
+        (function (t) {
+          return "string" == typeof t
+            ? t
+            : JSON.stringify(
+                (function (t) {
+                  const e = {};
+                  let n = t;
+                  for (; null !== n; )
+                    Object.getOwnPropertyNames(n).forEach((t) => {
+                      if (e[t]) return;
+                      const r = n[t];
+                      r && (e[t] = String(r));
+                    }),
+                      (n = Object.getPrototypeOf(n));
+                  return e;
+                })(t)
+              );
+        })(t)
+      );
+    };
+  }
+  let ue = ae();
+  function ce(t) {
+    try {
+      ue(t);
+    } catch {}
+  }
+  function le(t) {}
+  const pe =
+      "object" == typeof globalThis
+        ? globalThis
+        : "object" == typeof self
+        ? self
+        : "object" == typeof window
+        ? window
+        : "object" == typeof global
+        ? global
+        : {},
+    de = performance,
+    he = "exception.type",
+    fe = "exception.message",
+    ge = "http.method",
+    me = "http.url",
+    _e = "http.host",
+    ve = "http.scheme",
+    ye = "http.status_code",
+    Se = "http.user_agent",
+    be = "http.request_content_length_uncompressed",
+    Ee = "process.runtime.name",
+    Te = "telemetry.sdk.name",
+    we = "telemetry.sdk.language",
+    Ce = "telemetry.sdk.version",
+    Ae = "service.name",
+    Oe = "telemetry.sdk.language",
+    Re = "telemetry.sdk.name",
+    Ne = "telemetry.sdk.version",
+    xe = {
+      [Te]: "opentelemetry",
+      [Ee]: "browser",
+      [we]: "webjs",
+      [Ce]: "2.0.0",
+    };
+  function Pe(t) {}
+  const Le = Math.pow(10, 6),
+    De = Math.pow(10, 9);
+  function Ie(t) {
+    const e = t / 1e3;
+    return [Math.trunc(e), Math.round((t % 1e3) * Le)];
+  }
+  function Me() {
+    let t = de.timeOrigin;
+    if ("number" != typeof t) {
+      const e = de;
+      t = e.timing && e.timing.fetchStart;
+    }
+    return t;
+  }
+  function ke(t) {
+    return Ve(Ie(Me()), Ie("number" == typeof t ? t : de.now()));
+  }
+  function je(t) {
+    if (Fe(t)) return t;
+    if ("number" == typeof t) return t < Me() ? ke(t) : Ie(t);
+    if (t instanceof Date) return Ie(t.getTime());
+    throw TypeError("Invalid input type");
+  }
+  function Ue(t, e) {
+    let n = e[0] - t[0],
+      r = e[1] - t[1];
+    return r < 0 && ((n -= 1), (r += De)), [n, r];
+  }
+  function Be(t) {
+    return t[0] * De + t[1];
+  }
+  function Fe(t) {
+    return (
+      Array.isArray(t) &&
+      2 === t.length &&
+      "number" == typeof t[0] &&
+      "number" == typeof t[1]
+    );
+  }
+  function He(t) {
+    return Fe(t) || "number" == typeof t || t instanceof Date;
+  }
+  function Ve(t, e) {
+    const n = [t[0] + e[0], t[1] + e[1]];
+    return n[1] >= De && ((n[1] -= De), (n[0] += 1)), n;
+  }
+  var $e;
+  !(function (t) {
+    (t[(t.SUCCESS = 0)] = "SUCCESS"), (t[(t.FAILED = 1)] = "FAILED");
+  })($e || ($e = {}));
+  class ze {
+    _propagators;
+    _fields;
+    constructor(t = {}) {
+      (this._propagators = t.propagators ?? []),
+        (this._fields = Array.from(
+          new Set(
+            this._propagators
+              .map((t) => ("function" == typeof t.fields ? t.fields() : []))
+              .reduce((t, e) => t.concat(e), [])
+          )
+        ));
+    }
+    inject(t, e, n) {
+      for (const r of this._propagators)
+        try {
+          r.inject(t, e, n);
+        } catch (t) {
+          Lt.warn(
+            `Failed to inject with ${r.constructor.name}. Err: ${t.message}`
+          );
+        }
+    }
+    extract(t, e, n) {
+      return this._propagators.reduce((t, r) => {
+        try {
+          return r.extract(t, e, n);
+        } catch (t) {
+          Lt.warn(
+            `Failed to extract with ${r.constructor.name}. Err: ${t.message}`
+          );
+        }
+        return t;
+      }, t);
+    }
+    fields() {
+      return this._fields.slice();
+    }
+  }
+  const qe = "[_0-9a-z-*/]",
+    Ge = new RegExp(
+      `^(?:${`[a-z]${qe}{0,255}`}|${`[a-z0-9]${qe}{0,240}@[a-z]${qe}{0,13}`})$`
+    ),
+    Ke = /^[ -~]{0,255}[!-~]$/,
+    We = /,|=/;
+  class Xe {
+    _internalState = new Map();
+    constructor(t) {
+      t && this._parse(t);
+    }
+    set(t, e) {
+      const n = this._clone();
+      return (
+        n._internalState.has(t) && n._internalState.delete(t),
+        n._internalState.set(t, e),
+        n
+      );
+    }
+    unset(t) {
+      const e = this._clone();
+      return e._internalState.delete(t), e;
+    }
+    get(t) {
+      return this._internalState.get(t);
+    }
+    serialize() {
+      return this._keys()
+        .reduce((t, e) => (t.push(e + "=" + this.get(e)), t), [])
+        .join(",");
+    }
+    _parse(t) {
+      t.length > 512 ||
+        ((this._internalState = t
+          .split(",")
+          .reverse()
+          .reduce((t, e) => {
+            const n = e.trim(),
+              r = n.indexOf("=");
+            if (-1 !== r) {
+              const o = n.slice(0, r),
+                i = n.slice(r + 1, e.length);
+              (function (t) {
+                return Ge.test(t);
+              })(o) &&
+                (function (t) {
+                  return Ke.test(t) && !We.test(t);
+                })(i) &&
+                t.set(o, i);
+            }
+            return t;
+          }, new Map())),
+        this._internalState.size > 32 &&
+          (this._internalState = new Map(
+            Array.from(this._internalState.entries()).reverse().slice(0, 32)
+          )));
+    }
+    _keys() {
+      return Array.from(this._internalState.keys()).reverse();
+    }
+    _clone() {
+      const t = new Xe();
+      return (t._internalState = new Map(this._internalState)), t;
+    }
+  }
+  const Qe = "traceparent",
+    Ye = "tracestate",
+    Ze = new RegExp(
+      "^\\s?((?!ff)[\\da-f]{2})-((?![0]{32})[\\da-f]{32})-((?![0]{16})[\\da-f]{16})-([\\da-f]{2})(-.*)?\\s?$"
+    );
+  function Je(t) {
+    const e = Ze.exec(t);
+    return e
+      ? "00" === e[1] && e[5]
+        ? null
+        : { traceId: e[2], spanId: e[3], traceFlags: parseInt(e[4], 16) }
+      : null;
+  }
+  class tn {
+    inject(t, e, n) {
+      const r = Kt.getSpanContext(t);
+      if (!r || Qt(t) || !St(r)) return;
+      const o = `00-${r.traceId}-${r.spanId}-0${Number(
+        r.traceFlags || R.NONE
+      ).toString(16)}`;
+      n.set(e, Qe, o), r.traceState && n.set(e, Ye, r.traceState.serialize());
+    }
+    extract(t, e, n) {
+      const r = n.get(e, Qe);
+      if (!r) return t;
+      const o = Array.isArray(r) ? r[0] : r;
+      if ("string" != typeof o) return t;
+      const i = Je(o);
+      if (!i) return t;
+      i.isRemote = !0;
+      const s = n.get(e, Ye);
+      if (s) {
+        const t = Array.isArray(s) ? s.join(",") : s;
+        i.traceState = new Xe("string" == typeof t ? t : void 0);
+      }
+      return Kt.setSpanContext(t, i);
+    }
+    fields() {
+      return [Qe, Ye];
+    }
+  }
+  const en = A("OpenTelemetry SDK Context Key RPC_METADATA");
+  var nn;
+  !(function (t) {
+    t.HTTP = "http";
+  })(nn || (nn = {}));
+  const rn = "[object Object]",
+    on = "[object Null]",
+    sn = "[object Undefined]",
+    an = Function.prototype.toString,
+    un = an.call(Object),
+    cn = Object.getPrototypeOf,
+    ln = Object.prototype,
+    pn = ln.hasOwnProperty,
+    dn = Symbol ? Symbol.toStringTag : void 0,
+    hn = ln.toString;
+  function fn(t) {
+    if (
+      !(function (t) {
+        return null != t && "object" == typeof t;
+      })(t) ||
+      (function (t) {
+        if (null == t) return void 0 === t ? sn : on;
+        return dn && dn in Object(t)
+          ? (function (t) {
+              const e = pn.call(t, dn),
+                n = t[dn];
+              let r = !1;
+              try {
+                (t[dn] = void 0), (r = !0);
+              } catch (t) {}
+              const o = hn.call(t);
+              r && (e ? (t[dn] = n) : delete t[dn]);
+              return o;
+            })(t)
+          : (function (t) {
+              return hn.call(t);
+            })(t);
+      })(t) !== rn
+    )
+      return !1;
+    const e = cn(t);
+    if (null === e) return !0;
+    const n = pn.call(e, "constructor") && e.constructor;
+    return "function" == typeof n && n instanceof n && an.call(n) === un;
+  }
+  const gn = 20;
+  function mn(...t) {
+    let e = t.shift();
+    const n = new WeakMap();
+    for (; t.length > 0; ) e = vn(e, t.shift(), 0, n);
+    return e;
+  }
+  function _n(t) {
+    return Sn(t) ? t.slice() : t;
+  }
+  function vn(t, e, n = 0, r) {
+    let o;
+    if (!(n > gn)) {
+      if ((n++, Tn(t) || Tn(e) || bn(e))) o = _n(e);
+      else if (Sn(t)) {
+        if (((o = t.slice()), Sn(e)))
+          for (let t = 0, n = e.length; t < n; t++) o.push(_n(e[t]));
+        else if (En(e)) {
+          const t = Object.keys(e);
+          for (let n = 0, r = t.length; n < r; n++) {
+            const r = t[n];
+            o[r] = _n(e[r]);
+          }
+        }
+      } else if (En(t))
+        if (En(e)) {
+          if (
+            !(function (t, e) {
+              if (!fn(t) || !fn(e)) return !1;
+              return !0;
+            })(t, e)
+          )
+            return e;
+          o = Object.assign({}, t);
+          const i = Object.keys(e);
+          for (let s = 0, a = i.length; s < a; s++) {
+            const a = i[s],
+              u = e[a];
+            if (Tn(u)) void 0 === u ? delete o[a] : (o[a] = u);
+            else {
+              const i = o[a],
+                s = u;
+              if (yn(t, a, r) || yn(e, a, r)) delete o[a];
+              else {
+                if (En(i) && En(s)) {
+                  const n = r.get(i) || [],
+                    o = r.get(s) || [];
+                  n.push({ obj: t, key: a }),
+                    o.push({ obj: e, key: a }),
+                    r.set(i, n),
+                    r.set(s, o);
+                }
+                o[a] = vn(o[a], u, n, r);
+              }
+            }
+          }
+        } else o = e;
+      return o;
+    }
+  }
+  function yn(t, e, n) {
+    const r = n.get(t[e]) || [];
+    for (let n = 0, o = r.length; n < o; n++) {
+      const o = r[n];
+      if (o.key === e && o.obj === t) return !0;
+    }
+    return !1;
+  }
+  function Sn(t) {
+    return Array.isArray(t);
+  }
+  function bn(t) {
+    return "function" == typeof t;
+  }
+  function En(t) {
+    return !Tn(t) && !Sn(t) && !bn(t) && "object" == typeof t;
+  }
+  function Tn(t) {
+    return (
+      "string" == typeof t ||
+      "number" == typeof t ||
+      "boolean" == typeof t ||
+      void 0 === t ||
+      t instanceof Date ||
+      t instanceof RegExp ||
+      null === t
+    );
+  }
+  class wn extends Error {
+    constructor(t) {
+      super(t), Object.setPrototypeOf(this, wn.prototype);
+    }
+  }
+  function Cn(t, e) {
+    return "string" == typeof e ? t === e : !!t.match(e);
+  }
+  function An(t, e) {
+    if (!e) return !1;
+    for (const n of e) if (Cn(t, n)) return !0;
+    return !1;
+  }
+  class On {
+    _promise;
+    _resolve;
+    _reject;
+    constructor() {
+      this._promise = new Promise((t, e) => {
+        (this._resolve = t), (this._reject = e);
+      });
+    }
+    get promise() {
+      return this._promise;
+    }
+    resolve(t) {
+      this._resolve(t);
+    }
+    reject(t) {
+      this._reject(t);
+    }
+  }
+  class Rn {
+    _callback;
+    _that;
+    _isCalled = !1;
+    _deferred = new On();
+    constructor(t, e) {
+      (this._callback = t), (this._that = e);
+    }
+    get isCalled() {
+      return this._isCalled;
+    }
+    get promise() {
+      return this._deferred.promise;
+    }
+    call(...t) {
+      if (!this._isCalled) {
+        this._isCalled = !0;
+        try {
+          Promise.resolve(this._callback.call(this._that, ...t)).then(
+            (t) => this._deferred.resolve(t),
+            (t) => this._deferred.reject(t)
+          );
+        } catch (t) {
+          this._deferred.reject(t);
+        }
+      }
+      return this._deferred.promise;
+    }
+  }
+  const Nn = {
+    ALL: d.ALL,
+    VERBOSE: d.VERBOSE,
+    DEBUG: d.DEBUG,
+    INFO: d.INFO,
+    WARN: d.WARN,
+    ERROR: d.ERROR,
+    NONE: d.NONE,
+  };
+  const xn = {
+    _export: function (t, e) {
+      return new Promise((n) => {
+        Pt.with(Xt(Pt.active()), () => {
+          t.export(e, (t) => {
+            n(t);
+          });
+        });
+      });
+    },
+  };
+  var Pn = Object.freeze({
+    __proto__: null,
+    AnchoredClock: class {
+      _monotonicClock;
+      _epochMillis;
+      _performanceMillis;
+      constructor(t, e) {
+        (this._monotonicClock = e),
+          (this._epochMillis = t.now()),
+          (this._performanceMillis = e.now());
+      }
+      now() {
+        const t = this._monotonicClock.now() - this._performanceMillis;
+        return this._epochMillis + t;
+      }
+    },
+    BindOnceFuture: Rn,
+    CompositePropagator: ze,
+    get ExportResultCode() {
+      return $e;
+    },
+    get RPCType() {
+      return nn;
+    },
+    SDK_INFO: xe,
+    TRACE_PARENT_HEADER: Qe,
+    TRACE_STATE_HEADER: Ye,
+    TimeoutError: wn,
+    TraceState: Xe,
+    W3CBaggagePropagator: ne,
+    W3CTraceContextPropagator: tn,
+    _globalThis: pe,
+    addHrTimes: Ve,
+    callWithTimeout: function (t, e) {
+      let n;
+      const r = new Promise(function (t, r) {
+        n = setTimeout(function () {
+          r(new wn("Operation timed out."));
+        }, e);
+      });
+      return Promise.race([t, r]).then(
+        (t) => (clearTimeout(n), t),
+        (t) => {
+          throw (clearTimeout(n), t);
+        }
+      );
+    },
+    deleteRPCMetadata: function (t) {
+      return t.deleteValue(en);
+    },
+    diagLogLevelFromString: function (t) {
+      if (null == t) return;
+      const e = Nn[t.toUpperCase()];
+      return null == e
+        ? (Lt.warn(
+            `Unknown log level "${t}", expected one of ${Object.keys(
+              Nn
+            )}, using default`
+          ),
+          d.INFO)
+        : e;
+    },
+    getBooleanFromEnv: function (t) {},
+    getNumberFromEnv: le,
+    getRPCMetadata: function (t) {
+      return t.getValue(en);
+    },
+    getStringFromEnv: function (t) {},
+    getStringListFromEnv: function (t) {},
+    getTimeOrigin: Me,
+    globalErrorHandler: ce,
+    hrTime: ke,
+    hrTimeDuration: Ue,
+    hrTimeToMicroseconds: function (t) {
+      return 1e6 * t[0] + t[1] / 1e3;
+    },
+    hrTimeToMilliseconds: function (t) {
+      return 1e3 * t[0] + t[1] / 1e6;
+    },
+    hrTimeToNanoseconds: Be,
+    hrTimeToTimeStamp: function (t) {
+      const e = `${"0".repeat(9)}${t[1]}Z`,
+        n = e.substring(e.length - 9 - 1);
+      return new Date(1e3 * t[0]).toISOString().replace("000Z", n);
+    },
+    internal: xn,
+    isAttributeValue: ie,
+    isTimeInput: He,
+    isTimeInputHrTime: Fe,
+    isTracingSuppressed: Qt,
+    isUrlIgnored: An,
+    loggingErrorHandler: ae,
+    merge: mn,
+    millisToHrTime: Ie,
+    otperformance: de,
+    parseKeyPairsIntoRecord: function (t) {
+      return "string" != typeof t || 0 === t.length
+        ? {}
+        : t
+            .split(Jt)
+            .map((t) => ee(t))
+            .filter((t) => void 0 !== t && t.value.length > 0)
+            .reduce((t, e) => ((t[e.key] = e.value), t), {});
+    },
+    parseTraceParent: Je,
+    sanitizeAttributes: re,
+    setGlobalErrorHandler: function (t) {
+      ue = t;
+    },
+    setRPCMetadata: function (t, e) {
+      return t.setValue(en, e);
+    },
+    suppressTracing: Xt,
+    timeInputToHrTime: je,
+    unrefTimer: Pe,
+    unsuppressTracing: function (t) {
+      return t.deleteValue(Wt);
+    },
+    urlMatches: Cn,
+  });
+  function Ln(t) {
+    if (Object.prototype.hasOwnProperty.call(t, "__esModule")) return t;
+    var e = t.default;
+    if ("function" == typeof e) {
+      var n = function t() {
+        return this instanceof t
+          ? Reflect.construct(e, arguments, this.constructor)
+          : e.apply(this, arguments);
+      };
+      n.prototype = e.prototype;
+    } else n = {};
+    return (
+      Object.defineProperty(n, "__esModule", { value: !0 }),
+      Object.keys(t).forEach(function (e) {
+        var r = Object.getOwnPropertyDescriptor(t, e);
+        Object.defineProperty(
+          n,
+          e,
+          r.get
+            ? r
+            : {
+                enumerable: !0,
+                get: function () {
+                  return t[e];
+                },
+              }
+        );
+      }),
+      n
+    );
+  }
+  var Dn,
+    In = {},
+    Mn = {};
+  function kn() {
+    if (Dn) return Mn;
+    function t(t) {
+      return Object.keys(t).map((n) => e(n, t[n]));
+    }
+    function e(t, e) {
+      return { key: t, value: n(e) };
+    }
+    function n(t) {
+      const r = typeof t;
+      return "string" === r
+        ? { stringValue: t }
+        : "number" === r
+        ? Number.isInteger(t)
+          ? { intValue: t }
+          : { doubleValue: t }
+        : "boolean" === r
+        ? { boolValue: t }
+        : t instanceof Uint8Array
+        ? { bytesValue: t }
+        : Array.isArray(t)
+        ? { arrayValue: { values: t.map(n) } }
+        : "object" === r && null != t
+        ? {
+            kvlistValue: { values: Object.entries(t).map(([t, n]) => e(t, n)) },
+          }
+        : {};
+    }
+    return (
+      (Dn = 1),
+      Object.defineProperty(Mn, "__esModule", { value: !0 }),
+      (Mn.toAnyValue =
+        Mn.toKeyValue =
+        Mn.toAttributes =
+        Mn.createInstrumentationScope =
+        Mn.createResource =
+          void 0),
+      (Mn.createResource = function (e) {
+        return { attributes: t(e.attributes), droppedAttributesCount: 0 };
+      }),
+      (Mn.createInstrumentationScope = function (t) {
+        return { name: t.name, version: t.version };
+      }),
+      (Mn.toAttributes = t),
+      (Mn.toKeyValue = e),
+      (Mn.toAnyValue = n),
+      Mn
+    );
+  }
+  var jn,
+    Un,
+    Bn,
+    Fn = {},
+    Hn = Ln(Pn),
+    Vn = {};
+  function $n() {
+    if (jn) return Vn;
+    function t(t) {
+      return t >= 48 && t <= 57
+        ? t - 48
+        : t >= 97 && t <= 102
+        ? t - 87
+        : t - 55;
+    }
+    return (
+      (jn = 1),
+      Object.defineProperty(Vn, "__esModule", { value: !0 }),
+      (Vn.hexToBinary = void 0),
+      (Vn.hexToBinary = function (e) {
+        const n = new Uint8Array(e.length / 2);
+        let r = 0;
+        for (let o = 0; o < e.length; o += 2) {
+          const i = t(e.charCodeAt(o)),
+            s = t(e.charCodeAt(o + 1));
+          n[r++] = (i << 4) | s;
+        }
+        return n;
+      }),
+      Vn
+    );
+  }
+  function zn() {
+    if (Un) return Fn;
+    (Un = 1),
+      Object.defineProperty(Fn, "__esModule", { value: !0 }),
+      (Fn.getOtlpEncoder =
+        Fn.encodeAsString =
+        Fn.encodeAsLongBits =
+        Fn.toLongBits =
+        Fn.hrTimeToNanos =
+          void 0);
+    const t = Hn,
+      e = $n();
+    function n(t) {
+      const e = BigInt(1e9);
+      return BigInt(t[0]) * e + BigInt(t[1]);
+    }
+    function r(t) {
+      return {
+        low: Number(BigInt.asUintN(32, t)),
+        high: Number(BigInt.asUintN(32, t >> BigInt(32))),
+      };
+    }
+    function o(t) {
+      return r(n(t));
+    }
+    function i(t) {
+      return n(t).toString();
+    }
+    (Fn.hrTimeToNanos = n),
+      (Fn.toLongBits = r),
+      (Fn.encodeAsLongBits = o),
+      (Fn.encodeAsString = i);
+    const s = "undefined" != typeof BigInt ? i : t.hrTimeToNanoseconds;
+    function a(t) {
+      return t;
+    }
+    function u(t) {
+      if (void 0 !== t) return (0, e.hexToBinary)(t);
+    }
+    const c = {
+      encodeHrTime: o,
+      encodeSpanContext: e.hexToBinary,
+      encodeOptionalSpanContext: u,
+    };
+    return (
+      (Fn.getOtlpEncoder = function (t) {
+        if (void 0 === t) return c;
+        const n = t.useLongBits ?? !0,
+          r = t.useHex ?? !1;
+        return {
+          encodeHrTime: n ? o : s,
+          encodeSpanContext: r ? a : e.hexToBinary,
+          encodeOptionalSpanContext: r ? a : u,
+        };
+      }),
+      Fn
+    );
+  }
+  function qn() {
+    if (Bn) return In;
+    (Bn = 1),
+      Object.defineProperty(In, "__esModule", { value: !0 }),
+      (In.createExportTraceServiceRequest =
+        In.toOtlpSpanEvent =
+        In.toOtlpLink =
+        In.sdkSpanToOtlpSpan =
+          void 0);
+    const t = kn(),
+      e = zn();
+    function n(e, n) {
+      const i = e.spanContext(),
+        s = e.status,
+        a = e.parentSpanContext?.spanId
+          ? n.encodeSpanContext(e.parentSpanContext?.spanId)
+          : void 0;
+      return {
+        traceId: n.encodeSpanContext(i.traceId),
+        spanId: n.encodeSpanContext(i.spanId),
+        parentSpanId: a,
+        traceState: i.traceState?.serialize(),
+        name: e.name,
+        kind: null == e.kind ? 0 : e.kind + 1,
+        startTimeUnixNano: n.encodeHrTime(e.startTime),
+        endTimeUnixNano: n.encodeHrTime(e.endTime),
+        attributes: (0, t.toAttributes)(e.attributes),
+        droppedAttributesCount: e.droppedAttributesCount,
+        events: e.events.map((t) => o(t, n)),
+        droppedEventsCount: e.droppedEventsCount,
+        status: { code: s.code, message: s.message },
+        links: e.links.map((t) => r(t, n)),
+        droppedLinksCount: e.droppedLinksCount,
+      };
+    }
+    function r(e, n) {
+      return {
+        attributes: e.attributes ? (0, t.toAttributes)(e.attributes) : [],
+        spanId: n.encodeSpanContext(e.context.spanId),
+        traceId: n.encodeSpanContext(e.context.traceId),
+        traceState: e.context.traceState?.serialize(),
+        droppedAttributesCount: e.droppedAttributesCount || 0,
+      };
+    }
+    function o(e, n) {
+      return {
+        attributes: e.attributes ? (0, t.toAttributes)(e.attributes) : [],
+        name: e.name,
+        timeUnixNano: n.encodeHrTime(e.time),
+        droppedAttributesCount: e.droppedAttributesCount || 0,
+      };
+    }
+    function i(e, r) {
+      const o = (function (t) {
+          const e = new Map();
+          for (const n of t) {
+            let t = e.get(n.resource);
+            t || ((t = new Map()), e.set(n.resource, t));
+            const r = `${n.instrumentationScope.name}@${
+              n.instrumentationScope.version || ""
+            }:${n.instrumentationScope.schemaUrl || ""}`;
+            let o = t.get(r);
+            o || ((o = []), t.set(r, o)), o.push(n);
+          }
+          return e;
+        })(e),
+        i = [],
+        s = o.entries();
+      let a = s.next();
+      for (; !a.done; ) {
+        const [e, o] = a.value,
+          u = [],
+          c = o.values();
+        let l = c.next();
+        for (; !l.done; ) {
+          const e = l.value;
+          if (e.length > 0) {
+            const o = e.map((t) => n(t, r));
+            u.push({
+              scope: (0, t.createInstrumentationScope)(
+                e[0].instrumentationScope
+              ),
+              spans: o,
+              schemaUrl: e[0].instrumentationScope.schemaUrl,
+            });
+          }
+          l = c.next();
+        }
+        const p = {
+          resource: (0, t.createResource)(e),
+          scopeSpans: u,
+          schemaUrl: void 0,
+        };
+        i.push(p), (a = s.next());
+      }
+      return i;
+    }
+    return (
+      (In.sdkSpanToOtlpSpan = n),
+      (In.toOtlpLink = r),
+      (In.toOtlpSpanEvent = o),
+      (In.createExportTraceServiceRequest = function (t, n) {
+        return { resourceSpans: i(t, (0, e.getOtlpEncoder)(n)) };
+      }),
+      In
+    );
+  }
+  var Gn,
+    Kn = qn(),
+    Wn = {};
+  function Xn() {
+    return (
+      Gn ||
+        ((Gn = 1),
+        (function (t) {
+          var e;
+          Object.defineProperty(t, "__esModule", { value: !0 }),
+            (t.ESpanKind = void 0),
+            ((e = t.ESpanKind || (t.ESpanKind = {}))[
+              (e.SPAN_KIND_UNSPECIFIED = 0)
+            ] = "SPAN_KIND_UNSPECIFIED"),
+            (e[(e.SPAN_KIND_INTERNAL = 1)] = "SPAN_KIND_INTERNAL"),
+            (e[(e.SPAN_KIND_SERVER = 2)] = "SPAN_KIND_SERVER"),
+            (e[(e.SPAN_KIND_CLIENT = 3)] = "SPAN_KIND_CLIENT"),
+            (e[(e.SPAN_KIND_PRODUCER = 4)] = "SPAN_KIND_PRODUCER"),
+            (e[(e.SPAN_KIND_CONSUMER = 5)] = "SPAN_KIND_CONSUMER");
+        })(Wn)),
+      Wn
+    );
+  }
+  var Qn = Xn();
+  class Yn {
+    constructor(t) {
+      this.config = t;
+    }
+    export(t, n) {
+      const r = Kn.createExportTraceServiceRequest(t, {
+        useHex: !0,
+        useLongBits: !1,
+      });
+      this.config.api.pushTraces(r),
+        (function (t = []) {
+          var n, r;
+          for (const o of t) {
+            const { scopeSpans: t } = o;
+            for (const o of t) {
+              const { scope: t, spans: i = [] } = o;
+              for (const o of i) {
+                if (o.kind !== Qn.ESpanKind.SPAN_KIND_CLIENT) continue;
+                const i = {
+                    traceId: o.traceId.toString(),
+                    spanId: o.spanId.toString(),
+                  },
+                  s = {};
+                for (const t of o.attributes)
+                  s[t.key] = String(Object.values(t.value)[0]);
+                Number.isNaN(o.endTimeUnixNano) ||
+                  Number.isNaN(o.startTimeUnixNano) ||
+                  (s.duration_ns = String(
+                    Number(o.endTimeUnixNano) - Number(o.startTimeUnixNano)
+                  ));
+                const a = (
+                  null !== (n = null == t ? void 0 : t.name) && void 0 !== n
+                    ? n
+                    : ""
+                ).indexOf("-");
+                let u = e.unknownString;
+                (null == t ? void 0 : t.name) &&
+                  (-1 === a &&
+                    (u =
+                      null !== (r = t.name.split("/")[1]) && void 0 !== r
+                        ? r
+                        : t.name),
+                  a > -1 && (u = null == t ? void 0 : t.name.substring(a + 1))),
+                  e.faro.api.pushEvent(`faro.tracing.${u}`, s, void 0, {
+                    spanContext: i,
+                    timestampOverwriteMs: Number(o.endTimeUnixNano) / 1e6,
+                    customPayloadTransformer: (t) => {
+                      var e, n;
+                      return (
+                        null != s["faro.action.user.name"] &&
+                          null != s["faro.action.user.parentId"] &&
+                          ((t.action = {
+                            name: s["faro.action.user.name"],
+                            parentId: s["faro.action.user.parentId"],
+                          }),
+                          null === (e = t.attributes) ||
+                            void 0 === e ||
+                            delete e["faro.action.user.name"],
+                          null === (n = t.attributes) ||
+                            void 0 === n ||
+                            delete n["faro.action.user.parentId"]),
+                        t
+                      );
+                    },
+                  });
+              }
+            }
+          }
+        })(r.resourceSpans),
+        n({ code: $e.SUCCESS });
+    }
+    shutdown() {
+      return Promise.resolve(void 0);
+    }
+  }
+  const Zn = "session.id";
+  "function" == typeof SuppressedError && SuppressedError;
+  class Jn {
+    emit(t) {}
+  }
+  const tr = new Jn();
+  const er = new (class {
+    getLogger(t, e, n) {
+      return new Jn();
+    }
+  })();
+  class nr {
+    constructor(t, e, n, r) {
+      (this._provider = t),
+        (this.name = e),
+        (this.version = n),
+        (this.options = r);
+    }
+    emit(t) {
+      this._getLogger().emit(t);
+    }
+    _getLogger() {
+      if (this._delegate) return this._delegate;
+      const t = this._provider.getDelegateLogger(
+        this.name,
+        this.version,
+        this.options
+      );
+      return t ? ((this._delegate = t), this._delegate) : tr;
+    }
+  }
+  class rr {
+    getLogger(t, e, n) {
+      var r;
+      return null !== (r = this.getDelegateLogger(t, e, n)) && void 0 !== r
+        ? r
+        : new nr(this, t, e, n);
+    }
+    getDelegate() {
+      var t;
+      return null !== (t = this._delegate) && void 0 !== t ? t : er;
+    }
+    setDelegate(t) {
+      this._delegate = t;
+    }
+    getDelegateLogger(t, e, n) {
+      var r;
+      return null === (r = this._delegate) || void 0 === r
+        ? void 0
+        : r.getLogger(t, e, n);
+    }
+  }
+  const or =
+      "object" == typeof globalThis
+        ? globalThis
+        : "object" == typeof self
+        ? self
+        : "object" == typeof window
+        ? window
+        : "object" == typeof global
+        ? global
+        : {},
+    ir = Symbol.for("io.opentelemetry.js.api.logs"),
+    sr = or;
+  class ar {
+    constructor() {
+      this._proxyLoggerProvider = new rr();
+    }
+    static getInstance() {
+      return this._instance || (this._instance = new ar()), this._instance;
+    }
+    setGlobalLoggerProvider(t) {
+      return sr[ir]
+        ? this.getLoggerProvider()
+        : ((sr[ir] = ((e = 1), (n = t), (r = er), (t) => (t === e ? n : r))),
+          this._proxyLoggerProvider.setDelegate(t),
+          t);
+      var e, n, r;
+    }
+    getLoggerProvider() {
+      var t, e;
+      return null !==
+        (e = null === (t = sr[ir]) || void 0 === t ? void 0 : t.call(sr, 1)) &&
+        void 0 !== e
+        ? e
+        : this._proxyLoggerProvider;
+    }
+    getLogger(t, e, n) {
+      return this.getLoggerProvider().getLogger(t, e, n);
+    }
+    disable() {
+      delete sr[ir], (this._proxyLoggerProvider = new rr());
+    }
+  }
+  const ur = ar.getInstance();
+  var cr, lr;
+  var pr = (function () {
+    if (lr) return cr;
+    function t(t) {
+      return "function" == typeof t;
+    }
+    lr = 1;
+    var e = console.error.bind(console);
+    function n(t, e, n) {
+      var r = !!t[e] && t.propertyIsEnumerable(e);
+      Object.defineProperty(t, e, {
+        configurable: !0,
+        enumerable: r,
+        writable: !0,
+        value: n,
+      });
+    }
+    function r(n) {
+      n &&
+        n.logger &&
+        (t(n.logger)
+          ? (e = n.logger)
+          : e("new logger isn't a function, not replacing"));
+    }
+    function o(r, o, i) {
+      if (r && r[o]) {
+        if (!i) return e("no wrapper function"), void e(new Error().stack);
+        if (t(r[o]) && t(i)) {
+          var s = r[o],
+            a = i(s, o);
+          return (
+            n(a, "__original", s),
+            n(a, "__unwrap", function () {
+              r[o] === a && n(r, o, s);
+            }),
+            n(a, "__wrapped", !0),
+            n(r, o, a),
+            a
+          );
+        }
+        e("original object and wrapper must be functions");
+      } else e("no original function " + o + " to wrap");
+    }
+    function i(t, n) {
+      return t && t[n]
+        ? t[n].__unwrap
+          ? t[n].__unwrap()
+          : void e(
+              "no original to unwrap to -- has " +
+                n +
+                " already been unwrapped?"
+            )
+        : (e("no function to unwrap."), void e(new Error().stack));
+    }
+    return (
+      (r.wrap = o),
+      (r.massWrap = function (t, n, r) {
+        if (!t)
+          return (
+            e("must provide one or more modules to patch"),
+            void e(new Error().stack)
+          );
+        Array.isArray(t) || (t = [t]),
+          n && Array.isArray(n)
+            ? t.forEach(function (t) {
+                n.forEach(function (e) {
+                  o(t, e, r);
+                });
+              })
+            : e("must provide one or more functions to wrap on modules");
+      }),
+      (r.unwrap = i),
+      (r.massUnwrap = function (t, n) {
+        if (!t)
+          return (
+            e("must provide one or more modules to patch"),
+            void e(new Error().stack)
+          );
+        Array.isArray(t) || (t = [t]),
+          n && Array.isArray(n)
+            ? t.forEach(function (t) {
+                n.forEach(function (e) {
+                  i(t, e);
+                });
+              })
+            : e("must provide one or more functions to unwrap on modules");
+      }),
+      (cr = r)
+    );
+  })();
+  class dr {
+    instrumentationName;
+    instrumentationVersion;
+    _config = {};
+    _tracer;
+    _meter;
+    _logger;
+    _diag;
+    constructor(t, e, n) {
+      (this.instrumentationName = t),
+        (this.instrumentationVersion = e),
+        this.setConfig(n),
+        (this._diag = Lt.createComponentLogger({ namespace: t })),
+        (this._tracer = Kt.getTracer(t, e)),
+        (this._meter = Mt.getMeter(t, e)),
+        (this._logger = ur.getLogger(t, e)),
+        this._updateMetricInstruments();
+    }
+    _wrap = pr.wrap;
+    _unwrap = pr.unwrap;
+    _massWrap = pr.massWrap;
+    _massUnwrap = pr.massUnwrap;
+    get meter() {
+      return this._meter;
+    }
+    setMeterProvider(t) {
+      (this._meter = t.getMeter(
+        this.instrumentationName,
+        this.instrumentationVersion
+      )),
+        this._updateMetricInstruments();
+    }
+    get logger() {
+      return this._logger;
+    }
+    setLoggerProvider(t) {
+      this._logger = t.getLogger(
+        this.instrumentationName,
+        this.instrumentationVersion
+      );
+    }
+    getModuleDefinitions() {
+      const t = this.init() ?? [];
+      return Array.isArray(t) ? t : [t];
+    }
+    _updateMetricInstruments() {}
+    getConfig() {
+      return this._config;
+    }
+    setConfig(t) {
+      this._config = { enabled: !0, ...t };
+    }
+    setTracerProvider(t) {
+      this._tracer = t.getTracer(
+        this.instrumentationName,
+        this.instrumentationVersion
+      );
+    }
+    get tracer() {
+      return this._tracer;
+    }
+    _runSpanCustomizationHook(t, e, n, r) {
+      if (t)
+        try {
+          t(n, r);
+        } catch (t) {
+          this._diag.error(
+            "Error running span customization hook due to exception in handler",
+            { triggerName: e },
+            t
+          );
+        }
+    }
+  }
+  class hr extends dr {
+    constructor(t, e, n) {
+      super(t, e, n), this._config.enabled && this.enable();
+    }
+  }
+  function fr(t, e, n) {
+    let r, o;
+    try {
+      o = t();
+    } catch (t) {
+      r = t;
+    } finally {
+      return e(r, o), o;
+    }
+  }
+  function gr(t) {
+    return (
+      "function" == typeof t &&
+      "function" == typeof t.__original &&
+      "function" == typeof t.__unwrap &&
+      !0 === t.__wrapped
+    );
+  }
+  const mr = (t) =>
+    null !== t && "object" == typeof t && "function" == typeof t.then;
+  class _r {
+    _rawAttributes;
+    _asyncAttributesPending = !1;
+    _memoizedAttributes;
+    static FromAttributeList(t) {
+      const e = new _r({});
+      return (
+        (e._rawAttributes = t),
+        (e._asyncAttributesPending = t.filter(([t, e]) => mr(e)).length > 0),
+        e
+      );
+    }
+    constructor(t) {
+      const e = t.attributes ?? {};
+      this._rawAttributes = Object.entries(e).map(
+        ([t, e]) => (mr(e) && (this._asyncAttributesPending = !0), [t, e])
+      );
+    }
+    get asyncAttributesPending() {
+      return this._asyncAttributesPending;
+    }
+    async waitForAsyncAttributes() {
+      if (this.asyncAttributesPending) {
+        for (let t = 0; t < this._rawAttributes.length; t++) {
+          const [e, n] = this._rawAttributes[t];
+          try {
+            this._rawAttributes[t] = [e, mr(n) ? await n : n];
+          } catch (n) {
+            Lt.debug("a resource's async attributes promise rejected: %s", n),
+              (this._rawAttributes[t] = [e, void 0]);
+          }
+        }
+        this._asyncAttributesPending = !1;
+      }
+    }
+    get attributes() {
+      if (
+        (this.asyncAttributesPending &&
+          Lt.error(
+            "Accessing resource attributes before async attributes settled"
+          ),
+        this._memoizedAttributes)
+      )
+        return this._memoizedAttributes;
+      const t = {};
+      for (const [e, n] of this._rawAttributes)
+        mr(n)
+          ? Lt.debug(`Unsettled resource attribute ${e} skipped`)
+          : null != n && (t[e] ??= n);
+      return this._asyncAttributesPending || (this._memoizedAttributes = t), t;
+    }
+    getRawAttributes() {
+      return this._rawAttributes;
+    }
+    merge(t) {
+      return null == t
+        ? this
+        : _r.FromAttributeList([
+            ...t.getRawAttributes(),
+            ...this.getRawAttributes(),
+          ]);
+    }
+  }
+  function vr(t) {
+    return _r.FromAttributeList(Object.entries(t));
+  }
+  function yr() {
+    return vr({
+      [Ae]: "unknown_service",
+      [Oe]: xe[Oe],
+      [Re]: xe[Re],
+      [Ne]: xe[Ne],
+    });
+  }
+  class Sr {
+    _spanContext;
+    kind;
+    parentSpanContext;
+    attributes = {};
+    links = [];
+    events = [];
+    startTime;
+    resource;
+    instrumentationScope;
+    _droppedAttributesCount = 0;
+    _droppedEventsCount = 0;
+    _droppedLinksCount = 0;
+    name;
+    status = { code: At.UNSET };
+    endTime = [0, 0];
+    _ended = !1;
+    _duration = [-1, -1];
+    _spanProcessor;
+    _spanLimits;
+    _attributeValueLengthLimit;
+    _performanceStartTime;
+    _performanceOffset;
+    _startTimeProvided;
+    constructor(t) {
+      const e = Date.now();
+      (this._spanContext = t.spanContext),
+        (this._performanceStartTime = de.now()),
+        (this._performanceOffset = e - (this._performanceStartTime + Me())),
+        (this._startTimeProvided = null != t.startTime),
+        (this._spanLimits = t.spanLimits),
+        (this._attributeValueLengthLimit =
+          this._spanLimits.attributeValueLengthLimit || 0),
+        (this._spanProcessor = t.spanProcessor),
+        (this.name = t.name),
+        (this.parentSpanContext = t.parentSpanContext),
+        (this.kind = t.kind),
+        (this.links = t.links || []),
+        (this.startTime = this._getTime(t.startTime ?? e)),
+        (this.resource = t.resource),
+        (this.instrumentationScope = t.scope),
+        null != t.attributes && this.setAttributes(t.attributes),
+        this._spanProcessor.onStart(this, t.context);
+    }
+    spanContext() {
+      return this._spanContext;
+    }
+    setAttribute(t, e) {
+      if (null == e || this._isSpanEnded()) return this;
+      if (0 === t.length) return Lt.warn(`Invalid attribute key: ${t}`), this;
+      if (!ie(e))
+        return Lt.warn(`Invalid attribute value set for key: ${t}`), this;
+      const { attributeCountLimit: n } = this._spanLimits;
+      return void 0 !== n &&
+        Object.keys(this.attributes).length >= n &&
+        !Object.prototype.hasOwnProperty.call(this.attributes, t)
+        ? (this._droppedAttributesCount++, this)
+        : ((this.attributes[t] = this._truncateToSize(e)), this);
+    }
+    setAttributes(t) {
+      for (const [e, n] of Object.entries(t)) this.setAttribute(e, n);
+      return this;
+    }
+    addEvent(t, e, n) {
+      if (this._isSpanEnded()) return this;
+      const { eventCountLimit: r } = this._spanLimits;
+      if (0 === r)
+        return Lt.warn("No events allowed."), this._droppedEventsCount++, this;
+      void 0 !== r &&
+        this.events.length >= r &&
+        (0 === this._droppedEventsCount && Lt.debug("Dropping extra events."),
+        this.events.shift(),
+        this._droppedEventsCount++),
+        He(e) && (He(n) || (n = e), (e = void 0));
+      const o = re(e);
+      return (
+        this.events.push({
+          name: t,
+          attributes: o,
+          time: this._getTime(n),
+          droppedAttributesCount: 0,
+        }),
+        this
+      );
+    }
+    addLink(t) {
+      return this.links.push(t), this;
+    }
+    addLinks(t) {
+      return this.links.push(...t), this;
+    }
+    setStatus(t) {
+      return (
+        this._isSpanEnded() ||
+          ((this.status = { ...t }),
+          null != this.status.message &&
+            "string" != typeof t.message &&
+            (Lt.warn(
+              `Dropping invalid status.message of type '${typeof t.message}', expected 'string'`
+            ),
+            delete this.status.message)),
+        this
+      );
+    }
+    updateName(t) {
+      return this._isSpanEnded() || (this.name = t), this;
+    }
+    end(t) {
+      this._isSpanEnded()
+        ? Lt.error(
+            `${this.name} ${this._spanContext.traceId}-${this._spanContext.spanId} - You can only call end() on a span once.`
+          )
+        : ((this._ended = !0),
+          (this.endTime = this._getTime(t)),
+          (this._duration = Ue(this.startTime, this.endTime)),
+          this._duration[0] < 0 &&
+            (Lt.warn(
+              "Inconsistent start and end time, startTime > endTime. Setting span duration to 0ms.",
+              this.startTime,
+              this.endTime
+            ),
+            (this.endTime = this.startTime.slice()),
+            (this._duration = [0, 0])),
+          this._droppedEventsCount > 0 &&
+            Lt.warn(
+              `Dropped ${this._droppedEventsCount} events because eventCountLimit reached`
+            ),
+          this._spanProcessor.onEnd(this));
+    }
+    _getTime(t) {
+      if ("number" == typeof t && t <= de.now())
+        return ke(t + this._performanceOffset);
+      if ("number" == typeof t) return Ie(t);
+      if (t instanceof Date) return Ie(t.getTime());
+      if (Fe(t)) return t;
+      if (this._startTimeProvided) return Ie(Date.now());
+      const e = de.now() - this._performanceStartTime;
+      return Ve(this.startTime, Ie(e));
+    }
+    isRecording() {
+      return !1 === this._ended;
+    }
+    recordException(t, e) {
+      const n = {};
+      "string" == typeof t
+        ? (n[fe] = t)
+        : t &&
+          (t.code ? (n[he] = t.code.toString()) : t.name && (n[he] = t.name),
+          t.message && (n[fe] = t.message),
+          t.stack && (n["exception.stacktrace"] = t.stack)),
+        n[he] || n[fe]
+          ? this.addEvent("exception", n, e)
+          : Lt.warn(`Failed to record an exception ${t}`);
+    }
+    get duration() {
+      return this._duration;
+    }
+    get ended() {
+      return this._ended;
+    }
+    get droppedAttributesCount() {
+      return this._droppedAttributesCount;
+    }
+    get droppedEventsCount() {
+      return this._droppedEventsCount;
+    }
+    get droppedLinksCount() {
+      return this._droppedLinksCount;
+    }
+    _isSpanEnded() {
+      if (this._ended) {
+        const t = new Error(
+          `Operation attempted on ended Span {traceId: ${this._spanContext.traceId}, spanId: ${this._spanContext.spanId}}`
+        );
+        Lt.warn(
+          `Cannot execute the operation on ended Span {traceId: ${this._spanContext.traceId}, spanId: ${this._spanContext.spanId}}`,
+          t
+        );
+      }
+      return this._ended;
+    }
+    _truncateToLimitUtil(t, e) {
+      return t.length <= e ? t : t.substring(0, e);
+    }
+    _truncateToSize(t) {
+      const e = this._attributeValueLengthLimit;
+      return e <= 0
+        ? (Lt.warn(`Attribute value limit must be positive, got ${e}`), t)
+        : "string" == typeof t
+        ? this._truncateToLimitUtil(t, e)
+        : Array.isArray(t)
+        ? t.map((t) =>
+            "string" == typeof t ? this._truncateToLimitUtil(t, e) : t
+          )
+        : t;
+    }
+  }
+  var br;
+  !(function (t) {
+    (t[(t.NOT_RECORD = 0)] = "NOT_RECORD"),
+      (t[(t.RECORD = 1)] = "RECORD"),
+      (t[(t.RECORD_AND_SAMPLED = 2)] = "RECORD_AND_SAMPLED");
+  })(br || (br = {}));
+  class Er {
+    shouldSample() {
+      return { decision: br.NOT_RECORD };
+    }
+    toString() {
+      return "AlwaysOffSampler";
+    }
+  }
+  class Tr {
+    shouldSample() {
+      return { decision: br.RECORD_AND_SAMPLED };
+    }
+    toString() {
+      return "AlwaysOnSampler";
+    }
+  }
+  class wr {
+    _root;
+    _remoteParentSampled;
+    _remoteParentNotSampled;
+    _localParentSampled;
+    _localParentNotSampled;
+    constructor(t) {
+      (this._root = t.root),
+        this._root ||
+          (ce(
+            new Error("ParentBasedSampler must have a root sampler configured")
+          ),
+          (this._root = new Tr())),
+        (this._remoteParentSampled = t.remoteParentSampled ?? new Tr()),
+        (this._remoteParentNotSampled = t.remoteParentNotSampled ?? new Er()),
+        (this._localParentSampled = t.localParentSampled ?? new Tr()),
+        (this._localParentNotSampled = t.localParentNotSampled ?? new Er());
+    }
+    shouldSample(t, e, n, r, o, i) {
+      const s = Kt.getSpanContext(t);
+      return s && St(s)
+        ? s.isRemote
+          ? s.traceFlags & R.SAMPLED
+            ? this._remoteParentSampled.shouldSample(t, e, n, r, o, i)
+            : this._remoteParentNotSampled.shouldSample(t, e, n, r, o, i)
+          : s.traceFlags & R.SAMPLED
+          ? this._localParentSampled.shouldSample(t, e, n, r, o, i)
+          : this._localParentNotSampled.shouldSample(t, e, n, r, o, i)
+        : this._root.shouldSample(t, e, n, r, o, i);
+    }
+    toString() {
+      return `ParentBased{root=${this._root.toString()}, remoteParentSampled=${this._remoteParentSampled.toString()}, remoteParentNotSampled=${this._remoteParentNotSampled.toString()}, localParentSampled=${this._localParentSampled.toString()}, localParentNotSampled=${this._localParentNotSampled.toString()}}`;
+    }
+  }
+  class Cr {
+    _ratio;
+    _upperBound;
+    constructor(t = 0) {
+      (this._ratio = t),
+        (this._ratio = this._normalize(t)),
+        (this._upperBound = Math.floor(4294967295 * this._ratio));
+    }
+    shouldSample(t, e) {
+      return {
+        decision:
+          yt(e) && this._accumulate(e) < this._upperBound
+            ? br.RECORD_AND_SAMPLED
+            : br.NOT_RECORD,
+      };
+    }
+    toString() {
+      return `TraceIdRatioBased{${this._ratio}}`;
+    }
+    _normalize(t) {
+      return "number" != typeof t || isNaN(t) ? 0 : t >= 1 ? 1 : t <= 0 ? 0 : t;
+    }
+    _accumulate(t) {
+      let e = 0;
+      for (let n = 0; n < t.length / 8; n++) {
+        const r = 8 * n;
+        e = (e ^ parseInt(t.slice(r, r + 8), 16)) >>> 0;
+      }
+      return e;
+    }
+  }
+  const Ar = 1;
+  function Or() {
+    return {
+      sampler: Rr(),
+      forceFlushTimeoutMillis: 3e4,
+      generalLimits: {
+        attributeValueLengthLimit: 1 / 0,
+        attributeCountLimit: 128,
+      },
+      spanLimits: {
+        attributeValueLengthLimit: 1 / 0,
+        attributeCountLimit: 128,
+        linkCountLimit: 128,
+        eventCountLimit: 128,
+        attributePerEventCountLimit: 128,
+        attributePerLinkCountLimit: 128,
+      },
+    };
+  }
+  function Rr() {
+    const t = "parentbased_always_on";
+    switch (t) {
+      case "always_on":
+        return new Tr();
+      case "always_off":
+        return new Er();
+      case "parentbased_always_on":
+        return new wr({ root: new Tr() });
+      case "parentbased_always_off":
+        return new wr({ root: new Er() });
+      case "traceidratio":
+        return new Cr(Nr());
+      case "parentbased_traceidratio":
+        return new wr({ root: new Cr(Nr()) });
+      default:
+        return (
+          Lt.error(
+            `OTEL_TRACES_SAMPLER value "${t}" invalid, defaulting to "parentbased_always_on".`
+          ),
+          new wr({ root: new Tr() })
+        );
+    }
+  }
+  function Nr() {
+    return (
+      Lt.error(`OTEL_TRACES_SAMPLER_ARG is blank, defaulting to ${Ar}.`), Ar
+    );
+  }
+  const xr = 1 / 0;
+  class Pr {
+    _exporter;
+    _maxExportBatchSize;
+    _maxQueueSize;
+    _scheduledDelayMillis;
+    _exportTimeoutMillis;
+    _isExporting = !1;
+    _finishedSpans = [];
+    _timer;
+    _shutdownOnce;
+    _droppedSpansCount = 0;
+    constructor(t, e) {
+      (this._exporter = t),
+        (this._maxExportBatchSize =
+          "number" == typeof e?.maxExportBatchSize
+            ? e.maxExportBatchSize
+            : 512),
+        (this._maxQueueSize =
+          "number" == typeof e?.maxQueueSize ? e.maxQueueSize : 2048),
+        (this._scheduledDelayMillis =
+          "number" == typeof e?.scheduledDelayMillis
+            ? e.scheduledDelayMillis
+            : 5e3),
+        (this._exportTimeoutMillis =
+          "number" == typeof e?.exportTimeoutMillis
+            ? e.exportTimeoutMillis
+            : 3e4),
+        (this._shutdownOnce = new Rn(this._shutdown, this)),
+        this._maxExportBatchSize > this._maxQueueSize &&
+          (Lt.warn(
+            "BatchSpanProcessor: maxExportBatchSize must be smaller or equal to maxQueueSize, setting maxExportBatchSize to match maxQueueSize"
+          ),
+          (this._maxExportBatchSize = this._maxQueueSize));
+    }
+    forceFlush() {
+      return this._shutdownOnce.isCalled
+        ? this._shutdownOnce.promise
+        : this._flushAll();
+    }
+    onStart(t, e) {}
+    onEnd(t) {
+      this._shutdownOnce.isCalled ||
+        (t.spanContext().traceFlags & R.SAMPLED && this._addToBuffer(t));
+    }
+    shutdown() {
+      return this._shutdownOnce.call();
+    }
+    _shutdown() {
+      return Promise.resolve()
+        .then(() => this.onShutdown())
+        .then(() => this._flushAll())
+        .then(() => this._exporter.shutdown());
+    }
+    _addToBuffer(t) {
+      if (this._finishedSpans.length >= this._maxQueueSize)
+        return (
+          0 === this._droppedSpansCount &&
+            Lt.debug("maxQueueSize reached, dropping spans"),
+          void this._droppedSpansCount++
+        );
+      this._droppedSpansCount > 0 &&
+        (Lt.warn(
+          `Dropped ${this._droppedSpansCount} spans because maxQueueSize reached`
+        ),
+        (this._droppedSpansCount = 0)),
+        this._finishedSpans.push(t),
+        this._maybeStartTimer();
+    }
+    _flushAll() {
+      return new Promise((t, e) => {
+        const n = [];
+        for (
+          let t = 0,
+            e = Math.ceil(
+              this._finishedSpans.length / this._maxExportBatchSize
+            );
+          t < e;
+          t++
+        )
+          n.push(this._flushOneBatch());
+        Promise.all(n)
+          .then(() => {
+            t();
+          })
+          .catch(e);
+      });
+    }
+    _flushOneBatch() {
+      return (
+        this._clearTimer(),
+        0 === this._finishedSpans.length
+          ? Promise.resolve()
+          : new Promise((t, e) => {
+              const n = setTimeout(() => {
+                e(new Error("Timeout"));
+              }, this._exportTimeoutMillis);
+              Pt.with(Xt(Pt.active()), () => {
+                let r;
+                this._finishedSpans.length <= this._maxExportBatchSize
+                  ? ((r = this._finishedSpans), (this._finishedSpans = []))
+                  : (r = this._finishedSpans.splice(
+                      0,
+                      this._maxExportBatchSize
+                    ));
+                const o = () =>
+                  this._exporter.export(r, (r) => {
+                    clearTimeout(n),
+                      r.code === $e.SUCCESS
+                        ? t()
+                        : e(
+                            r.error ??
+                              new Error(
+                                "BatchSpanProcessor: span export failed"
+                              )
+                          );
+                  });
+                let i = null;
+                for (let t = 0, e = r.length; t < e; t++) {
+                  const e = r[t];
+                  e.resource.asyncAttributesPending &&
+                    e.resource.waitForAsyncAttributes &&
+                    ((i ??= []), i.push(e.resource.waitForAsyncAttributes()));
+                }
+                null === i
+                  ? o()
+                  : Promise.all(i).then(o, (t) => {
+                      ce(t), e(t);
+                    });
+              });
+            })
+      );
+    }
+    _maybeStartTimer() {
+      if (this._isExporting) return;
+      const t = () => {
+        (this._isExporting = !0),
+          this._flushOneBatch()
+            .finally(() => {
+              (this._isExporting = !1),
+                this._finishedSpans.length > 0 &&
+                  (this._clearTimer(), this._maybeStartTimer());
+            })
+            .catch((t) => {
+              (this._isExporting = !1), ce(t);
+            });
+      };
+      if (this._finishedSpans.length >= this._maxExportBatchSize) return t();
+      void 0 === this._timer &&
+        ((this._timer = setTimeout(() => t(), this._scheduledDelayMillis)),
+        this._timer);
+    }
+    _clearTimer() {
+      void 0 !== this._timer &&
+        (clearTimeout(this._timer), (this._timer = void 0));
+    }
+  }
+  class Lr extends Pr {
+    _visibilityChangeListener;
+    _pageHideListener;
+    constructor(t, e) {
+      super(t, e), this.onInit(e);
+    }
+    onInit(t) {
+      !0 !== t?.disableAutoFlushOnDocumentHide &&
+        "undefined" != typeof document &&
+        ((this._visibilityChangeListener = () => {
+          "hidden" === document.visibilityState &&
+            this.forceFlush().catch((t) => {
+              ce(t);
+            });
+        }),
+        (this._pageHideListener = () => {
+          this.forceFlush().catch((t) => {
+            ce(t);
+          });
+        }),
+        document.addEventListener(
+          "visibilitychange",
+          this._visibilityChangeListener
+        ),
+        document.addEventListener("pagehide", this._pageHideListener));
+    }
+    onShutdown() {
+      "undefined" != typeof document &&
+        (this._visibilityChangeListener &&
+          document.removeEventListener(
+            "visibilitychange",
+            this._visibilityChangeListener
+          ),
+        this._pageHideListener &&
+          document.removeEventListener("pagehide", this._pageHideListener));
+    }
+  }
+  class Dr {
+    generateTraceId = Mr(16);
+    generateSpanId = Mr(8);
+  }
+  const Ir = Array(32);
+  function Mr(t) {
+    return function () {
+      for (let e = 0; e < 2 * t; e++)
+        (Ir[e] = Math.floor(16 * Math.random()) + 48),
+          Ir[e] >= 58 && (Ir[e] += 39);
+      return String.fromCharCode.apply(null, Ir.slice(0, 2 * t));
+    };
+  }
+  class kr {
+    _sampler;
+    _generalLimits;
+    _spanLimits;
+    _idGenerator;
+    instrumentationScope;
+    _resource;
+    _spanProcessor;
+    constructor(t, e, n, r) {
+      const o = (function (t) {
+        const e = { sampler: Rr() },
+          n = Or(),
+          r = Object.assign({}, n, e, t);
+        return (
+          (r.generalLimits = Object.assign(
+            {},
+            n.generalLimits,
+            t.generalLimits || {}
+          )),
+          (r.spanLimits = Object.assign({}, n.spanLimits, t.spanLimits || {})),
+          r
+        );
+      })(e);
+      (this._sampler = o.sampler),
+        (this._generalLimits = o.generalLimits),
+        (this._spanLimits = o.spanLimits),
+        (this._idGenerator = e.idGenerator || new Dr()),
+        (this._resource = n),
+        (this._spanProcessor = r),
+        (this.instrumentationScope = t);
+    }
+    startSpan(t, e = {}, n = Pt.active()) {
+      e.root && (n = Kt.deleteSpan(n));
+      const r = Kt.getSpan(n);
+      if (Qt(n)) {
+        Lt.debug("Instrumentation suppressed, returning Noop Span");
+        return Kt.wrapSpanContext(ut);
+      }
+      const o = r?.spanContext(),
+        i = this._idGenerator.generateSpanId();
+      let s, a, u;
+      o && Kt.isSpanContextValid(o)
+        ? ((a = o.traceId), (u = o.traceState), (s = o))
+        : (a = this._idGenerator.generateTraceId());
+      const c = e.kind ?? Ct.INTERNAL,
+        l = (e.links ?? []).map((t) => ({
+          context: t.context,
+          attributes: re(t.attributes),
+        })),
+        p = re(e.attributes),
+        d = this._sampler.shouldSample(n, a, t, c, p, l);
+      u = d.traceState ?? u;
+      const h = {
+        traceId: a,
+        spanId: i,
+        traceFlags: d.decision === wt.RECORD_AND_SAMPLED ? R.SAMPLED : R.NONE,
+        traceState: u,
+      };
+      if (d.decision === wt.NOT_RECORD) {
+        Lt.debug(
+          "Recording is off, propagating context in a non-recording span"
+        );
+        return Kt.wrapSpanContext(h);
+      }
+      const f = re(Object.assign(p, d.attributes));
+      return new Sr({
+        resource: this._resource,
+        scope: this.instrumentationScope,
+        context: n,
+        spanContext: h,
+        name: t,
+        kind: c,
+        links: l,
+        parentSpanContext: s,
+        attributes: f,
+        startTime: e.startTime,
+        spanProcessor: this._spanProcessor,
+        spanLimits: this._spanLimits,
+      });
+    }
+    startActiveSpan(t, e, n, r) {
+      let o, i, s;
+      if (arguments.length < 2) return;
+      2 === arguments.length
+        ? (s = e)
+        : 3 === arguments.length
+        ? ((o = e), (s = n))
+        : ((o = e), (i = n), (s = r));
+      const a = i ?? Pt.active(),
+        u = this.startSpan(t, o, a),
+        c = Kt.setSpan(a, u);
+      return Pt.with(c, s, void 0, u);
+    }
+    getGeneralLimits() {
+      return this._generalLimits;
+    }
+    getSpanLimits() {
+      return this._spanLimits;
+    }
+  }
+  class jr {
+    _spanProcessors;
+    constructor(t) {
+      this._spanProcessors = t;
+    }
+    forceFlush() {
+      const t = [];
+      for (const e of this._spanProcessors) t.push(e.forceFlush());
+      return new Promise((e) => {
+        Promise.all(t)
+          .then(() => {
+            e();
+          })
+          .catch((t) => {
+            ce(t || new Error("MultiSpanProcessor: forceFlush failed")), e();
+          });
+      });
+    }
+    onStart(t, e) {
+      for (const n of this._spanProcessors) n.onStart(t, e);
+    }
+    onEnd(t) {
+      for (const e of this._spanProcessors) e.onEnd(t);
+    }
+    shutdown() {
+      const t = [];
+      for (const e of this._spanProcessors) t.push(e.shutdown());
+      return new Promise((e, n) => {
+        Promise.all(t).then(() => {
+          e();
+        }, n);
+      });
+    }
+  }
+  var Ur, Br;
+  !(function (t) {
+    (t[(t.resolved = 0)] = "resolved"),
+      (t[(t.timeout = 1)] = "timeout"),
+      (t[(t.error = 2)] = "error"),
+      (t[(t.unresolved = 3)] = "unresolved");
+  })(Ur || (Ur = {}));
+  class Fr {
+    _config;
+    _tracers = new Map();
+    _resource;
+    _activeSpanProcessor;
+    constructor(t = {}) {
+      const e = mn(
+        {},
+        Or(),
+        (function (t) {
+          const e = Object.assign({}, t.spanLimits);
+          return (
+            (e.attributeCountLimit =
+              t.spanLimits?.attributeCountLimit ??
+              t.generalLimits?.attributeCountLimit ??
+              void 0 ??
+              void 0 ??
+              128),
+            (e.attributeValueLengthLimit =
+              t.spanLimits?.attributeValueLengthLimit ??
+              t.generalLimits?.attributeValueLengthLimit ??
+              void 0 ??
+              void 0 ??
+              xr),
+            Object.assign({}, t, { spanLimits: e })
+          );
+        })(t)
+      );
+      (this._resource = e.resource ?? yr()),
+        (this._config = Object.assign({}, e, { resource: this._resource }));
+      const n = [];
+      t.spanProcessors?.length && n.push(...t.spanProcessors),
+        (this._activeSpanProcessor = new jr(n));
+    }
+    getTracer(t, e, n) {
+      const r = `${t}@${e || ""}:${n?.schemaUrl || ""}`;
+      return (
+        this._tracers.has(r) ||
+          this._tracers.set(
+            r,
+            new kr(
+              { name: t, version: e, schemaUrl: n?.schemaUrl },
+              this._config,
+              this._resource,
+              this._activeSpanProcessor
+            )
+          ),
+        this._tracers.get(r)
+      );
+    }
+    forceFlush() {
+      const t = this._config.forceFlushTimeoutMillis,
+        e = this._activeSpanProcessor._spanProcessors.map(
+          (e) =>
+            new Promise((n) => {
+              let r;
+              const o = setTimeout(() => {
+                n(
+                  new Error(
+                    `Span processor did not completed within timeout period of ${t} ms`
+                  )
+                ),
+                  (r = Ur.timeout);
+              }, t);
+              e.forceFlush()
+                .then(() => {
+                  clearTimeout(o),
+                    r !== Ur.timeout && ((r = Ur.resolved), n(r));
+                })
+                .catch((t) => {
+                  clearTimeout(o), (r = Ur.error), n(t);
+                });
+            })
+        );
+      return new Promise((t, n) => {
+        Promise.all(e)
+          .then((e) => {
+            const r = e.filter((t) => t !== Ur.resolved);
+            r.length > 0 ? n(r) : t();
+          })
+          .catch((t) => n([t]));
+      });
+    }
+    shutdown() {
+      return this._activeSpanProcessor.shutdown();
+    }
+  }
+  class Hr {
+    _enabled = !1;
+    _currentContext = x;
+    _bindFunction(t = x, e) {
+      const n = this,
+        r = function (...r) {
+          return n.with(t, () => e.apply(this, r));
+        };
+      return (
+        Object.defineProperty(r, "length", {
+          enumerable: !1,
+          configurable: !0,
+          writable: !1,
+          value: e.length,
+        }),
+        r
+      );
+    }
+    active() {
+      return this._currentContext;
+    }
+    bind(t, e) {
+      return (
+        void 0 === t && (t = this.active()),
+        "function" == typeof e ? this._bindFunction(t, e) : e
+      );
+    }
+    disable() {
+      return (this._currentContext = x), (this._enabled = !1), this;
+    }
+    enable() {
+      return (
+        this._enabled || ((this._enabled = !0), (this._currentContext = x)),
+        this
+      );
+    }
+    with(t, e, n, ...r) {
+      const o = this._currentContext;
+      this._currentContext = t || x;
+      try {
+        return e.call(n, ...r);
+      } finally {
+        this._currentContext = o;
+      }
+    }
+  }
+  class Vr extends Fr {
+    constructor(t = {}) {
+      super(t);
+    }
+    register(t = {}) {
+      var e;
+      Kt.setGlobalTracerProvider(this),
+        null !== (e = t.propagator) &&
+          (void 0 !== e
+            ? qt.setGlobalPropagator(e)
+            : qt.setGlobalPropagator(
+                new ze({ propagators: [new tn(), new ne()] })
+              )),
+        (function (t) {
+          if (null !== t) {
+            if (void 0 === t) {
+              const t = new Hr();
+              return t.enable(), void Pt.setGlobalContextManager(t);
+            }
+            t.enable(), Pt.setGlobalContextManager(t);
+          }
+        })(t.contextManager);
+    }
+  }
+  let $r;
+  function zr(t, e, n, r = !0) {
+    if (
+      !((o = n),
+      (i = e),
+      !(i in o) || "number" != typeof n[e] || (r && 0 === n[e]))
+    )
+      return t.addEvent(e, n[e]);
+    var o, i;
+  }
+  function qr(t, e, n = !1, r) {
+    void 0 === r && (r = 0 !== e[Br.START_TIME]),
+      n ||
+        (zr(t, Br.FETCH_START, e, r),
+        zr(t, Br.DOMAIN_LOOKUP_START, e, r),
+        zr(t, Br.DOMAIN_LOOKUP_END, e, r),
+        zr(t, Br.CONNECT_START, e, r),
+        zr(t, Br.SECURE_CONNECTION_START, e, r),
+        zr(t, Br.CONNECT_END, e, r),
+        zr(t, Br.REQUEST_START, e, r),
+        zr(t, Br.RESPONSE_START, e, r),
+        zr(t, Br.RESPONSE_END, e, r));
+    const o = e[Br.ENCODED_BODY_SIZE];
+    void 0 !== o && t.setAttribute("http.response_content_length", o);
+    const i = e[Br.DECODED_BODY_SIZE];
+    void 0 !== i &&
+      o !== i &&
+      t.setAttribute("http.response_content_length_uncompressed", i);
+  }
+  function Gr() {
+    return "undefined" != typeof location ? location.origin : void 0;
+  }
+  function Kr(t, e, n, r, o = new WeakSet(), i) {
+    const s = Wr(t),
+      a = (function (t, e, n, r, o, i) {
+        const s = Be(e),
+          a = Be(n);
+        let u = r.filter((e) => {
+          const n = Be(je(e[Br.FETCH_START])),
+            r = Be(je(e[Br.RESPONSE_END]));
+          return (
+            e.initiatorType.toLowerCase() === (i || "xmlhttprequest") &&
+            e.name === t &&
+            n >= s &&
+            r <= a
+          );
+        });
+        u.length > 0 && (u = u.filter((t) => !o.has(t)));
+        return u;
+      })((t = s.toString()), e, n, r, o, i);
+    if (0 === a.length) return { mainRequest: void 0 };
+    if (1 === a.length) return { mainRequest: a[0] };
+    const u = (function (t) {
+      return t.slice().sort((t, e) => {
+        const n = t[Br.FETCH_START],
+          r = e[Br.FETCH_START];
+        return n > r ? 1 : n < r ? -1 : 0;
+      });
+    })(a);
+    if (s.origin !== Gr() && u.length > 1) {
+      let t = u[0],
+        e = (function (t, e, n) {
+          const r = Be(n),
+            o = Be(je(e));
+          let i,
+            s = t[1];
+          const a = t.length;
+          for (let e = 1; e < a; e++) {
+            const n = t[e],
+              a = Be(je(n[Br.FETCH_START])),
+              u = r - Be(je(n[Br.RESPONSE_END]));
+            a >= o && (!i || u < i) && ((i = u), (s = n));
+          }
+          return s;
+        })(u, t[Br.RESPONSE_END], n);
+      const r = t[Br.RESPONSE_END];
+      return (
+        e[Br.FETCH_START] < r && ((e = t), (t = void 0)),
+        { corsPreFlightRequest: t, mainRequest: e }
+      );
+    }
+    return { mainRequest: a[0] };
+  }
+  function Wr(t) {
+    if ("function" == typeof URL)
+      return new URL(
+        t,
+        "undefined" != typeof document
+          ? document.baseURI
+          : "undefined" != typeof location
+          ? location.href
+          : void 0
+      );
+    const e = ($r || ($r = document.createElement("a")), $r);
+    return (e.href = t), e;
+  }
+  function Xr(t, e) {
+    let n = e || [];
+    ("string" == typeof n || n instanceof RegExp) && (n = [n]);
+    return Wr(t).origin === Gr() || n.some((e) => Cn(t, e));
+  }
+  var Qr;
+  !(function (t) {
+    (t.CONNECT_END = "connectEnd"),
+      (t.CONNECT_START = "connectStart"),
+      (t.DECODED_BODY_SIZE = "decodedBodySize"),
+      (t.DOM_COMPLETE = "domComplete"),
+      (t.DOM_CONTENT_LOADED_EVENT_END = "domContentLoadedEventEnd"),
+      (t.DOM_CONTENT_LOADED_EVENT_START = "domContentLoadedEventStart"),
+      (t.DOM_INTERACTIVE = "domInteractive"),
+      (t.DOMAIN_LOOKUP_END = "domainLookupEnd"),
+      (t.DOMAIN_LOOKUP_START = "domainLookupStart"),
+      (t.ENCODED_BODY_SIZE = "encodedBodySize"),
+      (t.FETCH_START = "fetchStart"),
+      (t.LOAD_EVENT_END = "loadEventEnd"),
+      (t.LOAD_EVENT_START = "loadEventStart"),
+      (t.NAVIGATION_START = "navigationStart"),
+      (t.REDIRECT_END = "redirectEnd"),
+      (t.REDIRECT_START = "redirectStart"),
+      (t.REQUEST_START = "requestStart"),
+      (t.RESPONSE_END = "responseEnd"),
+      (t.RESPONSE_START = "responseStart"),
+      (t.SECURE_CONNECTION_START = "secureConnectionStart"),
+      (t.START_TIME = "startTime"),
+      (t.UNLOAD_EVENT_END = "unloadEventEnd"),
+      (t.UNLOAD_EVENT_START = "unloadEventStart");
+  })(Br || (Br = {})),
+    (function (t) {
+      (t.COMPONENT = "component"),
+        (t.HTTP_ERROR_NAME = "http.error_name"),
+        (t.HTTP_STATUS_TEXT = "http.status_text");
+    })(Qr || (Qr = {}));
+  const Yr = Lt.createComponentLogger({
+    namespace: "@opentelemetry/opentelemetry-instrumentation-fetch/utils",
+  });
+  function Zr(...t) {
+    if (t[0] instanceof URL || "string" == typeof t[0]) {
+      const e = t[1];
+      if (!e?.body) return Promise.resolve();
+      if (e.body instanceof ReadableStream) {
+        const { body: t, length: n } = (function (t) {
+          if (!t.pipeThrough)
+            return (
+              Yr.warn("Platform has ReadableStream but not pipeThrough!"),
+              { body: t, length: Promise.resolve(void 0) }
+            );
+          let e,
+            n = 0;
+          const r = new Promise((t) => {
+              e = t;
+            }),
+            o = new TransformStream({
+              start() {},
+              async transform(t, e) {
+                const r = await t;
+                (n += r.byteLength), e.enqueue(t);
+              },
+              flush() {
+                e(n);
+              },
+            });
+          return { body: t.pipeThrough(o), length: r };
+        })(e.body);
+        return (e.body = t), n;
+      }
+      return Promise.resolve(
+        (function (t) {
+          if (
+            ((e = t), "undefined" != typeof Document && e instanceof Document)
+          )
+            return new XMLSerializer().serializeToString(document).length;
+          var e;
+          if ("string" == typeof t) return to(t);
+          if (t instanceof Blob) return t.size;
+          if (t instanceof FormData)
+            return (function (t) {
+              let e = 0;
+              for (const [n, r] of t.entries())
+                (e += n.length),
+                  r instanceof Blob ? (e += r.size) : (e += r.length);
+              return e;
+            })(t);
+          if (t instanceof URLSearchParams) return to(t.toString());
+          if (void 0 !== t.byteLength) return t.byteLength;
+          return void Yr.warn("unknown body type");
+        })(e.body)
+      );
+    }
+    {
+      const e = t[0];
+      return e?.body
+        ? e
+            .clone()
+            .text()
+            .then((t) => to(t))
+        : Promise.resolve();
+    }
+  }
+  const Jr = new TextEncoder();
+  function to(t) {
+    return Jr.encode(t).byteLength;
+  }
+  const eo = "0.200.0",
+    no = "object" == typeof process && "node" === process.release?.name;
+  class ro extends hr {
+    component = "fetch";
+    version = eo;
+    moduleName = this.component;
+    _usedResources = new WeakSet();
+    _tasksCount = 0;
+    constructor(t = {}) {
+      super("@opentelemetry/instrumentation-fetch", eo, t);
+    }
+    init() {}
+    _addChildSpan(t, e) {
+      const n = this.tracer.startSpan(
+        "CORS Preflight",
+        { startTime: e[Br.FETCH_START] },
+        Kt.setSpan(Pt.active(), t)
+      );
+      qr(n, e, this.getConfig().ignoreNetworkEvents), n.end(e[Br.RESPONSE_END]);
+    }
+    _addFinalSpanAttributes(t, e) {
+      const n = Wr(e.url);
+      t.setAttribute(ye, e.status),
+        null != e.statusText &&
+          t.setAttribute(Qr.HTTP_STATUS_TEXT, e.statusText),
+        t.setAttribute(_e, n.host),
+        t.setAttribute(ve, n.protocol.replace(":", "")),
+        "undefined" != typeof navigator &&
+          t.setAttribute(Se, navigator.userAgent);
+    }
+    _addHeaders(t, e) {
+      if (!Xr(e, this.getConfig().propagateTraceHeaderCorsUrls)) {
+        const t = {};
+        return (
+          qt.inject(Pt.active(), t),
+          void (
+            Object.keys(t).length > 0 &&
+            this._diag.debug("headers inject skipped due to CORS policy")
+          )
+        );
+      }
+      if (t instanceof Request)
+        qt.inject(Pt.active(), t.headers, {
+          set: (t, e, n) => t.set(e, "string" == typeof n ? n : String(n)),
+        });
+      else if (t.headers instanceof Headers)
+        qt.inject(Pt.active(), t.headers, {
+          set: (t, e, n) => t.set(e, "string" == typeof n ? n : String(n)),
+        });
+      else if (t.headers instanceof Map)
+        qt.inject(Pt.active(), t.headers, {
+          set: (t, e, n) => t.set(e, "string" == typeof n ? n : String(n)),
+        });
+      else {
+        const e = {};
+        qt.inject(Pt.active(), e),
+          (t.headers = Object.assign({}, e, t.headers || {}));
+      }
+    }
+    _clearResources() {
+      0 === this._tasksCount &&
+        this.getConfig().clearTimingResources &&
+        (performance.clearResourceTimings(),
+        (this._usedResources = new WeakSet()));
+    }
+    _createSpan(t, e = {}) {
+      if (An(t, this.getConfig().ignoreUrls))
+        return void this._diag.debug(
+          "ignoring span as url matches ignored url"
+        );
+      const n = (e.method || "GET").toUpperCase(),
+        r = `HTTP ${n}`;
+      return this.tracer.startSpan(r, {
+        kind: Ct.CLIENT,
+        attributes: { [Qr.COMPONENT]: this.moduleName, [ge]: n, [me]: t },
+      });
+    }
+    _findResourceAndAddNetworkEvents(t, e, n) {
+      let r = e.entries;
+      if (!r.length) {
+        if (!performance.getEntriesByType) return;
+        r = performance.getEntriesByType("resource");
+      }
+      const o = Kr(e.spanUrl, e.startTime, n, r, this._usedResources, "fetch");
+      if (o.mainRequest) {
+        const e = o.mainRequest;
+        this._markResourceAsUsed(e);
+        const n = o.corsPreFlightRequest;
+        n && (this._addChildSpan(t, n), this._markResourceAsUsed(n)),
+          qr(t, e, this.getConfig().ignoreNetworkEvents);
+      }
+    }
+    _markResourceAsUsed(t) {
+      this._usedResources.add(t);
+    }
+    _endSpan(t, e, n) {
+      const r = Ie(Date.now()),
+        o = ke();
+      this._addFinalSpanAttributes(t, n),
+        setTimeout(() => {
+          e.observer?.disconnect(),
+            this._findResourceAndAddNetworkEvents(t, e, o),
+            this._tasksCount--,
+            this._clearResources(),
+            t.end(r);
+        }, 300);
+    }
+    _patchConstructor() {
+      return (t) => {
+        const e = this;
+        return function (...n) {
+          const r = this,
+            o = Wr(n[0] instanceof Request ? n[0].url : String(n[0])).href,
+            i = n[0] instanceof Request ? n[0] : n[1] || {},
+            s = e._createSpan(o, i);
+          if (!s) return t.apply(this, n);
+          const a = e._prepareSpanData(o);
+          function u(t, n) {
+            e._applyAttributesAfterFetch(t, i, n),
+              e._endSpan(t, a, {
+                status: n.status || 0,
+                statusText: n.message,
+                url: o,
+              });
+          }
+          function c(t, n) {
+            e._applyAttributesAfterFetch(t, i, n),
+              n.status >= 200 && n.status < 400
+                ? e._endSpan(t, a, n)
+                : e._endSpan(t, a, {
+                    status: n.status,
+                    statusText: n.statusText,
+                    url: o,
+                  });
+          }
+          function l(t, e, n) {
+            try {
+              const e = n.clone().body;
+              if (e) {
+                const r = e.getReader(),
+                  o = () => {
+                    r.read().then(
+                      ({ done: e }) => {
+                        e ? c(t, n) : o();
+                      },
+                      (e) => {
+                        u(t, e);
+                      }
+                    );
+                  };
+                o();
+              } else c(t, n);
+            } finally {
+              e(n);
+            }
+          }
+          function p(t, e, n) {
+            try {
+              u(t, n);
+            } finally {
+              e(n);
+            }
+          }
+          return (
+            e.getConfig().measureRequestSize &&
+              Zr(...n)
+                .then((t) => {
+                  t && s.setAttribute(be, t);
+                })
+                .catch((t) => {
+                  e._diag.warn("getFetchBodyLength", t);
+                }),
+            new Promise((n, a) =>
+              Pt.with(
+                Kt.setSpan(Pt.active(), s),
+                () => (
+                  e._addHeaders(i, o),
+                  e._callRequestHook(s, i),
+                  e._tasksCount++,
+                  t
+                    .apply(r, i instanceof Request ? [i] : [o, i])
+                    .then(l.bind(r, s, n), p.bind(r, s, a))
+                )
+              )
+            )
+          );
+        };
+      };
+    }
+    _applyAttributesAfterFetch(t, e, n) {
+      const r = this.getConfig().applyCustomAttributesOnSpan;
+      r &&
+        fr(
+          () => r(t, e, n),
+          (t) => {
+            t && this._diag.error("applyCustomAttributesOnSpan", t);
+          }
+        );
+    }
+    _callRequestHook(t, e) {
+      const n = this.getConfig().requestHook;
+      n &&
+        fr(
+          () => n(t, e),
+          (t) => {
+            t && this._diag.error("requestHook", t);
+          }
+        );
+    }
+    _prepareSpanData(t) {
+      const e = ke(),
+        n = [];
+      if ("function" != typeof PerformanceObserver)
+        return { entries: n, startTime: e, spanUrl: t };
+      const r = new PerformanceObserver((e) => {
+        e.getEntries().forEach((e) => {
+          "fetch" === e.initiatorType && e.name === t && n.push(e);
+        });
+      });
+      return (
+        r.observe({ entryTypes: ["resource"] }),
+        { entries: n, observer: r, startTime: e, spanUrl: t }
+      );
+    }
+    enable() {
+      no
+        ? this._diag.warn(
+            "this instrumentation is intended for web usage only, it does not instrument Node.js's fetch()"
+          )
+        : (gr(fetch) &&
+            (this._unwrap(pe, "fetch"),
+            this._diag.debug("removing previous patch for constructor")),
+          this._wrap(pe, "fetch", this._patchConstructor()));
+    }
+    disable() {
+      no || (this._unwrap(pe, "fetch"), (this._usedResources = new WeakSet()));
+    }
+  }
+  var oo;
+  !(function (t) {
+    (t.METHOD_OPEN = "open"),
+      (t.METHOD_SEND = "send"),
+      (t.EVENT_ABORT = "abort"),
+      (t.EVENT_ERROR = "error"),
+      (t.EVENT_LOAD = "loaded"),
+      (t.EVENT_TIMEOUT = "timeout");
+  })(oo || (oo = {}));
+  const io = Lt.createComponentLogger({
+    namespace:
+      "@opentelemetry/opentelemetry-instrumentation-xml-http-request/utils",
+  });
+  function so(t) {
+    return (
+      (e = t),
+      "undefined" != typeof Document && e instanceof Document
+        ? new XMLSerializer().serializeToString(document).length
+        : "string" == typeof t
+        ? uo(t)
+        : t instanceof Blob
+        ? t.size
+        : t instanceof FormData
+        ? (function (t) {
+            let e = 0;
+            for (const [n, r] of t.entries())
+              (e += n.length),
+                r instanceof Blob ? (e += r.size) : (e += r.length);
+            return e;
+          })(t)
+        : t instanceof URLSearchParams
+        ? uo(t.toString())
+        : void 0 !== t.byteLength
+        ? t.byteLength
+        : void io.warn("unknown body type")
+    );
+    var e;
+  }
+  const ao = new TextEncoder();
+  function uo(t) {
+    return ao.encode(t).byteLength;
+  }
+  const co = "0.200.0";
+  var lo;
+  !(function (t) {
+    t.HTTP_STATUS_TEXT = "http.status_text";
+  })(lo || (lo = {}));
+  class po extends hr {
+    component = "xml-http-request";
+    version = co;
+    moduleName = this.component;
+    _tasksCount = 0;
+    _xhrMem = new WeakMap();
+    _usedResources = new WeakSet();
+    constructor(t = {}) {
+      super("@opentelemetry/instrumentation-xml-http-request", co, t);
+    }
+    init() {}
+    _addHeaders(t, e) {
+      if (!Xr(Wr(e).href, this.getConfig().propagateTraceHeaderCorsUrls)) {
+        const t = {};
+        return (
+          qt.inject(Pt.active(), t),
+          void (
+            Object.keys(t).length > 0 &&
+            this._diag.debug("headers inject skipped due to CORS policy")
+          )
+        );
+      }
+      const n = {};
+      qt.inject(Pt.active(), n),
+        Object.keys(n).forEach((e) => {
+          t.setRequestHeader(e, String(n[e]));
+        });
+    }
+    _addChildSpan(t, e) {
+      Pt.with(Kt.setSpan(Pt.active(), t), () => {
+        const t = this.tracer.startSpan("CORS Preflight", {
+          startTime: e[Br.FETCH_START],
+        });
+        qr(t, e, this.getConfig().ignoreNetworkEvents),
+          t.end(e[Br.RESPONSE_END]);
+      });
+    }
+    _addFinalSpanAttributes(t, e, n) {
+      if ("string" == typeof n) {
+        const r = Wr(n);
+        void 0 !== e.status && t.setAttribute(ye, e.status),
+          void 0 !== e.statusText &&
+            t.setAttribute(lo.HTTP_STATUS_TEXT, e.statusText),
+          t.setAttribute(_e, r.host),
+          t.setAttribute(ve, r.protocol.replace(":", "")),
+          t.setAttribute(Se, navigator.userAgent);
+      }
+    }
+    _applyAttributesAfterXHR(t, e) {
+      const n = this.getConfig().applyCustomAttributesOnSpan;
+      "function" == typeof n &&
+        fr(
+          () => n(t, e),
+          (t) => {
+            t && this._diag.error("applyCustomAttributesOnSpan", t);
+          }
+        );
+    }
+    _addResourceObserver(t, e) {
+      const n = this._xhrMem.get(t);
+      n &&
+        "function" == typeof PerformanceObserver &&
+        "function" == typeof PerformanceResourceTiming &&
+        ((n.createdResources = {
+          observer: new PerformanceObserver((t) => {
+            const r = t.getEntries(),
+              o = Wr(e);
+            r.forEach((t) => {
+              "xmlhttprequest" === t.initiatorType &&
+                t.name === o.href &&
+                n.createdResources &&
+                n.createdResources.entries.push(t);
+            });
+          }),
+          entries: [],
+        }),
+        n.createdResources.observer.observe({ entryTypes: ["resource"] }));
+    }
+    _clearResources() {
+      0 === this._tasksCount &&
+        this.getConfig().clearTimingResources &&
+        (de.clearResourceTimings(),
+        (this._xhrMem = new WeakMap()),
+        (this._usedResources = new WeakSet()));
+    }
+    _findResourceAndAddNetworkEvents(t, e, n, r, o) {
+      if (!(n && r && o && t.createdResources)) return;
+      let i = t.createdResources.entries;
+      (i && i.length) || (i = de.getEntriesByType("resource"));
+      const s = Kr(Wr(n).href, r, o, i, this._usedResources);
+      if (s.mainRequest) {
+        const t = s.mainRequest;
+        this._markResourceAsUsed(t);
+        const n = s.corsPreFlightRequest;
+        n && (this._addChildSpan(e, n), this._markResourceAsUsed(n)),
+          qr(e, t, this.getConfig().ignoreNetworkEvents);
+      }
+    }
+    _cleanPreviousSpanInformation(t) {
+      const e = this._xhrMem.get(t);
+      if (e) {
+        const n = e.callbackToRemoveEvents;
+        n && n(), this._xhrMem.delete(t);
+      }
+    }
+    _createSpan(t, e, n) {
+      if (An(e, this.getConfig().ignoreUrls))
+        return void this._diag.debug(
+          "ignoring span as url matches ignored url"
+        );
+      const r = n.toUpperCase(),
+        o = this.tracer.startSpan(r, {
+          kind: Ct.CLIENT,
+          attributes: { [ge]: n, [me]: Wr(e).toString() },
+        });
+      return (
+        o.addEvent(oo.METHOD_OPEN),
+        this._cleanPreviousSpanInformation(t),
+        this._xhrMem.set(t, { span: o, spanUrl: e }),
+        o
+      );
+    }
+    _markResourceAsUsed(t) {
+      this._usedResources.add(t);
+    }
+    _patchOpen() {
+      return (t) => {
+        const e = this;
+        return function (...n) {
+          const r = n[0],
+            o = n[1];
+          return e._createSpan(this, o, r), t.apply(this, n);
+        };
+      };
+    }
+    _patchSend() {
+      const t = this;
+      function e(e, n) {
+        const r = t._xhrMem.get(n);
+        if (!r) return;
+        (r.status = n.status),
+          (r.statusText = n.statusText),
+          t._xhrMem.delete(n),
+          r.span && t._applyAttributesAfterXHR(r.span, n);
+        const o = ke(),
+          i = Date.now();
+        setTimeout(() => {
+          !(function (e, n, r, o) {
+            const i = n.callbackToRemoveEvents;
+            "function" == typeof i && i();
+            const { span: s, spanUrl: a, sendStartTime: u } = n;
+            s &&
+              (t._findResourceAndAddNetworkEvents(n, s, a, u, r),
+              s.addEvent(e, o),
+              t._addFinalSpanAttributes(s, n, a),
+              s.end(o),
+              t._tasksCount--),
+              t._clearResources();
+          })(e, r, o, i);
+        }, 300);
+      }
+      function n() {
+        e(oo.EVENT_ERROR, this);
+      }
+      function r() {
+        e(oo.EVENT_ABORT, this);
+      }
+      function o() {
+        e(oo.EVENT_TIMEOUT, this);
+      }
+      function i() {
+        this.status < 299 ? e(oo.EVENT_LOAD, this) : e(oo.EVENT_ERROR, this);
+      }
+      return (e) =>
+        function (...s) {
+          const a = t._xhrMem.get(this);
+          if (!a) return e.apply(this, s);
+          const u = a.span,
+            c = a.spanUrl;
+          if (u && c) {
+            if (t.getConfig().measureRequestSize && s?.[0]) {
+              const t = so(s[0]);
+              void 0 !== t && u.setAttribute(be, t);
+            }
+            Pt.with(Kt.setSpan(Pt.active(), u), () => {
+              t._tasksCount++,
+                (a.sendStartTime = ke()),
+                u.addEvent(oo.METHOD_SEND),
+                this.addEventListener("abort", r),
+                this.addEventListener("error", n),
+                this.addEventListener("load", i),
+                this.addEventListener("timeout", o),
+                (a.callbackToRemoveEvents = () => {
+                  !(function (e) {
+                    e.removeEventListener("abort", r),
+                      e.removeEventListener("error", n),
+                      e.removeEventListener("load", i),
+                      e.removeEventListener("timeout", o);
+                    const s = t._xhrMem.get(e);
+                    s && (s.callbackToRemoveEvents = void 0);
+                  })(this),
+                    a.createdResources &&
+                      a.createdResources.observer.disconnect();
+                }),
+                t._addHeaders(this, c),
+                t._addResourceObserver(this, c);
+            });
+          }
+          return e.apply(this, s);
+        };
+    }
+    enable() {
+      this._diag.debug("applying patch to", this.moduleName, this.version),
+        gr(XMLHttpRequest.prototype.open) &&
+          (this._unwrap(XMLHttpRequest.prototype, "open"),
+          this._diag.debug("removing previous patch from method open")),
+        gr(XMLHttpRequest.prototype.send) &&
+          (this._unwrap(XMLHttpRequest.prototype, "send"),
+          this._diag.debug("removing previous patch from method send")),
+        this._wrap(XMLHttpRequest.prototype, "open", this._patchOpen()),
+        this._wrap(XMLHttpRequest.prototype, "send", this._patchSend());
+    }
+    disable() {
+      this._diag.debug("removing patch from", this.moduleName, this.version),
+        this._unwrap(XMLHttpRequest.prototype, "open"),
+        this._unwrap(XMLHttpRequest.prototype, "send"),
+        (this._tasksCount = 0),
+        (this._xhrMem = new WeakMap()),
+        (this._usedResources = new WeakSet());
+    }
+  }
+  class ho extends po {
+    constructor(t = {}) {
+      super(t);
+      this.parentCreateSpan = this._createSpan.bind(this);
+    }
+    _patchOpen() {
+      return (t) => {
+        const n = this;
+        return function (...r) {
+          try {
+            const t = r[0];
+            let o = e.getUrlFromResource(r[1]);
+            n.parentCreateSpan(this, o, t);
+          } catch (t) {
+            e.faro.internalLogger.error(t);
+          }
+          return t.apply(this, r);
+        };
+      };
+    }
+  }
+  function fo(t, e, n) {
+    go(t, n instanceof Error ? 0 : n.status);
+  }
+  function go(t, e) {
+    if (null == e) return;
+    (0 === e || (e >= 400 && e < 600)) && t.setStatus({ code: At.ERROR });
+  }
+  function mo(t) {
+    return (e, n, r) => {
+      fo(e, 0, r), null == t || t(e, n, r);
+    };
+  }
+  function _o(t) {
+    return (e, n) => {
+      !(function (t, e) {
+        go(t, e.status);
+      })(e, n),
+        null == t || t(e, n);
+    };
+  }
+  function vo(t = {}) {
+    const { fetchInstrumentationOptions: e, xhrInstrumentationOptions: n } = t,
+      r = (function (t, e) {
+        var n = {};
+        for (var r in t)
+          Object.prototype.hasOwnProperty.call(t, r) &&
+            e.indexOf(r) < 0 &&
+            (n[r] = t[r]);
+        if (null != t && "function" == typeof Object.getOwnPropertySymbols) {
+          var o = 0;
+          for (r = Object.getOwnPropertySymbols(t); o < r.length; o++)
+            e.indexOf(r[o]) < 0 &&
+              Object.prototype.propertyIsEnumerable.call(t, r[o]) &&
+              (n[r[o]] = t[r[o]]);
+        }
+        return n;
+      })(t, ["fetchInstrumentationOptions", "xhrInstrumentationOptions"]),
+      o = (function (t, e) {
+        return Object.assign(
+          Object.assign(
+            Object.assign(Object.assign({}, e), { ignoreNetworkEvents: !0 }),
+            t
+          ),
+          {
+            applyCustomAttributesOnSpan: mo(
+              null == t ? void 0 : t.applyCustomAttributesOnSpan
+            ),
+          }
+        );
+      })(e, r),
+      i = (function (t, e) {
+        return Object.assign(
+          Object.assign(
+            Object.assign(Object.assign({}, e), { ignoreNetworkEvents: !0 }),
+            t
+          ),
+          {
+            applyCustomAttributesOnSpan: _o(
+              null == t ? void 0 : t.applyCustomAttributesOnSpan
+            ),
+          }
+        );
+      })(n, r);
+    return [new ro(o), new ho(i)];
+  }
+  class yo {
+    constructor(t, e) {
+      (this.processor = t), (this.metas = e);
+    }
+    forceFlush() {
+      return this.processor.forceFlush();
+    }
+    onStart(t, e) {
+      var n;
+      const r = this.metas.value.session;
+      (null == r ? void 0 : r.id) &&
+        ((t.attributes[Zn] = r.id), (t.attributes.session_id = r.id));
+      const o = null !== (n = this.metas.value.user) && void 0 !== n ? n : {};
+      o.email && (t.attributes["user.email"] = o.email),
+        o.id && (t.attributes["user.id"] = o.id),
+        o.username && (t.attributes["user.name"] = o.username),
+        o.fullName && (t.attributes["user.full_name"] = o.fullName),
+        o.roles &&
+          (t.attributes["user.roles"] = o.roles
+            .split(",")
+            .map((t) => t.trim())),
+        o.hash && (t.attributes["user.hash"] = o.hash),
+        this.processor.onStart(t, e);
+    }
+    onEnd(t) {
+      this.processor.onEnd(t);
+    }
+    shutdown() {
+      return this.processor.shutdown();
+    }
+  }
+  class So {
+    constructor(t) {
+      (this.processor = t),
+        e.apiMessageBus.subscribe((t) => {
+          t.type !== e.USER_ACTION_START
+            ? [e.USER_ACTION_END, e.USER_ACTION_CANCEL].includes(t.type) &&
+              (this.message = void 0)
+            : (this.message = t);
+        });
+    }
+    forceFlush() {
+      return this.processor.forceFlush();
+    }
+    onStart(t, e) {
+      var n, r;
+      t.kind === Ct.CLIENT &&
+        this.message &&
+        ((t.attributes["faro.action.user.name"] =
+          null === (n = this.message) || void 0 === n ? void 0 : n.name),
+        (t.attributes["faro.action.user.parentId"] =
+          null === (r = this.message) || void 0 === r ? void 0 : r.parentId)),
+        this.processor.onStart(t, e);
+    }
+    onEnd(t) {
+      this.processor.onEnd(t);
+    }
+    shutdown() {
+      return this.processor.shutdown();
+    }
+  }
+  function bo(t = {}) {
+    var e;
+    return "true" ===
+      (null === (e = t.attributes) || void 0 === e ? void 0 : e.isSampled)
+      ? br.RECORD_AND_SAMPLED
+      : br.NOT_RECORD;
+  }
+  class Eo extends e.BaseInstrumentation {
+    constructor(t = {}) {
+      super(),
+        (this.options = t),
+        (this.name = "@grafana/faro-web-tracing"),
+        (this.version = e.VERSION);
+    }
+    initialize() {
+      var t, e, n, r;
+      const o = this.options,
+        i = {};
+      this.config.app.name && (i[Ae] = this.config.app.name),
+        this.config.app.namespace &&
+          (i["service.namespace"] = this.config.app.namespace),
+        this.config.app.version &&
+          (i["service.version"] = this.config.app.version),
+        this.config.app.environment &&
+          ((i["deployment.environment.name"] = this.config.app.environment),
+          (i["deployment.environment"] = this.config.app.environment)),
+        Object.assign(i, o.resourceAttributes);
+      const s = yr().merge(vr(i));
+      new Vr({
+        resource: s,
+        sampler: {
+          shouldSample: () => ({ decision: bo(this.api.getSession()) }),
+        },
+        spanProcessors: [
+          null !== (t = o.spanProcessor) && void 0 !== t
+            ? t
+            : new So(
+                new yo(
+                  new Lr(new Yn({ api: this.api }), {
+                    scheduledDelayMillis: Eo.SCHEDULED_BATCH_DELAY_MS,
+                    maxExportBatchSize: 30,
+                  }),
+                  this.metas
+                )
+              ),
+        ],
+      }).register({
+        propagator: null !== (e = o.propagator) && void 0 !== e ? e : new tn(),
+        contextManager: o.contextManager,
+      });
+      const {
+        propagateTraceHeaderCorsUrls: a,
+        fetchInstrumentationOptions: u,
+        xhrInstrumentationOptions: c,
+      } = null !== (n = this.options.instrumentationOptions) && void 0 !== n
+        ? n
+        : {};
+      !(function (t) {
+        const e = t.tracerProvider || Kt.getTracerProvider(),
+          n = t.meterProvider || Mt.getMeterProvider(),
+          r = t.loggerProvider || ur.getLoggerProvider(),
+          o = t.instrumentations?.flat() ?? [];
+        (function (t, e, n, r) {
+          for (let o = 0, i = t.length; o < i; o++) {
+            const i = t[o];
+            e && i.setTracerProvider(e),
+              n && i.setMeterProvider(n),
+              r && i.setLoggerProvider && i.setLoggerProvider(r),
+              i.getConfig().enabled || i.enable();
+          }
+        })(o, e, n, r);
+      })({
+        instrumentations:
+          null !== (r = o.instrumentations) && void 0 !== r
+            ? r
+            : vo({
+                ignoreUrls: this.getIgnoreUrls(),
+                propagateTraceHeaderCorsUrls: a,
+                fetchInstrumentationOptions: u,
+                xhrInstrumentationOptions: c,
+              }),
+      }),
+        this.api.initOTEL(Kt, Pt);
+    }
+    getIgnoreUrls() {
+      return this.transports.transports.flatMap((t) => t.getIgnoreUrls());
+    }
+  }
+  return (
+    (Eo.SCHEDULED_BATCH_DELAY_MS = 1e3),
+    (t.FaroSessionSpanProcessor = class {
+      constructor(t, e) {
+        (this.processor = t), (this.metas = e);
+      }
+      forceFlush() {
+        return this.processor.forceFlush();
+      }
+      onStart(t, e) {
+        const n = this.metas.value.session;
+        (null == n ? void 0 : n.id) &&
+          ((t.attributes[Zn] = n.id), (t.attributes.session_id = n.id)),
+          this.processor.onStart(t, e);
+      }
+      onEnd(t) {
+        this.processor.onEnd(t);
+      }
+      shutdown() {
+        return this.processor.shutdown();
+      }
+    }),
+    (t.FaroTraceExporter = Yn),
+    (t.TracingInstrumentation = Eo),
+    (t.fetchCustomAttributeFunctionWithDefaults = mo),
+    (t.getDefaultOTELInstrumentations = vo),
+    (t.getSamplingDecision = bo),
+    (t.setSpanStatusOnFetchError = fo),
+    t
+  );
+};
+
+export default GrafanaFaroWebTracing;

--- a/import/index.template.html
+++ b/import/index.template.html
@@ -28,6 +28,33 @@
         border: none;
       }
     </style>
+    <script type="module">
+      import GrafanaFaroWebSdk from "./grafana-faro-web-sdk.js";
+      import GrafanaFaroWebTracing from "./grafana-faro-web-tracing.js";
+
+      // set environment based on the host
+      let environment = "development";
+      const host = window.location.host;
+      if (host === "import.turnkey.com") {
+        environment = "production";
+      } else if (host === "import.preprod.turnkey.engineering") {
+        environment = "preprod";
+      }
+
+      const faro = GrafanaFaroWebSdk.initializeFaro({
+        url: "https://faro-collector-prod-us-central-0.grafana.net/collect/12e3db23aad500e66e877f9cdeff541c",
+        app: {
+          name: "wallet-import",
+          version: "1.0.0",
+          environment: environment,
+        },
+        trackGeolocation: false,
+      });
+
+      const grafanaTracing = GrafanaFaroWebTracing({}, GrafanaFaroWebSdk);
+
+      faro.instrumentations.add(new grafanaTracing.TracingInstrumentation());
+    </script>
   </head>
 
   <body>
@@ -140,7 +167,9 @@
             hexString.length % 2 != 0 ||
             !hexRegex.test(hexString)
           ) {
-            throw new Error("cannot create uint8array from invalid hex string");
+            const errorMessage = `cannot create uint8array from invalid hex string: ${hexString}`;
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
           return new Uint8Array(
             hexString.match(/../g).map((h) => parseInt(h, 16))
@@ -173,9 +202,9 @@
           var leadingZeros = [];
           for (var i = 0; i < s.length; i++) {
             if (alphabet.indexOf(s[i]) === -1) {
-              throw new Error(
-                `cannot base58-decode: ${s[i]} isn't a valid character`
-              );
+              const errorMessage = `cannot base58-decode: ${s[i]} isn't a valid character`;
+              reportError(errorMessage);
+              throw new Error(errorMessage);
             }
             var carry = alphabet.indexOf(s[i]);
 
@@ -222,9 +251,9 @@
             case "SOLANA":
               const decodedKeyBytes = base58Decode(privateKey);
               if (decodedKeyBytes.length !== 64) {
-                throw new Error(
-                  `invalid key length. Expected 64 bytes. Got ${decodedKeyBytes.length()}.`
-                );
+                const errorMessage = `invalid key length. Expected 64 bytes. Got ${decodedKeyBytes.length()}.`;
+                reportError(errorMessage);
+                throw new Error(errorMessage);
               }
               return decodedKeyBytes.subarray(0, 32);
             case "HEXADECIMAL":
@@ -274,9 +303,9 @@
             }
             // Check if the number of zeros found equals the number of zeroes expected
             if (zeroCount !== expectedZeroCount) {
-              throw new Error(
-                `invalid number of starting zeroes. Expected number of zeroes: ${expectedZeroCount}. Found: ${zeroCount}.`
-              );
+              const errorMessage = `invalid number of starting zeroes. Expected number of zeroes: ${expectedZeroCount}. Found: ${zeroCount}.`;
+              reportError(errorMessage);
+              throw new Error(errorMessage);
             }
             return byteArray.slice(
               expectedZeroCount,
@@ -306,9 +335,10 @@
 
           // Parse 'r' and check for integer tag (0x02)
           if (derSignatureBuf[index] !== 0x02) {
-            throw new Error(
-              "failed to convert DER-encoded signature: invalid tag for r"
-            );
+            const errorMessage =
+              "failed to convert DER-encoded signature: invalid tag for r";
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
           index++; // Move past the INTEGER tag
           const rLength = derSignatureBuf[index];
@@ -318,9 +348,10 @@
 
           // Parse 's' and check for integer tag (0x02)
           if (derSignatureBuf[index] !== 0x02) {
-            throw new Error(
-              "failed to convert DER-encoded signature: invalid tag for s"
-            );
+            const errorMessage =
+              "failed to convert DER-encoded signature: invalid tag for s";
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
           index++; // Move past the INTEGER tag
           const sLength = derSignatureBuf[index];
@@ -356,9 +387,10 @@
           const TURNKEY_SIGNER_ENCLAVE_QUORUM_PUBLIC_KEY =
             TURNKEY_SIGNERS_ENCLAVES["${TURNKEY_SIGNER_ENVIRONMENT}"];
           if (TURNKEY_SIGNER_ENCLAVE_QUORUM_PUBLIC_KEY === undefined) {
-            throw new Error(
-              "Configuration error: TURNKEY_SIGNER_ENCLAVE_QUORUM_PUBLIC_KEY is undefined"
-            );
+            const errorMessage =
+              "Configuration error: TURNKEY_SIGNER_ENCLAVE_QUORUM_PUBLIC_KEY is undefined";
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
 
           // todo(olivia): throw error if enclave quorum public is null once server changes are deployed
@@ -366,9 +398,9 @@
             if (
               enclaveQuorumPublic !== TURNKEY_SIGNER_ENCLAVE_QUORUM_PUBLIC_KEY
             ) {
-              throw new Error(
-                `enclave quorum public keys from client and bundle do not match. Client: ${TURNKEY_SIGNER_ENCLAVE_QUORUM_PUBLIC_KEY}. Bundle: ${enclaveQuorumPublic}.`
-              );
+              const errorMessage = `enclave quorum public keys from client and bundle do not match. Client: ${TURNKEY_SIGNER_ENCLAVE_QUORUM_PUBLIC_KEY}. Bundle: ${enclaveQuorumPublic}.`;
+              reportError(errorMessage);
+              throw new Error(errorMessage);
             }
           }
 
@@ -377,7 +409,9 @@
           );
           const quorumKey = await loadQuorumKey(encryptionQuorumPublicBuf);
           if (!quorumKey) {
-            throw new Error("failed to load quorum key");
+            const errorMessage = "failed to load quorum key";
+            reportError(errorMessage);
+            throw new Error(errorMessage);
           }
 
           // The ECDSA signature is ASN.1 DER encoded but WebCrypto uses raw format
@@ -438,24 +472,28 @@
           Object.entries(styles).forEach(([property, value]) => {
             const styleProperty = property.trim();
             if (styleProperty.length === 0) {
-              throw new Error("css style property cannot be empty");
+              const errorMessage = "css style property cannot be empty";
+              reportError(errorMessage);
+              throw new Error(errorMessage);
             }
             const styleRegexStr = cssValidationRegex[styleProperty];
             if (!styleRegexStr) {
-              throw new Error(
-                `invalid or unsupported css style property: "${styleProperty}"`
-              );
+              const errorMessage = `invalid or unsupported css style property: "${styleProperty}"`;
+              reportError(errorMessage);
+              throw new Error(errorMessage);
             }
             const styleRegex = new RegExp(styleRegexStr);
             const styleValue = value.trim();
             if (styleValue.length == 0) {
-              throw new Error(`css style for "${styleProperty}" is empty`);
+              const errorMessage = `css style for "${styleProperty}" is empty`;
+              reportError(errorMessage);
+              throw new Error(errorMessage);
             }
             const isValidStyle = styleRegex.test(styleValue);
             if (!isValidStyle) {
-              throw new Error(
-                `invalid css style value for property "${styleProperty}"`
-              );
+              const errorMessage = `invalid css style value for property "${styleProperty}"`;
+              reportError(errorMessage);
+              throw new Error(errorMessage);
             }
             validStyles[styleProperty] = styleValue;
           });
@@ -476,9 +514,10 @@
             // Valid styles will be applied the "plaintext" textarea HTML element.
             const plaintextTextarea = document.getElementById("plaintext");
             if (!plaintextTextarea) {
-              throw new Error(
-                "no plaintext textarea HTML element found to apply settings to."
-              );
+              const errorMessage =
+                "no plaintext textarea HTML element found to apply settings to.";
+              reportError(errorMessage);
+              throw new Error(errorMessage);
             }
 
             // Validate, sanitize, and apply the styles to the "plaintext" textarea.
@@ -507,6 +546,15 @@
          * @param requestId serves as an idempotency key to match incoming requests. Backwards compatible: if not provided, it isn't passed in.
          */
         function sendMessageUp(type, value, requestId) {
+          if (type === "ERROR") {
+            window.faro?.api?.pushError([value], {
+              context: {
+                requestId: requestId,
+              },
+              level: "error",
+            });
+          }
+
           const message = {
             type: type,
             value: value,
@@ -529,6 +577,15 @@
             );
           }
         }
+
+        /**
+         * Function to report errors to Grafana Faro.
+         */
+        var reportError = function (errorMessage) {
+          window.faro?.api?.pushError([errorMessage], {
+            level: "error",
+          });
+        };
 
         return {
           loadTargetKey,
@@ -692,90 +749,98 @@
         userId,
         requestId
       ) {
-        let targetPublicBuf;
-        let verified;
+        try {
+          let targetPublicBuf;
+          let verified;
 
-        // Parse the import bundle
-        const bundleObj = JSON.parse(bundle);
+          // Parse the import bundle
+          const bundleObj = JSON.parse(bundle);
 
-        switch (bundleObj.version) {
-          case "v1.0.0":
-            // Validate fields exist
-            if (!bundleObj.data) {
-              throw new Error('missing "data" in bundle');
-            }
-            if (!bundleObj.dataSignature) {
-              throw new Error('missing "dataSignature" in bundle');
-            }
-            if (!bundleObj.enclaveQuorumPublic) {
-              throw new Error('missing "enclaveQuorumPublic" in bundle');
-            }
+          switch (bundleObj.version) {
+            case "v1.0.0":
+              // Validate fields exist
+              if (!bundleObj.data) {
+                throw new Error('missing "data" in bundle');
+              }
+              if (!bundleObj.dataSignature) {
+                throw new Error('missing "dataSignature" in bundle');
+              }
+              if (!bundleObj.enclaveQuorumPublic) {
+                throw new Error('missing "enclaveQuorumPublic" in bundle');
+              }
 
-            // Verify enclave signature
-            if (!TKHQ.verifyEnclaveSignature) {
-              throw new Error("method not loaded");
-            }
-            verified = await TKHQ.verifyEnclaveSignature(
-              bundleObj.enclaveQuorumPublic,
-              bundleObj.dataSignature,
-              bundleObj.data
-            );
-            if (!verified) {
-              throw new Error(`failed to verify enclave signature: ${bundle}`);
-            }
-
-            // Parse the signed data. The data is produced by JSON encoding followed by hex encoding. We reverse this here.
-            const signedData = JSON.parse(
-              new TextDecoder().decode(
-                TKHQ.uint8arrayFromHexString(bundleObj.data)
-              )
-            );
-
-            // Validate fields match
-            if (!organizationId) {
-              // TODO: throw error if organization id is undefined once we've fully transitioned to v1.0.0 server messages and v2.0.0 iframe-stamper
-              console.warn(
-                'we highly recommend a version of @turnkey/iframe-stamper >= v2.0.0 to pass "organizationId" for security purposes.'
+              // Verify enclave signature
+              if (!TKHQ.verifyEnclaveSignature) {
+                throw new Error("method not loaded");
+              }
+              verified = await TKHQ.verifyEnclaveSignature(
+                bundleObj.enclaveQuorumPublic,
+                bundleObj.dataSignature,
+                bundleObj.data
               );
-            } else if (
-              !signedData.organizationId ||
-              signedData.organizationId !== organizationId
-            ) {
-              throw new Error(
-                `organization id does not match expected value. Expected: ${organizationId}. Found: ${signedData.organizationId}.`
-              );
-            }
-            if (!userId) {
-              // TODO: throw error if user id is undefined once we've fully transitioned to v1.0.0 server messages and v2.0.0 iframe-stamper
-              console.warn(
-                'we highly recommend a version of @turnkey/iframe-stamper >= v2.0.0 to pass "userId" for security purposes.'
-              );
-            } else if (!signedData.userId || signedData.userId !== userId) {
-              throw new Error(
-                `user id does not match expected value. Expected: ${userId}. Found: ${signedData.userId}.`
-              );
-            }
+              if (!verified) {
+                throw new Error(
+                  `failed to verify enclave signature: ${bundle}`
+                );
+              }
 
-            if (!signedData.targetPublic) {
-              throw new Error('missing "targetPublic" in bundle signed data');
-            }
+              // Parse the signed data. The data is produced by JSON encoding followed by hex encoding. We reverse this here.
+              const signedData = JSON.parse(
+                new TextDecoder().decode(
+                  TKHQ.uint8arrayFromHexString(bundleObj.data)
+                )
+              );
 
-            // Load target public key generated from enclave and set in local storage
-            targetPublicBuf = TKHQ.uint8arrayFromHexString(
-              signedData.targetPublic
-            );
-            break;
-          default:
-            throw new Error(`unsupported version: ${bundleObj.version}`);
+              // Validate fields match
+              if (!organizationId) {
+                // TODO: throw error if organization id is undefined once we've fully transitioned to v1.0.0 server messages and v2.0.0 iframe-stamper
+                console.warn(
+                  'we highly recommend a version of @turnkey/iframe-stamper >= v2.0.0 to pass "organizationId" for security purposes.'
+                );
+              } else if (
+                !signedData.organizationId ||
+                signedData.organizationId !== organizationId
+              ) {
+                throw new Error(
+                  `organization id does not match expected value. Expected: ${organizationId}. Found: ${signedData.organizationId}.`
+                );
+              }
+              if (!userId) {
+                // TODO: throw error if user id is undefined once we've fully transitioned to v1.0.0 server messages and v2.0.0 iframe-stamper
+                console.warn(
+                  'we highly recommend a version of @turnkey/iframe-stamper >= v2.0.0 to pass "userId" for security purposes.'
+                );
+              } else if (!signedData.userId || signedData.userId !== userId) {
+                throw new Error(
+                  `user id does not match expected value. Expected: ${userId}. Found: ${signedData.userId}.`
+                );
+              }
+
+              if (!signedData.targetPublic) {
+                throw new Error('missing "targetPublic" in bundle signed data');
+              }
+
+              // Load target public key generated from enclave and set in local storage
+              targetPublicBuf = TKHQ.uint8arrayFromHexString(
+                signedData.targetPublic
+              );
+              break;
+            default:
+              throw new Error(`unsupported version: ${bundleObj.version}`);
+          }
+
+          const targetPublicKeyJwk = await TKHQ.loadTargetKey(
+            new Uint8Array(targetPublicBuf)
+          );
+          TKHQ.setTargetEmbeddedKey(targetPublicKeyJwk);
+
+          // Send up BUNDLE_INJECTED message
+          TKHQ.sendMessageUp("BUNDLE_INJECTED", true, requestId);
+        } catch (e) {
+          const errorMessage = `failed to inject bundle: ${e.toString()}`;
+          reportError(e?.message || errorMessage);
+          throw new Error(e?.message || errorMessage);
         }
-
-        const targetPublicKeyJwk = await TKHQ.loadTargetKey(
-          new Uint8Array(targetPublicBuf)
-        );
-        TKHQ.setTargetEmbeddedKey(targetPublicKeyJwk);
-
-        // Send up BUNDLE_INJECTED message
-        TKHQ.sendMessageUp("BUNDLE_INJECTED", true, requestId);
       }
 
       /**
@@ -792,13 +857,17 @@
         // Get target embedded key from previous step (onInjectImportBundle)
         const targetPublicKeyJwk = TKHQ.getTargetEmbeddedKey();
         if (targetPublicKeyJwk == null) {
-          throw new Error("no target key found");
+          const errorMessage = "no target key found";
+          TKHQ.reportError(errorMessage);
+          throw new Error(errorMessage);
         }
 
         // Get plaintext wallet mnemonic
         const plaintext = document.getElementById("plaintext").value.trim();
         if (!plaintext) {
-          throw new Error("no wallet mnemonic entered");
+          const errorMessage = "no wallet mnemonic entered";
+          TKHQ.reportError(errorMessage);
+          throw new Error(errorMessage);
         }
         const plaintextBuf = new TextEncoder().encode(plaintext);
 
@@ -834,13 +903,17 @@
         // Get target embedded key from previous step (onInjectImportBundle)
         const targetPublicKeyJwk = TKHQ.getTargetEmbeddedKey();
         if (targetPublicKeyJwk == null) {
-          throw new Error("no target key found");
+          const errorMessage = "no target key found";
+          TKHQ.reportError(errorMessage);
+          throw new Error(errorMessage);
         }
 
         // Get plaintext private key
         const plaintext = document.getElementById("plaintext").value.trim();
         if (!plaintext) {
-          throw new Error("no private key entered");
+          const errorMessage = "no private key entered";
+          TKHQ.reportError(errorMessage);
+          throw new Error(errorMessage);
         }
         const plaintextBuf = TKHQ.decodeKey(plaintext, keyFormat);
 
@@ -928,7 +1001,9 @@
         try {
           ciphertextBuf = await senderCtx.seal(plaintextBuf, aad);
         } catch (e) {
-          throw new Error("failed to encrypt import bundle: " + e.toString());
+          const errorMessage = `failed to encrypt import bundle: ${e.toString()}`;
+          TKHQ.reportError(errorMessage);
+          throw new Error(errorMessage);
         }
 
         const ciphertextHex = TKHQ.uint8arrayToHexString(


### PR DESCRIPTION
- Added Grafana Faro [Web SDK](https://github.com/grafana/faro-web-sdk/tree/main/packages/web-sdk) & [Web Tracing SDK](https://github.com/grafana/faro-web-sdk/tree/main/packages/web-tracing)
  - included these as vendored scripts
- created `reportError()` helper function to send errors to Grafana
- added instrumentation to `email-auth`, `wallet-import`, and `wallet-export`