### PR TITLE
OAuth origin/redirect: add Facebook + Apple support, robust param handling, and CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        directory: ["auth", "export", "import", "export-and-sign"]
+        directory:
+          [
+            'auth',
+            'export',
+            'import',
+            'export-and-sign',
+            'oauth-origin',
+            'oauth-redirect',
+          ]
 
     steps:
       - name: Checkout

--- a/oauth-origin/index.test.js
+++ b/oauth-origin/index.test.js
@@ -192,7 +192,7 @@ describe("OAuth origin", () => {
     const search = new URLSearchParams(qs);
     expect(search.get("client_id")).toBe("myClient");
     expect(search.get("redirect_uri")).toBe("https://example.com?scheme=myapp");
-    expect(search.get("response_type")).toBe("id_token");
+    expect(search.get("response_type")).toBe("code id_token");
     expect(search.get("scope")).toBe("openid email profile");
     expect(search.get("nonce")).toBe("abc123");
     expect(search.get("prompt")).toBe("select_account");

--- a/oauth-origin/index.test.js
+++ b/oauth-origin/index.test.js
@@ -2,23 +2,99 @@ import "@testing-library/jest-dom";
 import { JSDOM } from "jsdom";
 import fs from "fs";
 import path from "path";
+import { pathToFileURL } from "url";
 
-const html = fs.readFileSync(path.resolve(__dirname, "./index.html"), "utf8");
+const indexPath = path.resolve(__dirname, "./index.html");
+const scriptPath = path.resolve(__dirname, "./oauth-origin.js");
 
-function createDOM(url) {
-  const domInstance = new JSDOM(html, {
+async function createDOMWithResourceLoading({ search = "" } = {}) {
+  const fileUrl = pathToFileURL(indexPath);
+  const url = new URL(fileUrl.href);
+  if (search) {
+    url.search = search.startsWith("?") ? search : `?${search}`;
+  }
+
+  const domInstance = await JSDOM.fromFile(indexPath, {
     // Necessary to run script tags
     runScripts: "dangerously",
-    url,
+    // Necessary to load external resources like ./oauth-origin.js
+    resources: "usable",
+    // Set the document location so the script sees the intended query
+    url: url.href,
     beforeParse(window) {
       // Necessary for TextDecoder to be available.
       // See https://github.com/jsdom/jsdom/issues/2524
       window.TextDecoder = TextDecoder;
       window.TextEncoder = TextEncoder;
+      // Stub navigation by overriding Location.prototype.href setter before any script runs
+      try {
+        window.__redirect_to = null;
+        const originalDescriptor = Object.getOwnPropertyDescriptor(
+          window.Location.prototype,
+          "href"
+        );
+        Object.defineProperty(window.Location.prototype, "href", {
+          configurable: true,
+          enumerable: true,
+          get() {
+            return window.__redirect_to || "about:blank";
+          },
+          set(value) {
+            window.__redirect_to = String(value);
+          },
+        });
+        // Also stub assign/replace
+        window.Location.prototype.assign = function (value) {
+          window.__redirect_to = String(value);
+        };
+        window.Location.prototype.replace = function (value) {
+          window.__redirect_to = String(value);
+        };
+        // Keep a reference in case future tests need original
+        window.__original_location_href__ = originalDescriptor;
+      } catch (e) {
+        // ignore if we cannot stub navigation
+      }
     },
   });
 
   return domInstance;
+}
+
+function waitForLoad(dom) {
+  return new Promise((resolve) => {
+    dom.window.addEventListener("load", () => resolve(), { once: true });
+  });
+}
+
+async function createDOMWithoutResourceLoading({ search = "" } = {}) {
+  const fileUrl = pathToFileURL(indexPath);
+  const url = new URL(fileUrl.href);
+  if (search) {
+    url.search = search.startsWith("?") ? search : `?${search}`;
+  }
+
+  const domInstance = await JSDOM.fromFile(indexPath, {
+    runScripts: "dangerously",
+    url: url.href,
+    beforeParse(window) {
+      window.TextDecoder = TextDecoder;
+      window.TextEncoder = TextEncoder;
+      // capture redirect target via a simple variable
+      window.__redirect_to = null;
+    },
+  });
+
+  return domInstance;
+}
+
+function runScriptWithStubbedNavigation(dom) {
+  const original = fs.readFileSync(scriptPath, "utf8");
+  const stubbed = original.replace(
+    /window\.location\.href\s*=\s*oauthUrl;/,
+    "window.__redirect_to = oauthUrl;"
+  );
+  dom.window.eval(stubbed);
 }
 
 describe("OAuth origin", () => {
@@ -30,9 +106,9 @@ describe("OAuth origin", () => {
     }
   });
 
-  it("displays an error if required query parameters are missing", () => {
-    const url = "http://localhost/?provider=google";
-    dom = createDOM(url);
+  it("displays an error if required query parameters are missing", async () => {
+    dom = await createDOMWithResourceLoading({ search: "?provider=google" });
+    await waitForLoad(dom);
 
     const errorEl = dom.window.document.querySelector("p.error");
     expect(errorEl).not.toBeNull();
@@ -42,30 +118,35 @@ describe("OAuth origin", () => {
     expect(errorEl.textContent).toContain("nonce");
   });
 
-  it("displays an error for Facebook when codeChallenge is missing", () => {
-    const url =
-      "http://localhost/?provider=facebook&clientId=dummy&redirectUri=https%3A%2F%2Fexample.com%3Fscheme%3Dmyapp&nonce=12345";
-    dom = createDOM(url);
+  it("displays an error for Facebook when codeChallenge is missing", async () => {
+    dom = await createDOMWithResourceLoading({
+      search:
+        "?provider=facebook&clientId=dummy&redirectUri=https%3A%2F%2Fexample.com%3Fscheme%3Dmyapp&nonce=12345",
+    });
+    await waitForLoad(dom);
     const errorEl = dom.window.document.querySelector("p.error");
     expect(errorEl).not.toBeNull();
     expect(errorEl.textContent).toContain("Missing query parameter");
     expect(errorEl.textContent).toContain("codeChallenge");
   });
 
-  it("redirects to Facebook OAuth when all required params are present", () => {
-    const url =
-      "http://localhost/?provider=facebook&clientId=myClient&redirectUri=https%3A%2F%2Fexample.com%3Fscheme%3Dmyapp&nonce=abc123&codeChallenge=cc123&state=provider%3Dfacebook%26flow%3Dredirect";
-    dom = createDOM(url);
-    const location = dom.window.location.href;
+  it("redirects to Facebook OAuth when all required params are present", async () => {
+    dom = await createDOMWithoutResourceLoading({
+      search:
+        "?provider=facebook&clientId=myClient&redirectUri=https%3A%2F%2Fexample.com%3Fscheme%3Dmyapp&nonce=abc123&codeChallenge=cc123&state=provider%3Dfacebook%26flow%3Dredirect",
+    });
+    runScriptWithStubbedNavigation(dom);
+    const location = dom.window.__redirect_to;
     // Should redirect to the Facebook OAuth URL with the expected params
-    expect(location.startsWith("https://www.facebook.com/v11.0/dialog/oauth?")).toBe(
-      true
-    );
+    expect(
+      location.startsWith("https://www.facebook.com/v23.0/dialog/oauth?")
+    ).toBe(true);
     const qs = location.split("?")[1];
     const search = new URLSearchParams(qs);
     expect(search.get("client_id")).toBe("myClient");
+    // Facebook normalizes redirect_uri to include a trailing slash before query
     expect(search.get("redirect_uri")).toBe(
-      "https://example.com?scheme=myapp"
+      "https://example.com/?scheme=myapp"
     );
     expect(search.get("response_type")).toBe("code");
     expect(search.get("scope")).toBe("openid");
@@ -73,5 +154,58 @@ describe("OAuth origin", () => {
     expect(search.get("code_challenge")).toBe("cc123");
     expect(search.get("code_challenge_method")).toBe("S256");
     expect(search.get("state")).toBe("provider=facebook&flow=redirect");
+  });
+
+  it("redirects to Apple OAuth and normalizes redirect_uri with trailing slash before query", async () => {
+    dom = await createDOMWithoutResourceLoading({
+      search:
+        "?provider=apple&clientId=myAppleClient&redirectUri=https%3A%2F%2Fexample.com%3Fscheme%3Dmyapp&nonce=xyz123",
+    });
+    runScriptWithStubbedNavigation(dom);
+    const location = dom.window.__redirect_to;
+    expect(
+      location.startsWith("https://appleid.apple.com/auth/authorize?")
+    ).toBe(true);
+    const qs = location.split("?")[1];
+    const search = new URLSearchParams(qs);
+    expect(search.get("client_id")).toBe("myAppleClient");
+    // Google does not normalize redirect_uri; it is passed as-is
+    expect(search.get("redirect_uri")).toBe(
+      "https://example.com/?scheme=myapp"
+    );
+    expect(search.get("response_type")).toBe("code id_token");
+    expect(search.get("response_mode")).toBe("fragment");
+    expect(search.get("nonce")).toBe("xyz123");
+  });
+
+  it("redirects to Google OAuth when all required params are present", async () => {
+    dom = await createDOMWithoutResourceLoading({
+      search:
+        "?provider=google&clientId=myClient&redirectUri=https%3A%2F%2Fexample.com%3Fscheme%3Dmyapp&nonce=abc123",
+    });
+    runScriptWithStubbedNavigation(dom);
+    const location = dom.window.__redirect_to;
+    expect(
+      location.startsWith("https://accounts.google.com/o/oauth2/v2/auth?")
+    ).toBe(true);
+    const qs = location.split("?")[1];
+    const search = new URLSearchParams(qs);
+    expect(search.get("client_id")).toBe("myClient");
+    expect(search.get("redirect_uri")).toBe("https://example.com?scheme=myapp");
+    expect(search.get("response_type")).toBe("id_token");
+    expect(search.get("scope")).toBe("openid email profile");
+    expect(search.get("nonce")).toBe("abc123");
+    expect(search.get("prompt")).toBe("select_account");
+  });
+
+  it("displays an error when redirectUri is invalid (non-absolute)", async () => {
+    dom = await createDOMWithResourceLoading({
+      search:
+        "?provider=facebook&clientId=myClient&redirectUri=example.com&nonce=abc123&codeChallenge=cc123",
+    });
+    await waitForLoad(dom);
+    const errorEl = dom.window.document.querySelector("p.error");
+    expect(errorEl).not.toBeNull();
+    expect(errorEl.textContent).toContain("Invalid redirectUri");
   });
 });

--- a/oauth-origin/index.test.js
+++ b/oauth-origin/index.test.js
@@ -42,19 +42,36 @@ describe("OAuth origin", () => {
     expect(errorEl.textContent).toContain("nonce");
   });
 
-  it("displays an error for an unsupported provider", () => {
+  it("displays an error for Facebook when codeChallenge is missing", () => {
     const url =
       "http://localhost/?provider=facebook&clientId=dummy&redirectUri=https%3A%2F%2Fexample.com%3Fscheme%3Dmyapp&nonce=12345";
     dom = createDOM(url);
     const errorEl = dom.window.document.querySelector("p.error");
     expect(errorEl).not.toBeNull();
-    expect(errorEl.textContent).toContain(
-      'Error: Unsupported provider "facebook"'
-    );
+    expect(errorEl.textContent).toContain("Missing query parameter");
+    expect(errorEl.textContent).toContain("codeChallenge");
+  });
 
-    // since the redirectUri exists, a back button should be rendered with an app URL scheme
-    const backButton = dom.window.document.querySelector("button.back-button");
-    expect(backButton).not.toBeNull();
-    expect(backButton.getAttribute("onclick")).toContain("myapp://");
+  it("redirects to Facebook OAuth when all required params are present", () => {
+    const url =
+      "http://localhost/?provider=facebook&clientId=myClient&redirectUri=https%3A%2F%2Fexample.com%3Fscheme%3Dmyapp&nonce=abc123&codeChallenge=cc123&state=provider%3Dfacebook%26flow%3Dredirect";
+    dom = createDOM(url);
+    const location = dom.window.location.href;
+    // Should redirect to the Facebook OAuth URL with the expected params
+    expect(location.startsWith("https://www.facebook.com/v11.0/dialog/oauth?")).toBe(
+      true
+    );
+    const qs = location.split("?")[1];
+    const search = new URLSearchParams(qs);
+    expect(search.get("client_id")).toBe("myClient");
+    expect(search.get("redirect_uri")).toBe(
+      "https://example.com?scheme=myapp"
+    );
+    expect(search.get("response_type")).toBe("code");
+    expect(search.get("scope")).toBe("openid");
+    expect(search.get("nonce")).toBe("abc123");
+    expect(search.get("code_challenge")).toBe("cc123");
+    expect(search.get("code_challenge_method")).toBe("S256");
+    expect(search.get("state")).toBe("provider=facebook&flow=redirect");
   });
 });

--- a/oauth-origin/oauth-origin.js
+++ b/oauth-origin/oauth-origin.js
@@ -1,107 +1,123 @@
 (function () {
-    "use strict";
+  "use strict";
 
-    function displayError(message) {
-      document.body.innerHTML = "";
+  function displayError(message) {
+    document.body.innerHTML = "";
 
-      const logo = document.createElement("img");
-      logo.className = "logo";
-      logo.src = "./favicon.svg";
-      logo.alt = "Logo";
-      document.body.appendChild(logo);
+    const logo = document.createElement("img");
+    logo.className = "logo";
+    logo.src = "./favicon.svg";
+    logo.alt = "Logo";
+    document.body.appendChild(logo);
 
-      const errorText = document.createElement("p");
-      errorText.className = "error";
-      errorText.textContent = message;
-      document.body.appendChild(errorText);
-    }
+    const errorText = document.createElement("p");
+    errorText.className = "error";
+    errorText.textContent = message;
+    document.body.appendChild(errorText);
+  }
 
-    function getOAuthUrl(provider, clientId, redirectUri, nonce, codeChallenge, state) {
-      let baseUrl;
-      let oauthParams = {};
+  function normalizeRedirectUriOrThrow(redirectUri) {
+    // Use URL parsing only; throws for invalid/relative URLs.
+    const u = new URL(redirectUri);
+    // Returning toString() ensures host-only URLs render with trailing '/'
+    // before any query/fragment (e.g., https://host?x=1 -> https://host/?x=1)
+    return u.toString();
+  }
 
-      switch (provider.toLowerCase()) {
-        case "google":
-          baseUrl = "https://accounts.google.com/o/oauth2/v2/auth";
-          oauthParams = {
-            client_id: clientId,
-            redirect_uri: redirectUri,
-            response_type: "id_token",
-            scope: "openid email profile",
-            nonce: nonce,
-            prompt: "select_account",
-          };
-          break;
-        case "apple": {
-          baseUrl = "https://appleid.apple.com/auth/authorize";
-          // Apple often requires a trailing slash in redirect URIs
-          const normalizedRedirectUri = redirectUri.endsWith("/")
-            ? redirectUri
-            : redirectUri + "/";
-          oauthParams = {
-            client_id: clientId,
-            redirect_uri: normalizedRedirectUri,
-            response_type: "code id_token",
-            response_mode: "fragment",
-            nonce: nonce,
-          };
-          break;
-        }
-        case "facebook": {
-          baseUrl = "https://www.facebook.com/v11.0/dialog/oauth";
-          oauthParams = {
-            client_id: clientId,
-            redirect_uri: redirectUri,
-            response_type: "code",
-            scope: "openid",
-            nonce: nonce,
-            code_challenge: codeChallenge,
-            code_challenge_method: "S256",
-          };
-          if (state) {
-            oauthParams.state = state;
-          }
-          break;
-        }
-        default:
-          return null;
+  function getOAuthUrl(
+    provider,
+    clientId,
+    redirectUri,
+    nonce,
+    codeChallenge,
+    state
+  ) {
+    let baseUrl;
+    let oauthParams = {};
+
+    switch (provider.toLowerCase()) {
+      case "google":
+        baseUrl = "https://accounts.google.com/o/oauth2/v2/auth";
+        oauthParams = {
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          response_type: "id_token",
+          scope: "openid email profile",
+          nonce: nonce,
+          prompt: "select_account",
+        };
+        break;
+      case "apple": {
+        baseUrl = "https://appleid.apple.com/auth/authorize";
+        // Apple often requires a trailing slash in redirect URIs
+        const normalizedRedirectUri = normalizeRedirectUriOrThrow(redirectUri);
+        oauthParams = {
+          client_id: clientId,
+          redirect_uri: normalizedRedirectUri,
+          response_type: "code id_token",
+          response_mode: "fragment",
+          nonce: nonce,
+        };
+        break;
       }
-
-      return `${baseUrl}?${new URLSearchParams(oauthParams).toString()}`;
+      case "facebook": {
+        baseUrl = "https://www.facebook.com/v23.0/dialog/oauth";
+        const normalizedRedirectUri = normalizeRedirectUriOrThrow(redirectUri);
+        oauthParams = {
+          client_id: clientId,
+          redirect_uri: normalizedRedirectUri,
+          response_type: "code",
+          scope: "openid",
+          nonce: nonce,
+          code_challenge: codeChallenge,
+          code_challenge_method: "S256",
+        };
+        if (state) {
+          oauthParams.state = state;
+        }
+        break;
+      }
+      default:
+        return null;
     }
 
-    const params = new URLSearchParams(window.location.search);
+    return `${baseUrl}?${new URLSearchParams(oauthParams).toString()}`;
+  }
 
-    // get the provider, clientId, redirectUri, and nonce from the query parameters
-    const provider = params.get("provider");
-    const clientId = params.get("clientId");
-    const redirectUri = params.get("redirectUri");
-    const nonce = params.get("nonce");
-    // optional for some providers
-    const codeChallenge = params.get("codeChallenge");
-    const state = params.get("state");
+  const params = new URLSearchParams(window.location.search);
 
-    const missingParams = [];
-    if (!provider) missingParams.push("provider");
-    if (!clientId) missingParams.push("clientId");
-    if (!redirectUri) missingParams.push("redirectUri");
-    if (!nonce) missingParams.push("nonce");
-    // Facebook requires PKCE (codeChallenge)
-    if (provider && provider.toLowerCase() === "facebook" && !codeChallenge) {
-      missingParams.push("codeChallenge");
-    }
+  // get the provider, clientId, redirectUri, and nonce from the query parameters
+  const provider = params.get("provider");
+  const clientId = params.get("clientId");
+  const redirectUri = params.get("redirectUri");
+  const nonce = params.get("nonce");
+  // optional for some providers
+  const codeChallenge = params.get("codeChallenge");
+  const state = params.get("state");
 
-    if (missingParams.length > 0) {
-      displayError(
-        "Error: Missing query parameter" +
-          (missingParams.length > 1 ? "s" : "") +
-          ": " +
-          missingParams.join(", ")
-      );
-      return;
-    }
+  const missingParams = [];
+  if (!provider) missingParams.push("provider");
+  if (!clientId) missingParams.push("clientId");
+  if (!redirectUri) missingParams.push("redirectUri");
+  if (!nonce) missingParams.push("nonce");
+  // Facebook requires PKCE (codeChallenge)
+  if (provider && provider.toLowerCase() === "facebook" && !codeChallenge) {
+    missingParams.push("codeChallenge");
+  }
 
-    const oauthUrl = getOAuthUrl(
+  if (missingParams.length > 0) {
+    displayError(
+      "Error: Missing query parameter" +
+        (missingParams.length > 1 ? "s" : "") +
+        ": " +
+        missingParams.join(", ")
+    );
+    return;
+  }
+
+  let oauthUrl;
+  try {
+    oauthUrl = getOAuthUrl(
       provider,
       clientId,
       redirectUri,
@@ -109,11 +125,15 @@
       codeChallenge,
       state
     );
-    if (!oauthUrl) {
-      displayError("Error: Unsupported provider.");
-      return;
-    }
+  } catch (e) {
+    displayError("Error: Invalid redirectUri");
+    return;
+  }
+  if (!oauthUrl) {
+    displayError("Error: Unsupported provider.");
+    return;
+  }
 
-    // redirect the browser to the google oauth URL
-    window.location.href = oauthUrl;
-  })();
+  // redirect the browser to the google oauth URL
+  window.location.href = oauthUrl;
+})();

--- a/oauth-origin/oauth-origin.js
+++ b/oauth-origin/oauth-origin.js
@@ -41,7 +41,7 @@
         oauthParams = {
           client_id: clientId,
           redirect_uri: redirectUri,
-          response_type: "id_token",
+          response_type: "code id_token",
           scope: "openid email profile",
           nonce: nonce,
           prompt: "select_account",

--- a/oauth-origin/oauth-origin.js
+++ b/oauth-origin/oauth-origin.js
@@ -46,6 +46,9 @@
           nonce: nonce,
           prompt: "select_account",
         };
+        if (state) {
+          oauthParams.state = state;
+        }
         break;
       case "apple": {
         baseUrl = "https://appleid.apple.com/auth/authorize";
@@ -58,6 +61,9 @@
           response_mode: "fragment",
           nonce: nonce,
         };
+        if (state) {
+          oauthParams.state = state;
+        }
         break;
       }
       case "facebook": {

--- a/oauth-origin/oauth-origin.js
+++ b/oauth-origin/oauth-origin.js
@@ -32,6 +32,21 @@
             prompt: "select_account",
           };
           break;
+        case "apple": {
+          baseUrl = "https://appleid.apple.com/auth/authorize";
+          // Apple often requires a trailing slash in redirect URIs
+          const normalizedRedirectUri = redirectUri.endsWith("/")
+            ? redirectUri
+            : redirectUri + "/";
+          oauthParams = {
+            client_id: clientId,
+            redirect_uri: normalizedRedirectUri,
+            response_type: "code id_token",
+            response_mode: "fragment",
+            nonce: nonce,
+          };
+          break;
+        }
         default:
           return null;
       }

--- a/oauth-redirect/index.html
+++ b/oauth-redirect/index.html
@@ -6,7 +6,7 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'none'; img-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self';"
     />
-    <meta name="referrer" content="origin">
+    <meta name="referrer" content="origin" />
     <title>Redirecting back to your app</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style>

--- a/oauth-redirect/oauth-redirect.js
+++ b/oauth-redirect/oauth-redirect.js
@@ -1,56 +1,68 @@
 (function () {
-    "use strict";
+  "use strict";
 
-    function displayError(message) {
-      document.body.innerHTML = "";
+  function displayError(message) {
+    document.body.innerHTML = "";
 
-      const logo = document.createElement("img");
-      logo.className = "logo";
-      logo.src = "./favicon.svg";
-      logo.alt = "Logo";
-      document.body.appendChild(logo);
+    const logo = document.createElement("img");
+    logo.className = "logo";
+    logo.src = "./favicon.svg";
+    logo.alt = "Logo";
+    document.body.appendChild(logo);
 
-      const errorText = document.createElement("p");
-      errorText.className = "error";
-      errorText.textContent = message;
-      document.body.appendChild(errorText);
-    }
+    const errorText = document.createElement("p");
+    errorText.className = "error";
+    errorText.textContent = message;
+    document.body.appendChild(errorText);
+  }
 
-    const searchParams = new URLSearchParams(window.location.search);
+  const searchParams = new URLSearchParams(window.location.search);
 
-    // get the app scheme from the query parameters
-    let scheme = searchParams.get("scheme");
+  // Extract the application deep-link scheme from the query string.
+  // Example: with `?scheme=myapp`, we will later redirect to `myapp://?...`.
+  let scheme = searchParams.get("scheme");
 
-    if (!scheme) {
-      displayError("Error: Missing scheme in query parameters.");
+  if (!scheme) {
+    displayError("Error: Missing scheme in query parameters.");
+    return;
+  }
+
+  // Normalize the scheme so it always includes "://" (e.g., "myapp" -> "myapp://").
+  if (!scheme.includes("://")) {
+    scheme += "://";
+  }
+
+  // Determine the source of OAuth parameters.
+  // Many providers return parameters in the URL hash (e.g., Google/Apple with id_token in the hash).
+  // Others return them in the query string (e.g., code+PKCE flows like Facebook/Discord/Twitter).
+  // We prefer the hash only if it contains clearly relevant keys; otherwise we fall back to the query.
+  const rawHash = window.location.hash.slice(1);
+  const hashParams = rawHash ? new URLSearchParams(rawHash) : null;
+  const hashHasMeaningfulParams = !!(
+    hashParams &&
+    (hashParams.has("id_token") ||
+      hashParams.has("access_token") ||
+      hashParams.has("code"))
+  );
+
+  let paramsToForward;
+  if (hashHasMeaningfulParams) {
+    paramsToForward = hashParams;
+  } else {
+    // Fallback: use query parameters when hash is empty or meaningless
+    // (e.g., some providers append "#_=_" which carries no data).
+    paramsToForward = new URLSearchParams(window.location.search);
+    paramsToForward.delete("scheme");
+    if ([...paramsToForward.keys()].length === 0) {
+      displayError("Error: Missing OAuth parameters.");
       return;
     }
+  }
 
-    // we ensure the scheme includes "://"
-    if (!scheme.includes("://")) {
-      scheme += "://";
-    }
+  // Build the deep-link URL to the host application by combining
+  // the normalized scheme with whichever parameter source we selected.
+  const redirectUrl = `${scheme}?${paramsToForward.toString()}`;
 
-    // Prefer hash fragment for providers that return it (e.g., Google/Apple)
-    const hash = window.location.hash.slice(1);
-
-    let paramsToForward;
-    if (hash) {
-      paramsToForward = new URLSearchParams(hash);
-    } else {
-      // Fallback to query parameters for code+PKCE providers (e.g., Discord/Twitter)
-      // Remove "scheme" from forwarded params
-      paramsToForward = new URLSearchParams(window.location.search);
-      paramsToForward.delete("scheme");
-      if ([...paramsToForward.keys()].length === 0) {
-        displayError("Error: Missing OAuth parameters.");
-        return;
-      }
-    }
-
-    // build the scheme URL with the selected parameters
-    const redirectUrl = `${scheme}?${paramsToForward.toString()}`;
-
-    // redirect the browser to the custom scheme URL
-    window.location.href = redirectUrl;
-  })();
+  // Perform the redirect to the application.
+  window.location.href = redirectUrl;
+})();

--- a/oauth-redirect/oauth-redirect.js
+++ b/oauth-redirect/oauth-redirect.js
@@ -34,7 +34,7 @@
 
   // Determine the source of OAuth parameters.
   // Many providers return parameters in the URL hash (e.g., Google/Apple with id_token in the hash).
-  // Others return them in the query string (e.g., code+PKCE flows like Facebook/Discord/Twitter).
+  // Others return them in the query string (e.g., code+PKCE flows like Facebook).
   // We prefer the hash only if it contains clearly relevant keys; otherwise we fall back to the query.
   const rawHash = window.location.hash.slice(1);
   const hashParams = rawHash ? new URLSearchParams(rawHash) : null;

--- a/oauth-redirect/oauth-redirect.js
+++ b/oauth-redirect/oauth-redirect.js
@@ -31,17 +31,25 @@
       scheme += "://";
     }
 
-    // parse the hash fragment that contains the oauth parameters
-    const hash = window.location.hash.slice(1); // remove the leading '#' character
-    if (!hash) {
-      displayError("Error: Missing OAuth hash parameters.");
-      return;
+    // Prefer hash fragment for providers that return it (e.g., Google/Apple)
+    const hash = window.location.hash.slice(1);
+
+    let paramsToForward;
+    if (hash) {
+      paramsToForward = new URLSearchParams(hash);
+    } else {
+      // Fallback to query parameters for code+PKCE providers (e.g., Discord/Twitter)
+      // Remove "scheme" from forwarded params
+      paramsToForward = new URLSearchParams(window.location.search);
+      paramsToForward.delete("scheme");
+      if ([...paramsToForward.keys()].length === 0) {
+        displayError("Error: Missing OAuth parameters.");
+        return;
+      }
     }
 
-    const hashParams = new URLSearchParams(hash);
-
-    // build the scheme URL with the hash parameters
-    const redirectUrl = `${scheme}?${hashParams.toString()}`;
+    // build the scheme URL with the selected parameters
+    const redirectUrl = `${scheme}?${paramsToForward.toString()}`;
 
     // redirect the browser to the custom scheme URL
     window.location.href = redirectUrl;


### PR DESCRIPTION
 > [!NOTE]
> Description below was generated by gpt-5-high based off of the PR diff 

### Summary
  - Adds provider support and robustness to `oauth-origin` and `oauth-redirect`.
  - Improves test coverage and CI to include `oauth-origin` and `oauth-redirect`.

### Changes

#### CI

- .github/workflows/ci.yml
  - Include `oauth-origin` and `oauth-redirect` in the matrix.
 
#### OAuth Origin

- oauth-origin.js
  - Add provider support beyond Google:
    - Apple: builds `https://appleid.apple.com/auth/authorize` with `response_type=code id_token`, `response_mode=fragment`, normalizes `redirect_uri` (ensures trailing slash before query), includes `nonce`.
    - Facebook: builds `https://www.facebook.com/v23.0/dialog/oauth` with PKCE (`code_challenge` and `code_challenge_method=S256`), `response_type=code`, `scope=openid`, optional `state`, and normalized `redirect_uri`.
  - Introduce `normalizeRedirectUriOrThrow(redirectUri)` to validate and normalize absolute URLs; surfaces “Invalid redirectUri” on parse failure.
  - Expand required param validation:
    - Always require `provider`, `clientId`, `redirectUri`, `nonce`.
    - Additionally require `codeChallenge` when `provider=facebook`.
  - Keep existing Google flow but build params robustly via `URLSearchParams`.
  - Improve error rendering helper consistency.
- index.test.js
  - Switch to JSDOM resource loading with `fromFile` and `resources: "usable"` to load external scripts.
  - Add navigation stubs and helpers (`__redirect_to`, `waitForLoad`, `runScriptWithStubbedNavigation`) for deterministic assertions.
  - New/updated tests:
    - Missing required params show consolidated error list.
    - Facebook missing `codeChallenge` errors.
    - Facebook happy path builds expected URL incl. normalized `redirect_uri` and PKCE params.
    - Apple happy path builds expected URL and normalizes `redirect_uri`.
    - Google happy path preserved.
    - Invalid `redirectUri` (non-absolute) errors.

#### OAuth Redirect

- oauth-redirect.js
  - Normalize scheme with `://` when missing.
  - Prefer extracting OAuth params from hash only when it contains meaningful keys (`id_token`, `access_token`, or `code`).
  - Fallback to query parameters (after removing `scheme`) when the hash is empty/meaningless (e.g., `#_=_` - as is the case for **Facebook**).
  - Error clearly when neither hash nor query contain OAuth params.
- index.test.js
  - Switch to `fromFile` + `resources: "usable"` and wait for `load`.
  - Updated tests for:
    - Missing `scheme` error.
    - Missing OAuth parameters in both hash and query shows unified error message.
- index.html
  - Minor formatting: self-close meta tag.

### Rationale
  - Many providers differ in how they return tokens/authorization codes. The `oauth-redirect` page now robustly handles both hash- and query-based flows, improving interoperability.
  - The `oauth-origin` page now supports Apple and Facebook, validates inputs more rigorously (including PKCE for Facebook), and normalizes redirect URIs to match provider expectations.
  - Tests were enhanced to ensure correctness across providers and flows. CI updated to run these tests.

### Testing
  - Added and updated Jest + JSDOM tests for both pages covering:
    - Param validation and error rendering.
    - URL construction for Apple, Facebook (with PKCE), Google.
    - Hash vs query param routing in redirect page.
  - CI: Included `oauth-origin` and `oauth-redirect` directories in the matrix so the new tests run on PRs.

### Breaking changes
  - None expected for consumers. The origin page will now error on invalid `redirectUri` and on missing Facebook `codeChallenge`, which is aligned with security best practices for PKCE.