### PR TITLE
add frame-ancestors CSP header to export-and-sign iframe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,4 @@ EXPOSE 8085/tcp
 
 WORKDIR /usr/share/nginx
 
-CMD ["nginx"]
+CMD ["/bin/sh", "-c", "envsubst '${TURNKEY_FRAME_ANCESTORS}' < /etc/nginx/nginx.conf > /tmp/nginx-final.conf && nginx -c /tmp/nginx-final.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,4 @@ EXPOSE 8085/tcp
 
 WORKDIR /usr/share/nginx
 
-CMD ["/bin/sh", "-c", "envsubst '${TURNKEY_FRAME_ANCESTORS}' < /etc/nginx/nginx.conf > /tmp/nginx-final.conf && nginx -c /tmp/nginx-final.conf"]
+CMD ["/bin/sh", "-c", "TURNKEY_FRAME_ANCESTORS=${TURNKEY_FRAME_ANCESTORS:-'none'} envsubst '${TURNKEY_FRAME_ANCESTORS}' < /etc/nginx/nginx.conf > /tmp/nginx-final.conf && nginx -c /tmp/nginx-final.conf"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -72,8 +72,8 @@ http {
     }
     server {
         listen 8086;
-        # optional: add CSP-related configs here later
         root /usr/share/nginx/templated/export-and-sign;
+        add_header Content-Security-Policy "frame-ancestors ${TURNKEY_FRAME_ANCESTORS}";
         location / {
             try_files $uri $uri/ /index.html =404;
         }


### PR DESCRIPTION
Closes ENG-3770 /
  https://linear.app/turnkey/issue/ENG-3770/sb-2026-3-frames-based-signing-workflow-vulnerable-to-cross-origin

  ## Background

  The export-and-sign iframe stores an embedded key in `localStorage` scoped to its origin. Because `localStorage` is
  shared across all iframes from the same origin regardless of parent, a malicious site can embed the iframe and supply a
  valid encrypted bundle — the iframe has no way to distinguish a legitimate parent from an attacker.

  ## Change

  Adds a `Content-Security-Policy: frame-ancestors` HTTP response header to the port 8086 (export-and-sign) nginx server
  block. This is enforced by the browser before the iframe loads, preventing unauthorized origins from embedding it in the
  first place.

  The header value is configurable via the `TURNKEY_FRAME_ANCESTORS` environment variable, defaulting to `'none'` (blocks
  all embedding) if unset. The Dockerfile CMD is updated to run `envsubst` at container startup, substituting only
  `TURNKEY_FRAME_ANCESTORS` so nginx's own `$variable` references are left untouched.

  ## Deployment

  Set `TURNKEY_FRAME_ANCESTORS` in the container environment to the origin(s) allowed to embed the iframe:

  ```sh
  # Single origin
  TURNKEY_FRAME_ANCESTORS="https://app.turnkey.com"

  # Multiple origins
  TURNKEY_FRAME_ANCESTORS="https://app.turnkey.com https://staging.turnkey.com"

  If the variable is not set, the header defaults to frame-ancestors 'none', which blocks all embedding until explicitly
  configured.
  ```

 ## Testing

 1. Build and run the container

  # With the env var set
  docker build -t frames-test .
  docker run -p 8086:8086 -e TURNKEY_FRAME_ANCESTORS="https://app.turnkey.com" frames-test

  2. Verify the header is present

  curl -sI http://localhost:8086/ | grep -i content-security-policy

  Should return:
  content-security-policy: frame-ancestors https://app.turnkey.com

  Then test the default (unset) case:
  docker run -p 8086:8086 frames-test
  curl -sI http://localhost:8086/ | grep -i content-security-policy

  Should return:
  content-security-policy: frame-ancestors 'none'