### PR TITLE
Fix dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.github
+.editorconfig
+**/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,17 @@ FROM node:18-bullseye-slim AS builder
 
 WORKDIR /app
 
-# Copy shared directory first (needed by import)
+# Copy shared directory first (needed by export-and-sign and import)
 COPY shared ./shared/
 RUN cd shared && npm ci
+
+# Copy export-and-sign module and build
+COPY export-and-sign ./export-and-sign/
+RUN cd export-and-sign && npm ci && npm run build
 
 # Copy import module and build
 COPY import ./import/
 RUN cd import && npm ci && npm run build
-
-# Note: export-and-sign is NOT built here. Its committed dist/ is used directly
-# (copied in the runtime stage below), just like the `export` frame. The CI
-# build-check job already rebuilds export-and-sign and verifies dist/ matches
-# source, so the committed artifact is trusted. Building it in this stage would
-# require `npm ci` of viem's very large file tree under QEMU-emulated arm64,
-# which fails with ECONNRESET.
 
 # Second stage: nginx runtime
 # This is nginx 1.24.0 on bullseye.
@@ -36,11 +33,8 @@ COPY auth /usr/share/nginx/recovery
 
 COPY export /usr/share/nginx/export
 
-# export-and-sign uses its committed dist/ directly (verified by the CI
-# build-check job); see the builder stage note above.
-COPY export-and-sign/dist /usr/share/nginx/export-and-sign
-
-# Copy built import files from builder stage
+# Copy built export-and-sign and import files from builder stage
+COPY --from=builder /app/export-and-sign/dist /usr/share/nginx/export-and-sign
 COPY --from=builder /app/import/dist /usr/share/nginx/import
 
 # oauth


### PR DESCRIPTION
It turns out we were including `node_modules` in docker context - this is incorrect and can cause issues when it comes to modules that provide native bindings.