### PR TITLE
fix: Eslint

### DIFF
--- a/auth/.eslintignore
+++ b/auth/.eslintignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+
+hpke-core.js

--- a/auth/.eslintrc.json
+++ b/auth/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../.eslintrc.json"
+}

--- a/auth/package.json
+++ b/auth/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "serve",
     "test": "jest",
-    "lint": "eslint \"**/*.js\"",
+    "lint": "eslint '**/*.{js,ts}'",
+    "lint:write": "eslint '**/*.{js,ts}' --fix",
     "prettier:check": "prettier --check \"**/*.{css,html,js,json,md,ts,tsx,yaml,yml}\" --ignore-path ../.prettierignore",
     "prettier:write": "prettier --write \"**/*.{css,html,js,json,md,ts,tsx,yaml,yml}\" --ignore-path ../.prettierignore"
   },

--- a/export-and-sign/.eslintignore
+++ b/export-and-sign/.eslintignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+
+hpke-core.js

--- a/export-and-sign/.eslintrc.json
+++ b/export-and-sign/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../.eslintrc.json"
+}

--- a/export-and-sign/package.json
+++ b/export-and-sign/package.json
@@ -8,7 +8,8 @@
     "start": "serve dist",
     "dev": "webpack serve --mode=development --open",
     "test": "jest",
-    "lint": "eslint \"src/**/*.js\"",
+    "lint": "eslint '**/*.{js,ts}'",
+    "lint:write": "eslint '**/*.{js,ts}' --fix",
     "prettier:check": "prettier --check \"**/*.{css,html,js,json,md,ts,tsx,yaml,yml}\" --ignore-path ../.prettierignore",
     "prettier:write": "prettier --write \"**/*.{css,html,js,json,md,ts,tsx,yaml,yml}\" --ignore-path ../.prettierignore"
   },

--- a/export/.eslintignore
+++ b/export/.eslintignore
@@ -1,0 +1,6 @@
+dist
+node_modules
+
+noble-hashes.js
+noble-ed25519.js
+hpke-core.js

--- a/export/.eslintrc.json
+++ b/export/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../.eslintrc.json"
+}

--- a/export/package.json
+++ b/export/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "serve",
     "test": "jest",
-    "lint": "eslint \"**/*.js\"",
+    "lint": "eslint '**/*.{js,ts}'",
+    "lint:write": "eslint '**/*.{js,ts}' --fix",
     "prettier:check": "prettier --check \"**/*.{css,html,js,json,md,ts,tsx,yaml,yml}\" --ignore-path ../.prettierignore",
     "prettier:write": "prettier --write \"**/*.{css,html,js,json,md,ts,tsx,yaml,yml}\" --ignore-path ../.prettierignore"
   },

--- a/import/.eslintignore
+++ b/import/.eslintignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/import/.eslintrc.json
+++ b/import/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../.eslintrc.json"
+}

--- a/import/package.json
+++ b/import/package.json
@@ -8,7 +8,8 @@
     "start": "serve dist",
     "dev": "webpack serve --mode=development --open",
     "test": "jest",
-    "lint": "eslint \"src/**/*.js\"",
+    "lint": "eslint '**/*.{js,ts}'",
+    "lint:write": "eslint '**/*.{js,ts}' --fix",
     "prettier:check": "prettier --check \"**/*.{css,html,js,json,md,ts,tsx,yaml,yml}\" --ignore-path ../.prettierignore",
     "prettier:write": "prettier --write \"**/*.{css,html,js,json,md,ts,tsx,yaml,yml}\" --ignore-path ../.prettierignore"
   },

--- a/oauth-origin/.eslintignore
+++ b/oauth-origin/.eslintignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/oauth-origin/.eslintrc.json
+++ b/oauth-origin/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../.eslintrc.json"
+}

--- a/oauth-origin/package.json
+++ b/oauth-origin/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "serve",
     "test": "jest",
-    "lint": "eslint \"**/*.js\"",
+    "lint": "eslint '**/*.{js,ts}'",
+    "lint:write": "eslint '**/*.{js,ts}' --fix",
     "prettier:check": "prettier --check \"**/*.{css,html,js,json,md,ts,tsx,yaml,yml}\" --ignore-path ../.prettierignore",
     "prettier:write": "prettier --write \"**/*.{css,html,js,json,md,ts,tsx,yaml,yml}\" --ignore-path ../.prettierignore"
   },

--- a/oauth-redirect/.eslintignore
+++ b/oauth-redirect/.eslintignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/oauth-redirect/.eslintrc.json
+++ b/oauth-redirect/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../.eslintrc.json"
+}

--- a/oauth-redirect/package.json
+++ b/oauth-redirect/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "serve",
     "test": "jest",
-    "lint": "eslint \"**/*.js\"",
+    "lint": "eslint '**/*.{js,ts}'",
+    "lint:write": "eslint '**/*.{js,ts}' --fix",
     "prettier:check": "prettier --check \"**/*.{css,html,js,json,md,ts,tsx,yaml,yml}\" --ignore-path ../.prettierignore",
     "prettier:write": "prettier --write \"**/*.{css,html,js,json,md,ts,tsx,yaml,yml}\" --ignore-path ../.prettierignore"
   },

--- a/shared/.eslintignore
+++ b/shared/.eslintignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/shared/.eslintrc.json
+++ b/shared/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../.eslintrc.json"
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -5,7 +5,8 @@
   "main": "turnkey-core.js",
   "scripts": {
     "test": "jest",
-    "lint": "eslint \"**/*.js\"",
+    "lint": "eslint '**/*.{js,ts}'",
+    "lint:write": "eslint '**/*.{js,ts}' --fix",
     "prettier:check": "prettier --check \"**/*.{css,html,js,json,md,ts,tsx,yaml,yml}\" --ignore-path ../.prettierignore",
     "prettier:write": "prettier --write \"**/*.{css,html,js,json,md,ts,tsx,yaml,yml}\" --ignore-path ../.prettierignore"
   },


### PR DESCRIPTION
### In this PR

- Fixing `eslint` command - the `**/*.js` glob was being expanded on the shell and was causing `.eslintignore` to be ignored
- Adding `lint:fix` command
- Adding per-package `.eslintrc.json` and `.eslintignore`, a good practice